### PR TITLE
Add class members pane

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/CoordinationPanelClientInner.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/CoordinationPanelClientInner.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import { Flex, Text, VStack } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import { KeyStageDropdown } from "./_components/dropdowns/KeyStageDropdown/KeyStageDropdown";
 import { YearDropdown } from "./_components/dropdowns/YearGroup/YearDropdown";
 import { ContentCard } from "@/components/layout/Card";
 import { useState } from "react";
 import { SubjectDropdown } from "./_components/dropdowns/SubjectsDropdown/SubjectDropdown";
 import { ClassDropdown } from "./_components/dropdowns/ClassDropdown/ClassDropdown";
+import { ContentGrid } from "@/components/ContentGrid";
+import ClassMembersPane from "./_components/ClassMembersPane";
 
 export default function CoordinationPanelClientInner() {
   const [keyStageId, setKeyStageId] = useState<string | null>(null);
@@ -17,8 +19,9 @@ export default function CoordinationPanelClientInner() {
   console.log("PARENT RENDERING");
 
   return (
-    <ContentCard>
-      <Flex gap={8} flexDir="column">
+    <ContentGrid>
+      <ContentCard>
+        <Flex gap={8} flexDir="column">
         {/* ------------------- 1. key stage ------------------- */}
         <Flex flexDir="column" gap={2}>
           <Text>Key Stage</Text>
@@ -70,7 +73,11 @@ export default function CoordinationPanelClientInner() {
             onChange={(id: string | null) => setClassId(id)}
           />
         </Flex>
-      </Flex>
-    </ContentCard>
+
+        </Flex>
+      </ContentCard>
+
+      <ClassMembersPane classId={classId} />
+    </ContentGrid>
   );
 }

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/ClassMembersPane.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/ClassMembersPane.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { ContentCard } from "@/components/layout/Card";
+import { DataTableSimple } from "@/components/tables/DataTableSimple";
+import { CreateUserModal } from "../../user-manager/_components/modals/CreateUserModal";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+import {
+  Input,
+  VStack,
+  Heading,
+  HStack,
+  Button,
+} from "@chakra-ui/react";
+import { useQuery } from "@apollo/client";
+import { useMemo, useState } from "react";
+
+const GET_CLASS_WITH_MEMBERS = typedGql("query")({
+  getClass: [
+    { data: $("data", "IdInput!") },
+    {
+      id: true,
+      name: true,
+      students: { id: true, studentId: true, schoolYear: true },
+      educators: { id: true, staffId: true },
+    },
+  ],
+} as const);
+
+interface Props {
+  classId: string | null;
+}
+
+export default function ClassMembersPane({ classId }: Props) {
+  const [search, setSearch] = useState("");
+  const [modalType, setModalType] = useState<"student" | "educator">("student");
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const variables = useMemo(
+    () =>
+      classId ? { data: { id: Number(classId), relations: ["students", "educators"] } } : undefined,
+    [classId]
+  );
+
+  const { data, loading, refetch } = useQuery(GET_CLASS_WITH_MEMBERS, {
+    variables,
+    skip: !classId,
+  });
+
+  const students = data?.getClass?.students ?? [];
+  const educators = data?.getClass?.educators ?? [];
+
+  const filteredStudents = students.filter((s) =>
+    String(s.studentId).toLowerCase().includes(search.toLowerCase())
+  );
+
+  const columns = [
+    { key: "id", label: "ID" },
+    { key: "studentId", label: "Student ID" },
+    { key: "schoolYear", label: "School Year" },
+  ];
+
+  return (
+    <ContentCard gap={4} overflow="hidden">
+      {!classId ? (
+        <Heading size="md">Select a class to view members</Heading>
+      ) : (
+        <VStack align="stretch" gap={4} overflow="hidden">
+          <VStack align="stretch" gap={2}>
+            <Heading size="md">Educators</Heading>
+            {educators.length ? (
+              educators.map((e) => (
+                <span key={e.id}>Staff ID: {e.staffId}</span>
+              ))
+            ) : (
+              <span>No educators</span>
+            )}
+          </VStack>
+
+          <VStack align="stretch" gap={2}>
+            <HStack>
+              <Heading size="md" flex={1}>
+                Students
+              </Heading>
+              <Button
+                size="sm"
+                colorScheme="green"
+                onClick={() => {
+                  setModalType("student");
+                  setIsModalOpen(true);
+                }}
+              >
+                Add Student
+              </Button>
+              <Button
+                size="sm"
+                colorScheme="blue"
+                onClick={() => {
+                  setModalType("educator");
+                  setIsModalOpen(true);
+                }}
+              >
+                Add Staff
+              </Button>
+            </HStack>
+            <Input
+              placeholder="Search..."
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              size="sm"
+            />
+            <DataTableSimple data={filteredStudents} columns={columns} />
+          </VStack>
+        </VStack>
+      )}
+
+      <CreateUserModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+          refetch();
+        }}
+        userType={modalType}
+      />
+    </ContentCard>
+  );
+}


### PR DESCRIPTION
## Summary
- add `ClassMembersPane` to coordination panel
- display class students in `DataTableSimple`
- show educators above the table
- arrange dropdowns and new pane in `ContentGrid`

## Testing
- `npm run lint` *(fails: `next` not found)*