### PR TITLE
Add user search functionality

### DIFF
--- a/insight-be/src/modules/user/dto/req/req.dto.ts
+++ b/insight-be/src/modules/user/dto/req/req.dto.ts
@@ -116,3 +116,15 @@ export class UpdateUserRequestDto extends OmitType(CreateUserRequestDto, [
   @Field()
   publicId: string;
 }
+
+@InputType()
+export class SearchUsersRequestDto {
+  @Field()
+  @IsString()
+  search!: string;
+
+  @Field(() => Int, { nullable: true })
+  @IsOptional()
+  @IsInt()
+  limit?: number;
+}

--- a/insight-be/src/modules/user/user.resolver.ts
+++ b/insight-be/src/modules/user/user.resolver.ts
@@ -23,6 +23,7 @@ import {
   CreateUserRequestDto,
   UpdateUserRequestDto,
   UpdateUserRolesFromArrayRequestDto,
+  SearchUsersRequestDto,
 } from './dto/req/req.dto';
 import { CreateUserWithProfileInput } from './input/create-user-with-profile.input';
 import { UpdateUserWithProfileInput } from './input/update-user-with-profile-input';
@@ -45,6 +46,15 @@ export class UserResolver {
   ): Promise<User[]> {
     const { limit, offset } = data;
     return this.userService.findAll(limit, offset);
+  }
+
+  @Query(() => [User])
+  @RbacPermissionKey('user.searchUsers')
+  async searchUsers(
+    @Args('data') data: SearchUsersRequestDto,
+  ): Promise<User[]> {
+    const { search, limit } = data;
+    return this.userService.searchByName(search, limit);
   }
 
   @Query(() => User)

--- a/insight-be/src/modules/user/user.service.ts
+++ b/insight-be/src/modules/user/user.service.ts
@@ -1,7 +1,7 @@
 // user.service.ts
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In, DataSource } from 'typeorm';
+import { Repository, In, DataSource, ILike } from 'typeorm';
 import { User } from './user.model';
 
 import { Role } from 'src/modules/rbac/sub/role/role.entity';
@@ -33,6 +33,16 @@ export class UsersService {
   async findAll(limit?: number, offset?: number): Promise<User[]> {
     return this.userRepository.find({
       skip: offset,
+      take: limit,
+    });
+  }
+
+  async searchByName(search: string, limit = 10): Promise<User[]> {
+    return this.userRepository.find({
+      where: [
+        { firstName: ILike(`%${search}%`) },
+        { lastName: ILike(`%${search}%`) },
+      ],
       take: limit,
     });
   }

--- a/insight-fe/schema.graphql
+++ b/insight-fe/schema.graphql
@@ -359,6 +359,11 @@ input PaginatedGetAllRequestDto {
   offset: Int
 }
 
+input SearchUsersRequestDto {
+  search: String!
+  limit: Int
+}
+
 type Permission {
   createdAt: DateTime!
   description: String
@@ -424,6 +429,7 @@ type Query {
   """Returns all Subject (optionally filtered)"""
   getAllSubject(data: FindAllInput!): [SubjectEntity!]!
   getAllUsers(data: PaginatedGetAllRequestDto!): [User!]!
+  searchUsers(data: SearchUsersRequestDto!): [User!]!
 
   """Returns all YearGroup (optionally filtered)"""
   getAllYearGroup(data: FindAllInput!): [YearGroupEntity!]!

--- a/insight-fe/src/app/(main)/(protected)/administration/user-manager/UserManagerPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/user-manager/UserManagerPageClient.tsx
@@ -10,6 +10,7 @@ import { usePermissionRedirect } from "@/hooks/PermissionRedirect";
 import { ContentCard } from "@/components/layout/Card";
 import { Center } from "@chakra-ui/react";
 import { NoUserSelectedCard } from "./_components/cards/NoUserSelectedCard";
+import { UserSearchInput } from "./_components/sections/user/UserSearchInput";
 
 export function UserManagerPageClient() {
   const [selectedUserPublicId, setSelectedUserPublicId] = useState<
@@ -23,6 +24,7 @@ export function UserManagerPageClient() {
 
   return (
     <>
+      <UserSearchInput onSelect={setSelectedUserPublicId} />
       <ContentGrid gridTemplateColumns="1fr 1fr">
         <UserListTable setSelectedUserPublicId={setSelectedUserPublicId} />
 

--- a/insight-fe/src/app/(main)/(protected)/administration/user-manager/_components/sections/user/UserSearchInput.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/user-manager/_components/sections/user/UserSearchInput.tsx
@@ -1,0 +1,75 @@
+"use client";
+
+import { Box, Input, List, ListItem } from "@chakra-ui/react";
+import { useLazyQuery } from "@apollo/client";
+import { useEffect, useState } from "react";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+
+/* -------------------------------------------------------------------------- */
+/* GraphQL document                                                           */
+/* -------------------------------------------------------------------------- */
+export const SEARCH_USERS = typedGql("query")({
+  searchUsers: [
+    { data: $("data", "SearchUsersRequestDto!") },
+    { publicId: true, firstName: true, lastName: true },
+  ],
+} as const);
+
+/* -------------------------------------------------------------------------- */
+/* Component                                                                  */
+/* -------------------------------------------------------------------------- */
+interface UserSearchInputProps {
+  onSelect: (publicId: string) => void;
+}
+
+export function UserSearchInput({ onSelect }: UserSearchInputProps) {
+  const [term, setTerm] = useState("");
+  const [executeSearch, { data }] = useLazyQuery(SEARCH_USERS);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      if (term.length > 1) {
+        executeSearch({ variables: { data: { search: term, limit: 5 } } });
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [term, executeSearch]);
+
+  const results = data?.searchUsers ?? [];
+
+  return (
+    <Box position="relative" mb={4}>
+      <Input
+        placeholder="Search users..."
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+      />
+      {results.length > 0 && (
+        <Box
+          position="absolute"
+          top="100%"
+          left={0}
+          right={0}
+          borderWidth="1px"
+          bg="white"
+          zIndex={2}
+        >
+          <List spacing={0} m={0}>
+            {results.map((u) => (
+              <ListItem
+                key={u.publicId}
+                p={2}
+                _hover={{ backgroundColor: "gray.100", cursor: "pointer" }}
+                onClick={() => {
+                  onSelect(u.publicId);
+                  setTerm("");
+                }}
+              >{`${u.firstName} ${u.lastName}`}</ListItem>
+            ))}
+          </List>
+        </Box>
+      )}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- allow searching for users by name
- expose `searchUsers` GraphQL query and supporting DTO
- show a user search box in the user manager page

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `insight-fe` *(fails: missing script)*