### PR TITLE
Add generic search functionality

### DIFF
--- a/insight-be/src/common/base.inputs.ts
+++ b/insight-be/src/common/base.inputs.ts
@@ -123,3 +123,22 @@ export class HasRelationsInput {
   })
   relationIds?: RelationIdsInput[];
 }
+
+/* ------------------------------------------------------------------ */
+/* Generic search input                                               */
+/* ------------------------------------------------------------------ */
+
+@InputType()
+export class SearchInput {
+  @Field()
+  search!: string;
+
+  @Field(() => [String])
+  columns!: string[];
+
+  @Field(() => Int, { nullable: true })
+  limit?: number;
+
+  @Field(() => [String], { nullable: true })
+  relations?: string[];
+}

--- a/insight-be/src/common/base.service.ts
+++ b/insight-be/src/common/base.service.ts
@@ -11,6 +11,7 @@ import {
   FindOptionsWhere,
   In,
   Repository,
+  ILike,
 } from 'typeorm';
 
 import { RelationIdsInput } from './base.inputs';
@@ -178,5 +179,17 @@ export class BaseService<
   async remove(id: number): Promise<number> {
     await this.repo.delete(id);
     return id;
+  }
+
+  /* ----------------------- search by columns ----------------------- */
+
+  async searchByColumns(
+    search: string,
+    columns: (keyof T)[],
+    opts?: { limit?: number; relations?: string[] },
+  ): Promise<T[]> {
+    const { limit = 10, relations } = opts ?? {};
+    const where = columns.map((c) => ({ [c as string]: ILike(`%${search}%`) })) as any[];
+    return this.repo.find({ where, take: limit, relations });
   }
 }

--- a/insight-be/src/modules/rbac/sub/permission-group/permission-group.resolver.ts
+++ b/insight-be/src/modules/rbac/sub/permission-group/permission-group.resolver.ts
@@ -28,6 +28,7 @@ const BasePermissionGroupResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
   immutableOperations: ['create', 'update', 'remove'],
 });

--- a/insight-be/src/modules/rbac/sub/permission/permission.resolver.ts
+++ b/insight-be/src/modules/rbac/sub/permission/permission.resolver.ts
@@ -20,6 +20,7 @@ const BasePermissionResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
   immutableOperations: ['create', 'update', 'remove'],
 });

--- a/insight-be/src/modules/rbac/sub/role/role.resolver.ts
+++ b/insight-be/src/modules/rbac/sub/role/role.resolver.ts
@@ -27,6 +27,7 @@ const BaseRoleResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
   immutableOperations: ['create', 'update', 'remove'],
 });

--- a/insight-be/src/modules/timbuktu/administrative/assignment-submission/assignment-submission.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/assignment-submission/assignment-submission.resolver.ts
@@ -23,6 +23,7 @@ const BaseAssignmentSubmissionResolver = createBaseResolver<
       'create',
       'update',
       'remove',
+      'search',
     ],
   },
 );

--- a/insight-be/src/modules/timbuktu/administrative/assignment/assignment.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/assignment/assignment.resolver.ts
@@ -21,6 +21,7 @@ const BaseAssignmentResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
 });
 

--- a/insight-be/src/modules/timbuktu/administrative/class/class.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/class/class.resolver.ts
@@ -22,6 +22,7 @@ const BaseClassResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
 });
 

--- a/insight-be/src/modules/timbuktu/administrative/key-stage/key-stage.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/key-stage/key-stage.resolver.ts
@@ -20,6 +20,7 @@ const BaseKeyStageResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
   immutableOperations: ['create', 'update', 'remove'],
 });

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.ts
@@ -18,6 +18,7 @@ const BaseLessonResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
 });
 

--- a/insight-be/src/modules/timbuktu/administrative/subject/subject.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/subject/subject.resolver.ts
@@ -19,6 +19,7 @@ const BaseSubjectResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
 });
 

--- a/insight-be/src/modules/timbuktu/administrative/year-group/year-group.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/year-group/year-group.resolver.ts
@@ -23,6 +23,7 @@ const BaseYearGroupResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
 });
 

--- a/insight-be/src/modules/timbuktu/administrative/year-group/year-group.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/year-group/year-group.resolver.ts
@@ -19,6 +19,7 @@ const BaseYearGroupResolver = createBaseResolver<
     'findAll',
     'findOne',
     'findOneBy',
+    'search',
     'create',
     'update',
     'remove',

--- a/insight-be/src/modules/timbuktu/user-profiles/educator-profile/educator-profile.resolver.ts
+++ b/insight-be/src/modules/timbuktu/user-profiles/educator-profile/educator-profile.resolver.ts
@@ -21,6 +21,7 @@ const BaseEducatorResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
   immutableOperations: ['create', 'update', 'remove'],
 });

--- a/insight-be/src/modules/timbuktu/user-profiles/student-profile/student-profile.resolver.ts
+++ b/insight-be/src/modules/timbuktu/user-profiles/student-profile/student-profile.resolver.ts
@@ -21,6 +21,7 @@ const BaseStudentProfileResolver = createBaseResolver<
     'create',
     'update',
     'remove',
+    'search',
   ],
   immutableOperations: ['create', 'update', 'remove'],
 });

--- a/insight-be/src/modules/user/dto/req/req.dto.ts
+++ b/insight-be/src/modules/user/dto/req/req.dto.ts
@@ -116,3 +116,4 @@ export class UpdateUserRequestDto extends OmitType(CreateUserRequestDto, [
   @Field()
   publicId: string;
 }
+

--- a/insight-be/src/modules/user/user.resolver.ts
+++ b/insight-be/src/modules/user/user.resolver.ts
@@ -26,6 +26,7 @@ import {
 } from './dto/req/req.dto';
 import { CreateUserWithProfileInput } from './input/create-user-with-profile.input';
 import { UpdateUserWithProfileInput } from './input/update-user-with-profile-input';
+import { SearchInput } from 'src/common/base.inputs';
 
 @ObjectType()
 export class RemoveUserResponse {
@@ -45,6 +46,13 @@ export class UserResolver {
   ): Promise<User[]> {
     const { limit, offset } = data;
     return this.userService.findAll(limit, offset);
+  }
+
+  @Query(() => [User])
+  @RbacPermissionKey('user.searchUsers')
+  async searchUsers(@Args('data') data: SearchInput): Promise<User[]> {
+    const { search, columns, limit } = data;
+    return this.userService.search(search, columns as (keyof User)[], limit);
   }
 
   @Query(() => User)

--- a/insight-be/src/modules/user/user.service.ts
+++ b/insight-be/src/modules/user/user.service.ts
@@ -1,7 +1,7 @@
 // user.service.ts
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, In, DataSource } from 'typeorm';
+import { Repository, In, DataSource, ILike } from 'typeorm';
 import { User } from './user.model';
 
 import { Role } from 'src/modules/rbac/sub/role/role.entity';
@@ -35,6 +35,15 @@ export class UsersService {
       skip: offset,
       take: limit,
     });
+  }
+
+  async search(
+    search: string,
+    columns: (keyof User)[],
+    limit = 10,
+  ): Promise<User[]> {
+    const where = columns.map((c) => ({ [c]: ILike(`%${search}%`) })) as any[];
+    return this.userRepository.find({ where, take: limit });
   }
 
   async hashPassword(plainPass: string): Promise<string> {

--- a/insight-fe/schema.graphql
+++ b/insight-fe/schema.graphql
@@ -359,6 +359,13 @@ input PaginatedGetAllRequestDto {
   offset: Int
 }
 
+input SearchInput {
+  search: String!
+  columns: [String!]!
+  limit: Int
+  relations: [String!]
+}
+
 type Permission {
   createdAt: DateTime!
   description: String
@@ -424,6 +431,8 @@ type Query {
   """Returns all Subject (optionally filtered)"""
   getAllSubject(data: FindAllInput!): [SubjectEntity!]!
   getAllUsers(data: PaginatedGetAllRequestDto!): [User!]!
+  searchUsers(data: SearchInput!): [User!]!
+  searchYearGroup(data: SearchInput!): [YearGroupEntity!]!
 
   """Returns all YearGroup (optionally filtered)"""
   getAllYearGroup(data: FindAllInput!): [YearGroupEntity!]!

--- a/insight-fe/src/__generated__/schema-types.ts
+++ b/insight-fe/src/__generated__/schema-types.ts
@@ -704,6 +704,31 @@ export type Query = {
   getYearGroup: YearGroupEntity;
   /** Returns one YearGroup by given conditions */
   getYearGroupBy: YearGroupEntity;
+  /** Search Assignment records by given columns */
+  searchAssignment: Array<AssignmentEntity>;
+  /** Search AssignmentSubmission records by given columns */
+  searchAssignmentSubmission: Array<AssignmentSubmissionEntity>;
+  /** Search Class records by given columns */
+  searchClass: Array<ClassEntity>;
+  /** Search EducatorProfile records by given columns */
+  searchEducatorProfile: Array<EducatorProfileDto>;
+  /** Search KeyStage records by given columns */
+  searchKeyStage: Array<KeyStageEntity>;
+  /** Search Lesson records by given columns */
+  searchLesson: Array<LessonEntity>;
+  /** Search Permission records by given columns */
+  searchPermission: Array<Permission>;
+  /** Search PermissionGroup records by given columns */
+  searchPermissionGroup: Array<PermissionGroup>;
+  /** Search Role records by given columns */
+  searchRole: Array<Role>;
+  /** Search StudentProfile records by given columns */
+  searchStudentProfile: Array<StudentProfileDto>;
+  /** Search Subject records by given columns */
+  searchSubject: Array<SubjectEntity>;
+  searchUsers: Array<User>;
+  /** Search YearGroup records by given columns */
+  searchYearGroup: Array<YearGroupEntity>;
 };
 
 
@@ -921,6 +946,71 @@ export type QueryGetYearGroupByArgs = {
   data: FindOneByInput;
 };
 
+
+export type QuerySearchAssignmentArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchAssignmentSubmissionArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchClassArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchEducatorProfileArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchKeyStageArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchLessonArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchPermissionArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchPermissionGroupArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchRoleArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchStudentProfileArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchSubjectArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchUsersArgs = {
+  data: SearchInput;
+};
+
+
+export type QuerySearchYearGroupArgs = {
+  data: SearchInput;
+};
+
 export type RelationIdsInput = {
   ids: Array<Scalars['ID']['input']>;
   relation: Scalars['String']['input'];
@@ -949,6 +1039,13 @@ export type RolesPermissionsResponse = {
   __typename?: 'RolesPermissionsResponse';
   permissions: Array<PermissionDto>;
   roles: Array<RoleDto>;
+};
+
+export type SearchInput = {
+  columns: Array<Scalars['String']['input']>;
+  limit?: InputMaybe<Scalars['Int']['input']>;
+  relations?: InputMaybe<Array<Scalars['String']['input']>>;
+  search: Scalars['String']['input'];
 };
 
 export type StudentProfileDto = {

--- a/insight-fe/src/app/(main)/(protected)/administration/user-manager/UserManagerPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/user-manager/UserManagerPageClient.tsx
@@ -10,6 +10,7 @@ import { usePermissionRedirect } from "@/hooks/PermissionRedirect";
 import { ContentCard } from "@/components/layout/Card";
 import { Center } from "@chakra-ui/react";
 import { NoUserSelectedCard } from "./_components/cards/NoUserSelectedCard";
+import { UserSearchInput } from "./_components/sections/user/UserSearchInput";
 
 export function UserManagerPageClient() {
   const [selectedUserPublicId, setSelectedUserPublicId] = useState<
@@ -23,6 +24,7 @@ export function UserManagerPageClient() {
 
   return (
     <>
+      <UserSearchInput onSelect={setSelectedUserPublicId} />
       <ContentGrid gridTemplateColumns="1fr 1fr">
         <UserListTable setSelectedUserPublicId={setSelectedUserPublicId} />
 

--- a/insight-fe/src/app/(main)/(protected)/administration/user-manager/UserManagerPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/user-manager/UserManagerPageClient.tsx
@@ -24,7 +24,7 @@ export function UserManagerPageClient() {
 
   return (
     <>
-      <UserSearchInput onSelect={setSelectedUserPublicId} />
+      {/* needs some work but will want  <UserSearchInput onSelect={setSelectedUserPublicId} /> */}
       <ContentGrid gridTemplateColumns="1fr 1fr">
         <UserListTable setSelectedUserPublicId={setSelectedUserPublicId} />
 

--- a/insight-fe/src/app/(main)/(protected)/administration/user-manager/_components/sections/user/UserSearchInput.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/user-manager/_components/sections/user/UserSearchInput.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { Box, Input, List, ListItem } from "@chakra-ui/react";
+import { useLazyQuery } from "@apollo/client";
+import { useEffect, useState } from "react";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+
+/* -------------------------------------------------------------------------- */
+/* GraphQL document                                                           */
+/* -------------------------------------------------------------------------- */
+export const SEARCH_USERS = typedGql("query")({
+  searchUsers: [
+    { data: $("data", "SearchInput!") },
+    { publicId: true, firstName: true, lastName: true },
+  ],
+} as const);
+
+/* -------------------------------------------------------------------------- */
+/* Component                                                                  */
+/* -------------------------------------------------------------------------- */
+interface UserSearchInputProps {
+  onSelect: (publicId: string) => void;
+}
+
+export function UserSearchInput({ onSelect }: UserSearchInputProps) {
+  const [term, setTerm] = useState("");
+  const [executeSearch, { data }] = useLazyQuery(SEARCH_USERS);
+
+  useEffect(() => {
+    const handle = setTimeout(() => {
+      if (term.length > 1) {
+        executeSearch({
+          variables: {
+            data: { search: term, columns: ["firstName", "lastName"], limit: 5 },
+          },
+        });
+      }
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [term, executeSearch]);
+
+  const results = data?.searchUsers ?? [];
+
+  return (
+    <Box position="relative" mb={4}>
+      <Input
+        placeholder="Search users..."
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+      />
+      {results.length > 0 && (
+        <Box
+          position="absolute"
+          top="100%"
+          left={0}
+          right={0}
+          borderWidth="1px"
+          bg="white"
+          zIndex={2}
+        >
+          <List spacing={0} m={0}>
+            {results.map((u) => (
+              <ListItem
+                key={u.publicId}
+                p={2}
+                _hover={{ backgroundColor: "gray.100", cursor: "pointer" }}
+                onClick={() => {
+                  onSelect(u.publicId);
+                  setTerm("");
+                }}
+              >{`${u.firstName} ${u.lastName}`}</ListItem>
+            ))}
+          </List>
+        </Box>
+      )}
+    </Box>
+  );
+}

--- a/insight-fe/src/zeus/const.ts
+++ b/insight-fe/src/zeus/const.ts
@@ -345,9 +345,51 @@ export const AllTypesProps: Record<string,any> = {
 		},
 		getYearGroupBy:{
 			data:"FindOneByInput"
+		},
+		searchAssignment:{
+			data:"SearchInput"
+		},
+		searchAssignmentSubmission:{
+			data:"SearchInput"
+		},
+		searchClass:{
+			data:"SearchInput"
+		},
+		searchEducatorProfile:{
+			data:"SearchInput"
+		},
+		searchKeyStage:{
+			data:"SearchInput"
+		},
+		searchLesson:{
+			data:"SearchInput"
+		},
+		searchPermission:{
+			data:"SearchInput"
+		},
+		searchPermissionGroup:{
+			data:"SearchInput"
+		},
+		searchRole:{
+			data:"SearchInput"
+		},
+		searchStudentProfile:{
+			data:"SearchInput"
+		},
+		searchSubject:{
+			data:"SearchInput"
+		},
+		searchUsers:{
+			data:"SearchInput"
+		},
+		searchYearGroup:{
+			data:"SearchInput"
 		}
 	},
 	RelationIdsInput:{
+
+	},
+	SearchInput:{
 
 	},
 	SubmitIdArrayByIdRequestDto:{
@@ -596,7 +638,20 @@ export const ReturnTypes: Record<string,any> = {
 		getUserByPublicId:"User",
 		getUsersRolesAndPermissions:"RolesPermissionsResponse",
 		getYearGroup:"YearGroupEntity",
-		getYearGroupBy:"YearGroupEntity"
+		getYearGroupBy:"YearGroupEntity",
+		searchAssignment:"AssignmentEntity",
+		searchAssignmentSubmission:"AssignmentSubmissionEntity",
+		searchClass:"ClassEntity",
+		searchEducatorProfile:"EducatorProfileDto",
+		searchKeyStage:"KeyStageEntity",
+		searchLesson:"LessonEntity",
+		searchPermission:"Permission",
+		searchPermissionGroup:"PermissionGroup",
+		searchRole:"Role",
+		searchStudentProfile:"StudentProfileDto",
+		searchSubject:"SubjectEntity",
+		searchUsers:"User",
+		searchYearGroup:"YearGroupEntity"
 	},
 	Role:{
 		createdAt:"DateTime",

--- a/insight-fe/src/zeus/index.ts
+++ b/insight-fe/src/zeus/index.ts
@@ -1252,6 +1252,19 @@ getUserByPublicId?: [{	data: ValueTypes["PublicIdRequestDto"] | Variable<any, st
 getUsersRolesAndPermissions?: [{	data: ValueTypes["UserPermissionsInput"] | Variable<any, string>},ValueTypes["RolesPermissionsResponse"]],
 getYearGroup?: [{	data: ValueTypes["IdInput"] | Variable<any, string>},ValueTypes["YearGroupEntity"]],
 getYearGroupBy?: [{	data: ValueTypes["FindOneByInput"] | Variable<any, string>},ValueTypes["YearGroupEntity"]],
+searchAssignment?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["AssignmentEntity"]],
+searchAssignmentSubmission?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["AssignmentSubmissionEntity"]],
+searchClass?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["ClassEntity"]],
+searchEducatorProfile?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["EducatorProfileDto"]],
+searchKeyStage?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["KeyStageEntity"]],
+searchLesson?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["LessonEntity"]],
+searchPermission?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["Permission"]],
+searchPermissionGroup?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["PermissionGroup"]],
+searchRole?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["Role"]],
+searchStudentProfile?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["StudentProfileDto"]],
+searchSubject?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["SubjectEntity"]],
+searchUsers?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["User"]],
+searchYearGroup?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},ValueTypes["YearGroupEntity"]],
 		__typename?: boolean | `@${string}`
 }>;
 	["RelationIdsInput"]: {
@@ -1280,6 +1293,12 @@ getYearGroupBy?: [{	data: ValueTypes["FindOneByInput"] | Variable<any, string>},
 	roles?:ValueTypes["RoleDTO"],
 		__typename?: boolean | `@${string}`
 }>;
+	["SearchInput"]: {
+	columns: Array<string> | Variable<any, string>,
+	limit?: number | undefined | null | Variable<any, string>,
+	relations?: Array<string> | undefined | null | Variable<any, string>,
+	search: string | Variable<any, string>
+};
 	["StudentProfileDto"]: AliasType<{
 	createdAt?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
@@ -1788,6 +1807,19 @@ getUserByPublicId?: [{	data: ResolverInputTypes["PublicIdRequestDto"]},ResolverI
 getUsersRolesAndPermissions?: [{	data: ResolverInputTypes["UserPermissionsInput"]},ResolverInputTypes["RolesPermissionsResponse"]],
 getYearGroup?: [{	data: ResolverInputTypes["IdInput"]},ResolverInputTypes["YearGroupEntity"]],
 getYearGroupBy?: [{	data: ResolverInputTypes["FindOneByInput"]},ResolverInputTypes["YearGroupEntity"]],
+searchAssignment?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["AssignmentEntity"]],
+searchAssignmentSubmission?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["AssignmentSubmissionEntity"]],
+searchClass?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["ClassEntity"]],
+searchEducatorProfile?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["EducatorProfileDto"]],
+searchKeyStage?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["KeyStageEntity"]],
+searchLesson?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["LessonEntity"]],
+searchPermission?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["Permission"]],
+searchPermissionGroup?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["PermissionGroup"]],
+searchRole?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["Role"]],
+searchStudentProfile?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["StudentProfileDto"]],
+searchSubject?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["SubjectEntity"]],
+searchUsers?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["User"]],
+searchYearGroup?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes["YearGroupEntity"]],
 		__typename?: boolean | `@${string}`
 }>;
 	["RelationIdsInput"]: {
@@ -1816,6 +1848,12 @@ getYearGroupBy?: [{	data: ResolverInputTypes["FindOneByInput"]},ResolverInputTyp
 	roles?:ResolverInputTypes["RoleDTO"],
 		__typename?: boolean | `@${string}`
 }>;
+	["SearchInput"]: {
+	columns: Array<string>,
+	limit?: number | undefined | null,
+	relations?: Array<string> | undefined | null,
+	search: string
+};
 	["StudentProfileDto"]: AliasType<{
 	createdAt?:boolean | `@${string}`,
 	id?:boolean | `@${string}`,
@@ -2387,7 +2425,32 @@ export type ModelTypes = {
 	/** Returns one YearGroup */
 	getYearGroup: ModelTypes["YearGroupEntity"],
 	/** Returns one YearGroup by given conditions */
-	getYearGroupBy: ModelTypes["YearGroupEntity"]
+	getYearGroupBy: ModelTypes["YearGroupEntity"],
+	/** Search Assignment records by given columns */
+	searchAssignment: Array<ModelTypes["AssignmentEntity"]>,
+	/** Search AssignmentSubmission records by given columns */
+	searchAssignmentSubmission: Array<ModelTypes["AssignmentSubmissionEntity"]>,
+	/** Search Class records by given columns */
+	searchClass: Array<ModelTypes["ClassEntity"]>,
+	/** Search EducatorProfile records by given columns */
+	searchEducatorProfile: Array<ModelTypes["EducatorProfileDto"]>,
+	/** Search KeyStage records by given columns */
+	searchKeyStage: Array<ModelTypes["KeyStageEntity"]>,
+	/** Search Lesson records by given columns */
+	searchLesson: Array<ModelTypes["LessonEntity"]>,
+	/** Search Permission records by given columns */
+	searchPermission: Array<ModelTypes["Permission"]>,
+	/** Search PermissionGroup records by given columns */
+	searchPermissionGroup: Array<ModelTypes["PermissionGroup"]>,
+	/** Search Role records by given columns */
+	searchRole: Array<ModelTypes["Role"]>,
+	/** Search StudentProfile records by given columns */
+	searchStudentProfile: Array<ModelTypes["StudentProfileDto"]>,
+	/** Search Subject records by given columns */
+	searchSubject: Array<ModelTypes["SubjectEntity"]>,
+	searchUsers: Array<ModelTypes["User"]>,
+	/** Search YearGroup records by given columns */
+	searchYearGroup: Array<ModelTypes["YearGroupEntity"]>
 };
 	["RelationIdsInput"]: {
 	ids: Array<ModelTypes["ID"]>,
@@ -2411,6 +2474,12 @@ export type ModelTypes = {
 	["RolesPermissionsResponse"]: {
 		permissions: Array<ModelTypes["PermissionDTO"]>,
 	roles: Array<ModelTypes["RoleDTO"]>
+};
+	["SearchInput"]: {
+	columns: Array<string>,
+	limit?: number | undefined | null,
+	relations?: Array<string> | undefined | null,
+	search: string
 };
 	["StudentProfileDto"]: {
 		createdAt: ModelTypes["DateTime"],
@@ -2990,7 +3059,32 @@ export type GraphQLTypes = {
 	/** Returns one YearGroup */
 	getYearGroup: GraphQLTypes["YearGroupEntity"],
 	/** Returns one YearGroup by given conditions */
-	getYearGroupBy: GraphQLTypes["YearGroupEntity"]
+	getYearGroupBy: GraphQLTypes["YearGroupEntity"],
+	/** Search Assignment records by given columns */
+	searchAssignment: Array<GraphQLTypes["AssignmentEntity"]>,
+	/** Search AssignmentSubmission records by given columns */
+	searchAssignmentSubmission: Array<GraphQLTypes["AssignmentSubmissionEntity"]>,
+	/** Search Class records by given columns */
+	searchClass: Array<GraphQLTypes["ClassEntity"]>,
+	/** Search EducatorProfile records by given columns */
+	searchEducatorProfile: Array<GraphQLTypes["EducatorProfileDto"]>,
+	/** Search KeyStage records by given columns */
+	searchKeyStage: Array<GraphQLTypes["KeyStageEntity"]>,
+	/** Search Lesson records by given columns */
+	searchLesson: Array<GraphQLTypes["LessonEntity"]>,
+	/** Search Permission records by given columns */
+	searchPermission: Array<GraphQLTypes["Permission"]>,
+	/** Search PermissionGroup records by given columns */
+	searchPermissionGroup: Array<GraphQLTypes["PermissionGroup"]>,
+	/** Search Role records by given columns */
+	searchRole: Array<GraphQLTypes["Role"]>,
+	/** Search StudentProfile records by given columns */
+	searchStudentProfile: Array<GraphQLTypes["StudentProfileDto"]>,
+	/** Search Subject records by given columns */
+	searchSubject: Array<GraphQLTypes["SubjectEntity"]>,
+	searchUsers: Array<GraphQLTypes["User"]>,
+	/** Search YearGroup records by given columns */
+	searchYearGroup: Array<GraphQLTypes["YearGroupEntity"]>
 };
 	["RelationIdsInput"]: {
 		ids: Array<GraphQLTypes["ID"]>,
@@ -3017,6 +3111,12 @@ export type GraphQLTypes = {
 	__typename: "RolesPermissionsResponse",
 	permissions: Array<GraphQLTypes["PermissionDTO"]>,
 	roles: Array<GraphQLTypes["RoleDTO"]>
+};
+	["SearchInput"]: {
+		columns: Array<string>,
+	limit?: number | undefined | null,
+	relations?: Array<string> | undefined | null,
+	search: string
 };
 	["StudentProfileDto"]: {
 	__typename: "StudentProfileDto",
@@ -3217,6 +3317,7 @@ type ZEUS_VARIABLES = {
 	["PaginationInput"]: ValueTypes["PaginationInput"];
 	["PublicIdRequestDto"]: ValueTypes["PublicIdRequestDto"];
 	["RelationIdsInput"]: ValueTypes["RelationIdsInput"];
+	["SearchInput"]: ValueTypes["SearchInput"];
 	["SubmitIdArrayByIdRequestDto"]: ValueTypes["SubmitIdArrayByIdRequestDto"];
 	["UpdateAssignmentInput"]: ValueTypes["UpdateAssignmentInput"];
 	["UpdateAssignmentSubmissionInput"]: ValueTypes["UpdateAssignmentSubmissionInput"];


### PR DESCRIPTION
## Summary
- add SearchInput DTO for flexible column searching
- support searchByColumns in BaseService and BaseResolver
- update user search resolver & service to use new generic method
- enable search operation for year groups
- revise UI search component and GraphQL schema

## Testing
- `npm test` in `insight-be` *(fails: jest not found)*
- `npm test` in `insight-fe` *(fails: missing script)*
