### PR TITLE
Fix search with userType filters

### DIFF
--- a/insight-be/src/common/base.inputs.ts
+++ b/insight-be/src/common/base.inputs.ts
@@ -141,4 +141,7 @@ export class SearchInput {
 
   @Field(() => [String], { nullable: true })
   relations?: string[];
+
+  @Field(() => [FilterInput], { nullable: true })
+  filters?: FilterInput[];
 }

--- a/insight-be/src/common/base.resolver.ts
+++ b/insight-be/src/common/base.resolver.ts
@@ -134,10 +134,11 @@ export function createBaseResolver<
     async search(
       @Args('data', { type: () => SearchInput }) data: SearchInput,
     ): Promise<T[]> {
-      const { search, columns, limit, relations } = data;
+      const { search, columns, limit, relations, filters } = data;
       return this.service.searchByColumns(search, columns as (keyof T)[], {
         limit,
         relations,
+        filters,
       });
     }
 

--- a/insight-be/src/modules/user/user.resolver.ts
+++ b/insight-be/src/modules/user/user.resolver.ts
@@ -51,8 +51,8 @@ export class UserResolver {
   @Query(() => [User])
   @RbacPermissionKey('user.searchUsers')
   async searchUsers(@Args('data') data: SearchInput): Promise<User[]> {
-    const { search, columns, limit } = data;
-    return this.userService.search(search, columns as (keyof User)[], limit);
+    const { search, columns, limit, filters } = data;
+    return this.userService.search(search, columns as (keyof User)[], limit, filters);
   }
 
   @Query(() => User)

--- a/insight-fe/schema.graphql
+++ b/insight-fe/schema.graphql
@@ -364,6 +364,7 @@ input SearchInput {
   columns: [String!]!
   limit: Int
   relations: [String!]
+  filters: [FilterInput!]
 }
 
 type Permission {

--- a/insight-fe/src/__generated__/schema-types.ts
+++ b/insight-fe/src/__generated__/schema-types.ts
@@ -1045,6 +1045,7 @@ export type SearchInput = {
   columns: Array<Scalars['String']['input']>;
   limit?: InputMaybe<Scalars['Int']['input']>;
   relations?: InputMaybe<Array<Scalars['String']['input']>>;
+  filters?: InputMaybe<Array<FilterInput>>;
   search: Scalars['String']['input'];
 };
 

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/EducatorSearchInput.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/EducatorSearchInput.tsx
@@ -7,9 +7,9 @@ import { typedGql } from "@/zeus/typedDocumentNode";
 import { $ } from "@/zeus";
 
 const SEARCH_EDUCATORS = typedGql("query")({
-  searchEducatorProfile: [
+  searchUsers: [
     { data: $("data", "SearchInput!") },
-    { id: true, staffId: true },
+    { id: true, firstName: true, lastName: true },
   ],
 } as const);
 
@@ -26,7 +26,12 @@ export default function EducatorSearchInput({ onSelect }: EducatorSearchInputPro
       if (term.length > 1) {
         executeSearch({
           variables: {
-            data: { search: term, columns: ["staffId"], limit: 5 },
+            data: {
+              search: term,
+              columns: ["firstName", "lastName"],
+              limit: 5,
+              filters: [{ column: "userType", value: "educator" }],
+            },
           },
         });
       }
@@ -34,7 +39,7 @@ export default function EducatorSearchInput({ onSelect }: EducatorSearchInputPro
     return () => clearTimeout(handle);
   }, [term, executeSearch]);
 
-  const results = data?.searchEducatorProfile ?? [];
+  const results = data?.searchUsers ?? [];
 
   return (
     <Box position="relative" mb={4}>
@@ -55,7 +60,7 @@ export default function EducatorSearchInput({ onSelect }: EducatorSearchInputPro
                   onSelect(String(e.id));
                   setTerm("");
                 }}
-              >{`Staff ID ${e.staffId}`}</ListItem>
+              >{`${e.firstName} ${e.lastName}`}</ListItem>
             ))}
           </List>
         </Box>

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/StudentSearchInput.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/StudentSearchInput.tsx
@@ -7,9 +7,9 @@ import { typedGql } from "@/zeus/typedDocumentNode";
 import { $ } from "@/zeus";
 
 const SEARCH_STUDENTS = typedGql("query")({
-  searchStudentProfile: [
+  searchUsers: [
     { data: $("data", "SearchInput!") },
-    { id: true, studentId: true, schoolYear: true },
+    { id: true, firstName: true, lastName: true },
   ],
 } as const);
 
@@ -26,7 +26,12 @@ export default function StudentSearchInput({ onSelect }: StudentSearchInputProps
       if (term.length > 1) {
         executeSearch({
           variables: {
-            data: { search: term, columns: ["studentId"], limit: 5 },
+            data: {
+              search: term,
+              columns: ["firstName", "lastName"],
+              limit: 5,
+              filters: [{ column: "userType", value: "student" }],
+            },
           },
         });
       }
@@ -34,7 +39,7 @@ export default function StudentSearchInput({ onSelect }: StudentSearchInputProps
     return () => clearTimeout(handle);
   }, [term, executeSearch]);
 
-  const results = data?.searchStudentProfile ?? [];
+  const results = data?.searchUsers ?? [];
 
   return (
     <Box position="relative" mb={4}>
@@ -55,7 +60,7 @@ export default function StudentSearchInput({ onSelect }: StudentSearchInputProps
                   onSelect(String(s.id));
                   setTerm("");
                 }}
-              >{`ID ${s.studentId} (Y${s.schoolYear})`}</ListItem>
+              >{`${s.firstName} ${s.lastName}`}</ListItem>
             ))}
           </List>
         </Box>

--- a/insight-fe/src/zeus/index.ts
+++ b/insight-fe/src/zeus/index.ts
@@ -1296,8 +1296,9 @@ searchYearGroup?: [{	data: ValueTypes["SearchInput"] | Variable<any, string>},Va
 	["SearchInput"]: {
 	columns: Array<string> | Variable<any, string>,
 	limit?: number | undefined | null | Variable<any, string>,
-	relations?: Array<string> | undefined | null | Variable<any, string>,
-	search: string | Variable<any, string>
+        relations?: Array<string> | undefined | null | Variable<any, string>,
+        filters?: Array<ValueTypes["FilterInput"]> | undefined | null | Variable<any, string>,
+        search: string | Variable<any, string>
 };
 	["StudentProfileDto"]: AliasType<{
 	createdAt?:boolean | `@${string}`,
@@ -1850,9 +1851,10 @@ searchYearGroup?: [{	data: ResolverInputTypes["SearchInput"]},ResolverInputTypes
 }>;
 	["SearchInput"]: {
 	columns: Array<string>,
-	limit?: number | undefined | null,
-	relations?: Array<string> | undefined | null,
-	search: string
+        limit?: number | undefined | null,
+        relations?: Array<string> | undefined | null,
+        filters?: Array<ResolverInputTypes["FilterInput"]> | undefined | null,
+        search: string
 };
 	["StudentProfileDto"]: AliasType<{
 	createdAt?:boolean | `@${string}`,
@@ -2476,10 +2478,11 @@ export type ModelTypes = {
 	roles: Array<ModelTypes["RoleDTO"]>
 };
 	["SearchInput"]: {
-	columns: Array<string>,
-	limit?: number | undefined | null,
-	relations?: Array<string> | undefined | null,
-	search: string
+        columns: Array<string>,
+        limit?: number | undefined | null,
+        relations?: Array<string> | undefined | null,
+        filters?: Array<ModelTypes["FilterInput"]> | undefined | null,
+        search: string
 };
 	["StudentProfileDto"]: {
 		createdAt: ModelTypes["DateTime"],
@@ -3114,9 +3117,10 @@ export type GraphQLTypes = {
 };
 	["SearchInput"]: {
 		columns: Array<string>,
-	limit?: number | undefined | null,
-	relations?: Array<string> | undefined | null,
-	search: string
+        limit?: number | undefined | null,
+        relations?: Array<string> | undefined | null,
+        filters?: Array<GraphQLTypes["FilterInput"]> | undefined | null,
+        search: string
 };
 	["StudentProfileDto"]: {
 	__typename: "StudentProfileDto",


### PR DESCRIPTION
## Summary
- extend `SearchInput` with optional filters
- allow `searchByColumns` to take extra filters
- update `UsersService.search` accordingly
- use `searchUsers` in student and educator search inputs
- update generated schema types

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: @eslint/js not found)*