### PR TITLE
Add class dropdown

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/CoordinationPanelClientInner.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/CoordinationPanelClientInner.tsx
@@ -6,11 +6,13 @@ import { YearDropdown } from "./_components/dropdowns/YearGroup/YearDropdown";
 import { ContentCard } from "@/components/layout/Card";
 import { useState } from "react";
 import { SubjectDropdown } from "./_components/dropdowns/SubjectsDropdown/SubjectDropdown";
+import { ClassDropdown } from "./_components/dropdowns/ClassDropdown/ClassDropdown";
 
 export default function CoordinationPanelClientInner() {
   const [keyStageId, setKeyStageId] = useState<string | null>(null);
   const [yearGroupId, setYearGroupId] = useState<string | null>(null);
   const [subjectId, setSubjectId] = useState<string | null>(null);
+  const [classId, setClassId] = useState<string | null>(null);
 
   console.log("PARENT RENDERING");
 
@@ -26,6 +28,7 @@ export default function CoordinationPanelClientInner() {
               setKeyStageId(id);
               setYearGroupId(null);
               setSubjectId(null);
+              setClassId(null);
             }}
           />
         </Flex>
@@ -39,6 +42,7 @@ export default function CoordinationPanelClientInner() {
             onChange={(id: string | null) => {
               setYearGroupId(id);
               setSubjectId(null);
+              setClassId(null);
             }}
           />
         </Flex>
@@ -51,7 +55,19 @@ export default function CoordinationPanelClientInner() {
             value={subjectId}
             onChange={(id: string | null) => {
               setSubjectId(id);
+              setClassId(null);
             }}
+          />
+        </Flex>
+
+        {/* ------------------- 4. class ------------------ */}
+        <Flex flexDir="column" gap={2}>
+          <Text>Class</Text>
+          <ClassDropdown
+            yearGroupId={yearGroupId}
+            subjectId={subjectId}
+            value={classId}
+            onChange={(id: string | null) => setClassId(id)}
           />
         </Flex>
       </Flex>

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/ClassDropdown/ClassDropdown.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/ClassDropdown/ClassDropdown.tsx
@@ -1,78 +1,73 @@
 "use client";
 
-import React, { ChangeEvent, useEffect, useMemo } from "react";
+import React, { ChangeEvent, useMemo } from "react";
 import CrudDropdown from "../CrudDropdown";
 
 import { useQuery } from "@apollo/client";
 import { typedGql } from "@/zeus/typedDocumentNode";
 import { $ } from "@/zeus";
-import { YearGroupEntity } from "@/__generated__/schema-types";
 
 /* -------------------------------------------------------------------------- */
 /* GraphQL document                                                           */
 /* -------------------------------------------------------------------------- */
-const GET_YEAR_GROUPS_BY_KEY_STAGE = typedGql("query")({
-  getAllYearGroup: [
-    { data: $("data", "FindAllInput!") }, // { all, filters }
-    { id: true, year: true, keyStageId: true },
+const GET_CLASSES = typedGql("query")({
+  getAllClass: [
+    { data: $("data", "FindAllInput!") },
+    { id: true, name: true, subjectId: true, yearGroupId: true },
   ],
 } as const);
 
 /* -------------------------------------------------------------------------- */
 /* Component                                                                  */
 /* -------------------------------------------------------------------------- */
-interface YearDropdownProps {
-  keyStageId: number | null; // selected KS id from parent
-  value: number | null; // current YearGroup id
-  onChange: (id: number | null) => void;
+interface ClassDropdownProps {
+  yearGroupId: string | null;
+  subjectId: string | null;
+  value: string | null;
+  onChange: (id: string | null) => void;
 }
 
-export function YearDropdown({
-  keyStageId,
+export function ClassDropdown({
+  yearGroupId,
+  subjectId,
   value,
   onChange,
-}: YearDropdownProps) {
-  /* -------- fetch -------- */
-  const { data, loading } = useQuery(GET_YEAR_GROUPS_BY_KEY_STAGE, {
-    skip: keyStageId === null,
-    variables:
-      keyStageId !== null
+}: ClassDropdownProps) {
+  const variables = useMemo(
+    () =>
+      yearGroupId && subjectId
         ? {
             data: {
               all: true,
-              filters: [{ column: "keyStageId", value: String(keyStageId) }],
+              filters: [
+                { column: "yearGroupId", value: String(yearGroupId) },
+                { column: "subjectId", value: String(subjectId) },
+              ],
             },
           }
         : undefined,
-  });
-
-  const yearGroups = keyStageId !== null ? data?.getAllYearGroup ?? [] : [];
-
-  /* -------- options -------- */
-  const options = useMemo(
-    () =>
-      yearGroups.map((yg) => ({
-        label: yg.year,
-        value: String(yg.id),
-      })),
-    [yearGroups]
+    [yearGroupId, subjectId]
   );
 
-  /* -------- clear invalid selection if KS changes -------- */
-  useEffect(() => {
-    if (value !== null && !options.some((o) => o.value === String(value))) {
-      onChange(null);
-    }
-  }, [options, value, onChange]);
+  const { data, loading } = useQuery(GET_CLASSES, {
+    variables,
+    skip: !(yearGroupId && subjectId),
+  });
 
-  /* -------- render -------- */
+  const classes = yearGroupId && subjectId ? data?.getAllClass ?? [] : [];
+
+  const options = useMemo(
+    () => classes.map((c) => ({ label: c.name, value: String(c.id) })),
+    [classes]
+  );
+
   return (
     <CrudDropdown
       options={options}
       value={value ?? ""}
       isLoading={loading}
       onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-        onChange(e.target.value ? Number(e.target.value) : null)
+        onChange(e.target.value || null)
       }
       onCreate={() => {}}
       onUpdate={() => {}}
@@ -80,7 +75,7 @@ export function YearDropdown({
       isCreateDisabled
       isUpdateDisabled
       isDeleteDisabled
-      isDisabled={keyStageId === null}
+      isDisabled={!(yearGroupId && subjectId)}
     />
   );
 }


### PR DESCRIPTION
## Summary
- add new ClassDropdown component
- display Class dropdown in the coordination panel with proper state clearing

## Testing
- `npm run lint` *(fails: `next` not found)*