### PR TITLE
Add class creation form

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/class/class.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/class/class.module.ts
@@ -4,9 +4,21 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ClassEntity } from './class.entity';
 import { ClassService } from './class.service';
 import { ClassResolver } from './class.resolver';
+import { YearGroupEntity } from '../year-group/year-group.entity';
+import { SubjectEntity } from '../subject/subject.entity';
+import { EducatorProfileEntity } from '../../user-profiles/educator-profile/educator-profile.entity';
+import { StudentProfileEntity } from '../../user-profiles/student-profile/student-profile.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ClassEntity])],
+  imports: [
+    TypeOrmModule.forFeature([
+      ClassEntity,
+      YearGroupEntity,
+      SubjectEntity,
+      EducatorProfileEntity,
+      StudentProfileEntity,
+    ]),
+  ],
   providers: [ClassService, ClassResolver],
   exports: [ClassService],
 })

--- a/insight-be/src/modules/timbuktu/administrative/class/class.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/class/class.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Resolver } from '@nestjs/graphql';
 
 import { createBaseResolver } from 'src/common/base.resolver';
 import { ClassService } from './class.service';
@@ -27,5 +27,10 @@ const BaseClassResolver = createBaseResolver<
 export class ClassResolver extends BaseClassResolver {
   constructor(private readonly classService: ClassService) {
     super(classService);
+  }
+
+  @Mutation(() => ClassEntity, { name: 'createClass' })
+  async create(@Args('data') data: CreateClassInput): Promise<ClassEntity> {
+    return this.classService.createWithRelations(data);
   }
 }

--- a/insight-be/src/modules/timbuktu/administrative/class/class.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/class/class.service.ts
@@ -1,9 +1,13 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { BaseService } from 'src/common/base.service';
 import { ClassEntity } from './class.entity';
 import { CreateClassInput, UpdateClassInput } from './class.inputs';
+import { YearGroupEntity } from '../year-group/year-group.entity';
+import { SubjectEntity } from '../subject/subject.entity';
+import { EducatorProfileEntity } from '../../user-profiles/educator-profile/educator-profile.entity';
+import { StudentProfileEntity } from '../../user-profiles/student-profile/student-profile.entity';
 
 @Injectable()
 export class ClassService extends BaseService<
@@ -17,5 +21,72 @@ export class ClassService extends BaseService<
     @InjectDataSource() dataSource: DataSource,
   ) {
     super(classRepository, dataSource);
+  }
+
+  /**
+   * Create a class and attach educator & student relations.
+   * Validates uniqueness of class name within a year group + subject.
+   */
+  async createWithRelations(data: CreateClassInput): Promise<ClassEntity> {
+    return this.dataSource.transaction(async (manager) => {
+      const classRepo = manager.getRepository(ClassEntity);
+
+      // Ensure unique name within year group & subject
+      if (data.yearGroupId && data.subjectId) {
+        const existing = await classRepo.findOne({
+          where: {
+            name: data.name.trim(),
+            yearGroup: { id: data.yearGroupId },
+            subject: { id: data.subjectId },
+          } as any,
+        });
+        if (existing) {
+          throw new BadRequestException(
+            'A class with this name already exists for this year group and subject.',
+          );
+        }
+      }
+
+      const entity = classRepo.create({ name: data.name.trim() });
+
+      if (data.yearGroupId) {
+        entity.yearGroup = await manager
+          .getRepository(YearGroupEntity)
+          .findOneByOrFail({ id: data.yearGroupId });
+      }
+
+      if (data.subjectId) {
+        entity.subject = await manager
+          .getRepository(SubjectEntity)
+          .findOneByOrFail({ id: data.subjectId });
+      }
+
+      if (data.educatorIds?.length) {
+        const educators = await manager
+          .getRepository(EducatorProfileEntity)
+          .find({ where: { id: In(data.educatorIds) } });
+        if (educators.length !== data.educatorIds.length) {
+          throw new BadRequestException('Invalid educator ids provided');
+        }
+        entity.educators = educators;
+      }
+
+      if (data.studentIds?.length) {
+        const students = await manager
+          .getRepository(StudentProfileEntity)
+          .find({ where: { id: In(data.studentIds) } });
+        if (students.length !== data.studentIds.length) {
+          throw new BadRequestException('Invalid student ids provided');
+        }
+        entity.students = students;
+      }
+
+      const saved = await classRepo.save(entity);
+
+      return classRepo.findOneOrFail({
+        where: { id: saved.id },
+        relations: ['yearGroup', 'subject', 'educators', 'students'],
+      });
+    });
   }
 }

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/ClassDropdown/ClassDropdown.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/ClassDropdown/ClassDropdown.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import React, { ChangeEvent, useMemo } from "react";
+import React, { ChangeEvent, useMemo, useState } from "react";
 import CrudDropdown from "../CrudDropdown";
+import { BaseModal } from "@/components/modals/BaseModal";
+import CreateClassForm from "./forms/CreateClassForm";
 
 import { useQuery } from "@apollo/client";
 import { typedGql } from "@/zeus/typedDocumentNode";
@@ -33,6 +35,7 @@ export function ClassDropdown({
   value,
   onChange,
 }: ClassDropdownProps) {
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const variables = useMemo(
     () =>
       yearGroupId && subjectId
@@ -62,20 +65,35 @@ export function ClassDropdown({
   );
 
   return (
-    <CrudDropdown
-      options={options}
-      value={value ?? ""}
-      isLoading={loading}
-      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-        onChange(e.target.value || null)
-      }
-      onCreate={() => {}}
-      onUpdate={() => {}}
-      onDelete={() => {}}
-      isCreateDisabled
-      isUpdateDisabled
-      isDeleteDisabled
-      isDisabled={!(yearGroupId && subjectId)}
-    />
+    <>
+      <CrudDropdown
+        options={options}
+        value={value ?? ""}
+        isLoading={loading}
+        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+          onChange(e.target.value || null)
+        }
+        onCreate={() => setIsModalOpen(true)}
+        onUpdate={() => {}}
+        onDelete={() => {}}
+        isUpdateDisabled
+        isDeleteDisabled
+        isDisabled={!(yearGroupId && subjectId)}
+      />
+
+      <BaseModal
+        isOpen={isModalOpen}
+        onClose={() => setIsModalOpen(false)}
+        title="Create Class"
+      >
+        {yearGroupId && subjectId && (
+          <CreateClassForm
+            yearGroupId={yearGroupId}
+            subjectId={subjectId}
+            onSuccess={() => setIsModalOpen(false)}
+          />
+        )}
+      </BaseModal>
+    </>
   );
 }

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/ClassDropdown/forms/CreateClassForm.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/ClassDropdown/forms/CreateClassForm.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import React, { useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  CheckboxGroup,
+  FormControl,
+  FormLabel,
+  Input,
+  SimpleGrid,
+  Spinner,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import { Controller, useForm, SubmitHandler } from "react-hook-form";
+import { useQuery, useMutation } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+
+interface CreateClassFormProps {
+  yearGroupId: string;
+  subjectId: string;
+  onSuccess: () => void;
+}
+
+type FormValues = {
+  name: string;
+  educatorIds: string[];
+  studentIds: string[];
+};
+
+const GET_YEAR = typedGql("query")({
+  getYearGroup: [
+    { data: $("data", "IdInput!") },
+    { id: true, year: true },
+  ],
+} as const);
+
+const GET_USERS = typedGql("query")({
+  getAllUsers: [
+    { data: { limit: 1000, offset: 0 } },
+    {
+      id: true,
+      firstName: true,
+      lastName: true,
+      userType: true,
+      studentProfile: { id: true, schoolYear: true },
+      educatorProfile: { id: true },
+    },
+  ],
+} as const);
+
+const CREATE_CLASS = typedGql("mutation")({
+  createClass: [{ data: $("data", "CreateClassInput!") }, { id: true }],
+} as const);
+
+export default function CreateClassForm({
+  yearGroupId,
+  subjectId,
+  onSuccess,
+}: CreateClassFormProps) {
+  const { register, handleSubmit, control, formState } = useForm<FormValues>({
+    defaultValues: { name: "", educatorIds: [], studentIds: [] },
+    mode: "onChange",
+  });
+
+  const { data: ygData } = useQuery(GET_YEAR, {
+    variables: { data: { id: Number(yearGroupId) } },
+    skip: !yearGroupId,
+  });
+
+  const { data: usersData, loading: loadingUsers } = useQuery(GET_USERS);
+
+  const [createClass, { loading: creating }] = useMutation(CREATE_CLASS, {
+    onCompleted: onSuccess,
+  });
+
+  const yearNumber = useMemo(() => {
+    const y = ygData?.getYearGroup?.year ?? "";
+    const match = /\d+/.exec(y);
+    return match ? Number(match[0]) : undefined;
+  }, [ygData]);
+
+  const students = useMemo(() => {
+    if (!usersData) return [] as any[];
+    return usersData.getAllUsers.filter(
+      (u: any) =>
+        u.userType === "student" &&
+        u.studentProfile &&
+        yearNumber === u.studentProfile.schoolYear
+    );
+  }, [usersData, yearNumber]);
+
+  const educators = useMemo(() => {
+    if (!usersData) return [] as any[];
+    return usersData.getAllUsers.filter((u: any) => u.userType === "educator");
+  }, [usersData]);
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    await createClass({
+      variables: {
+        data: {
+          name: values.name.trim(),
+          yearGroupId: Number(yearGroupId),
+          subjectId: Number(subjectId),
+          educatorIds: values.educatorIds.map(Number),
+          studentIds: values.studentIds.map(Number),
+        },
+      },
+    });
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4}>
+      <Stack spacing={6}>
+        <FormControl isRequired>
+          <FormLabel>Class name</FormLabel>
+          <Input placeholder="e.g. 7A Maths" {...register("name", { required: true })} />
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>Educators</FormLabel>
+          {loadingUsers && <Spinner />}
+          {!loadingUsers && (
+            <Controller
+              control={control}
+              name="educatorIds"
+              render={({ field: { value, onChange } }) => (
+                <CheckboxGroup value={value} onChange={onChange}>
+                  <SimpleGrid columns={{ base: 1, md: 2 }} spacing={2}>
+                    {educators.map((e) => (
+                      <Checkbox key={e.id} value={String(e.educatorProfile.id)}>
+                        {e.firstName} {e.lastName}
+                      </Checkbox>
+                    ))}
+                  </SimpleGrid>
+                </CheckboxGroup>
+              )}
+            />
+          )}
+        </FormControl>
+
+        <FormControl>
+          <FormLabel>Students</FormLabel>
+          {loadingUsers && <Spinner />}
+          {!loadingUsers && (
+            <Controller
+              control={control}
+              name="studentIds"
+              render={({ field: { value, onChange } }) => (
+                <CheckboxGroup value={value} onChange={onChange}>
+                  <SimpleGrid columns={{ base: 1, md: 2 }} spacing={2}>
+                    {students.map((s) => (
+                      <Checkbox key={s.id} value={String(s.studentProfile.id)}>
+                        {s.firstName} {s.lastName}
+                      </Checkbox>
+                    ))}
+                  </SimpleGrid>
+                </CheckboxGroup>
+              )}
+            />
+          )}
+        </FormControl>
+
+        <Button type="submit" colorScheme="blue" isDisabled={!formState.isValid || creating}>
+          {creating ? <Spinner size="sm" /> : "Create class"}
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+


### PR DESCRIPTION
## Summary
- support relations when creating classes on the backend
- expose a custom `createClass` resolver
- load related entities in `ClassModule`
- add `CreateClassForm` and hook it up in the coordination panel dropdown

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm run lint` *(fails: ESLint package missing)*