### PR TITLE
Add topic module

### DIFF
--- a/insight-be/src/app.module.ts
+++ b/insight-be/src/app.module.ts
@@ -28,6 +28,7 @@ import { KeyStageModule } from './modules/timbuktu/administrative/key-stage/key-
 import { LessonModule } from './modules/timbuktu/administrative/lesson/lesson.module';
 import { SubjectModule } from './modules/timbuktu/administrative/subject/subject.module';
 import { YearGroupModule } from './modules/timbuktu/administrative/year-group/year-group.module';
+import { TopicModule } from './modules/timbuktu/administrative/topic/topic.module';
 import { AssignmentSubmissionModule } from './modules/timbuktu/administrative/assignment-submission/assignment-submission.model';
 import { AssignmentModule } from './modules/timbuktu/administrative/assignment/assignment.module';
 import { AssignmentSubmissionEntity } from './modules/timbuktu/administrative/assignment-submission/assignment-submission.entity';
@@ -37,6 +38,7 @@ import { KeyStageEntity } from './modules/timbuktu/administrative/key-stage/key-
 import { LessonEntity } from './modules/timbuktu/administrative/lesson/lesson.entity';
 import { SubjectEntity } from './modules/timbuktu/administrative/subject/subject.entity';
 import { YearGroupEntity } from './modules/timbuktu/administrative/year-group/year-group.entity';
+import { TopicEntity } from './modules/timbuktu/administrative/topic/topic.entity';
 import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-tables/class-lesson/class-lesson.entity';
 
 @Module({
@@ -71,6 +73,7 @@ import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-table
         YearGroupEntity,
         SubjectEntity,
         LessonEntity,
+        TopicEntity,
         AssignmentSubmissionEntity,
         AssignmentEntity,
         ClassLessonEntity,
@@ -92,6 +95,7 @@ import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-table
     KeyStageModule,
     YearGroupModule,
     SubjectModule,
+    TopicModule,
     ClassModule,
     LessonModule,
     AssignmentModule,

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
@@ -11,8 +11,8 @@ import { ObjectType, Field, ID } from '@nestjs/graphql';
 
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { EducatorProfileEntity } from '../../user-profiles/educator-profile/educator-profile.entity';
-import { SubjectEntity } from '../subject/subject.entity';
 import { YearGroupEntity } from '../year-group/year-group.entity';
+import { TopicEntity } from '../topic/topic.entity';
 import { EducatorProfileDto } from '../../user-profiles/educator-profile/dto/educator-profile.dto';
 
 @ObjectType()
@@ -28,11 +28,9 @@ export class LessonEntity extends AbstractBaseEntity {
 
   /* ---------- relationships ---------- */
 
-  @Field(() => SubjectEntity, { nullable: true })
-  @ManyToOne(() => SubjectEntity, (subject) => subject.lessons, {
-    nullable: true,
-  })
-  subject?: SubjectEntity;
+  @Field(() => TopicEntity, { nullable: true })
+  @ManyToOne(() => TopicEntity, (topic) => topic.lessons, { nullable: true })
+  topic?: TopicEntity;
 
   @Field(() => [YearGroupEntity], { nullable: true })
   @ManyToMany(() => YearGroupEntity, { nullable: true })

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
@@ -9,10 +9,10 @@ export class CreateLessonInput {
   content?: string;
 
   /**
-   * Optional "subjectId" if you want to link the lesson to a subject
+   * Topic that this lesson belongs to
    */
-  @Field(() => ID, { nullable: true })
-  subjectId?: number;
+  @Field(() => ID)
+  topicId!: number;
 
   /**
    * If you allow a lesson to be recommended for multiple YearGroups:

--- a/insight-be/src/modules/timbuktu/administrative/subject/subject.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/subject/subject.entity.ts
@@ -5,8 +5,8 @@ import { Entity, Column, ManyToMany, OneToMany, JoinTable } from 'typeorm';
 import { ObjectType, Field } from '@nestjs/graphql';
 
 import { AbstractBaseEntity } from 'src/common/base.entity';
-import { LessonEntity } from '../lesson/lesson.entity';
 import { YearGroupEntity } from '../year-group/year-group.entity';
+import { TopicEntity } from '../topic/topic.entity';
 
 @ObjectType()
 @Entity('subjects')
@@ -17,8 +17,9 @@ export class SubjectEntity extends AbstractBaseEntity {
 
   /* ---------- relationships ---------- */
 
-  @OneToMany(() => LessonEntity, (lesson) => lesson.subject)
-  lessons?: LessonEntity[];
+  @Field(() => [TopicEntity], { nullable: true })
+  @OneToMany(() => TopicEntity, (topic) => topic.subject)
+  topics?: TopicEntity[];
 
   @Field(() => [YearGroupEntity], { nullable: true })
   @ManyToMany(() => YearGroupEntity, (yg) => yg.subjects, {

--- a/insight-be/src/modules/timbuktu/administrative/topic/topic.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/topic/topic.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, Column, ManyToOne, OneToMany, Unique, Index } from 'typeorm';
+import { ObjectType, Field } from '@nestjs/graphql';
+
+import { AbstractBaseEntity } from 'src/common/base.entity';
+import { SubjectEntity } from '../subject/subject.entity';
+import { YearGroupEntity } from '../year-group/year-group.entity';
+import { LessonEntity } from '../lesson/lesson.entity';
+
+@ObjectType()
+@Index('idx_topic_year_subject', ['yearGroup', 'subject'])
+@Unique('uq_topic_year_subject_name', ['yearGroup', 'subject', 'name'])
+@Entity('topics')
+export class TopicEntity extends AbstractBaseEntity {
+  @Field()
+  @Column()
+  name: string;
+
+  @Field(() => YearGroupEntity)
+  @ManyToOne(() => YearGroupEntity, (yg) => yg.topics, { nullable: false })
+  yearGroup!: YearGroupEntity;
+
+  @Field(() => SubjectEntity)
+  @ManyToOne(() => SubjectEntity, (sub) => sub.topics, { nullable: false })
+  subject!: SubjectEntity;
+
+  @Field(() => [LessonEntity], { nullable: true })
+  @OneToMany(() => LessonEntity, (lesson) => lesson.topic)
+  lessons?: LessonEntity[];
+}

--- a/insight-be/src/modules/timbuktu/administrative/topic/topic.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/topic/topic.inputs.ts
@@ -1,0 +1,32 @@
+import { InputType, Field, ID, PartialType } from '@nestjs/graphql';
+import { IsOptional } from 'class-validator';
+import { HasRelationsInput } from 'src/common/base.inputs';
+import { PaginationInput } from 'src/common/utils/pagination.util';
+
+@InputType()
+export class CreateTopicInput extends HasRelationsInput {
+  @Field()
+  name!: string;
+}
+
+@InputType()
+export class UpdateTopicInput extends PartialType(CreateTopicInput) {
+  @Field(() => ID)
+  id!: number;
+}
+
+@InputType()
+export class TopicByYearSubjectInput {
+  @Field(() => ID)
+  yearGroupId!: string;
+
+  @Field(() => ID)
+  subjectId!: string;
+
+  @Field(() => Boolean, { defaultValue: false })
+  @IsOptional()
+  withLessons?: boolean;
+
+  @Field(() => PaginationInput, { nullable: true })
+  pagination?: PaginationInput;
+}

--- a/insight-be/src/modules/timbuktu/administrative/topic/topic.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/topic/topic.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+import { TopicEntity } from './topic.entity';
+import { TopicService } from './topic.service';
+import { TopicResolver } from './topic.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TopicEntity])],
+  providers: [TopicService, TopicResolver],
+  exports: [TopicService],
+})
+export class TopicModule {}

--- a/insight-be/src/modules/timbuktu/administrative/topic/topic.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/topic/topic.resolver.ts
@@ -1,0 +1,43 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+import { createBaseResolver } from 'src/common/base.resolver';
+import { TopicEntity } from './topic.entity';
+import {
+  CreateTopicInput,
+  UpdateTopicInput,
+  TopicByYearSubjectInput,
+} from './topic.inputs';
+import { TopicService } from './topic.service';
+import { RbacPermissionKey } from 'src/modules/rbac/decorators/resolver-permission-key.decorator';
+
+const BaseTopicResolver = createBaseResolver<
+  TopicEntity,
+  CreateTopicInput,
+  UpdateTopicInput
+>(TopicEntity, CreateTopicInput, UpdateTopicInput, {
+  queryName: 'Topic',
+  stableKeyPrefix: 'topic',
+  enabledOperations: [
+    'findAll',
+    'findOne',
+    'findOneBy',
+    'create',
+    'update',
+    'remove',
+    'search',
+  ],
+});
+
+@Resolver(() => TopicEntity)
+export class TopicResolver extends BaseTopicResolver {
+  constructor(private readonly topicService: TopicService) {
+    super(topicService);
+  }
+
+  @RbacPermissionKey('topic.findAllByYearAndSubject')
+  @Query(() => [TopicEntity])
+  async topicsByYearAndSubject(
+    @Args('input') input: TopicByYearSubjectInput,
+  ): Promise<TopicEntity[]> {
+    return this.topicService.findByYearAndSubject(input);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/topic/topic.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/topic/topic.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BaseService } from 'src/common/base.service';
+import { TopicEntity } from './topic.entity';
+import {
+  CreateTopicInput,
+  UpdateTopicInput,
+  TopicByYearSubjectInput,
+} from './topic.inputs';
+
+@Injectable()
+export class TopicService extends BaseService<
+  TopicEntity,
+  CreateTopicInput,
+  UpdateTopicInput
+> {
+  constructor(
+    @InjectRepository(TopicEntity)
+    topicRepository: Repository<TopicEntity>,
+    @InjectDataSource() dataSource: DataSource,
+  ) {
+    super(topicRepository, dataSource);
+  }
+
+  async findByYearAndSubject(
+    input: TopicByYearSubjectInput,
+  ): Promise<TopicEntity[]> {
+    const { yearGroupId, subjectId, withLessons = false } = input;
+
+    const qb = this.repo
+      .createQueryBuilder('topic')
+      .innerJoin('topic.yearGroup', 'yg', 'yg.id = :yearGroupId', { yearGroupId })
+      .innerJoin('topic.subject', 'sub', 'sub.id = :subjectId', { subjectId });
+
+    if (withLessons) {
+      qb.leftJoinAndSelect('topic.lessons', 'les');
+    }
+
+    return qb.orderBy('topic.name', 'ASC').getMany();
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/year-group/year-group.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/year-group/year-group.entity.ts
@@ -8,6 +8,7 @@ import { AbstractBaseEntity } from 'src/common/base.entity';
 import { ClassEntity } from '../class/class.entity';
 import { KeyStageEntity } from '../key-stage/key-stage.entity';
 import { SubjectEntity } from '../subject/subject.entity';
+import { TopicEntity } from '../topic/topic.entity';
 
 export enum ValidYear {
   Year7 = 'Year 7',
@@ -35,6 +36,10 @@ export class YearGroupEntity extends AbstractBaseEntity {
 
   @OneToMany(() => ClassEntity, (cls) => cls.yearGroup)
   classes?: ClassEntity[];
+
+  @Field(() => [TopicEntity], { nullable: true })
+  @OneToMany(() => TopicEntity, (topic) => topic.yearGroup)
+  topics?: TopicEntity[];
 
   @Field(() => [SubjectEntity], { nullable: true })
   @ManyToMany(() => SubjectEntity, (s) => s.yearGroups, { nullable: true })


### PR DESCRIPTION
## Summary
- add topic entity, service, resolver, and module
- connect topics to subjects, year groups, and lessons
- expose Topic module via AppModule
- allow lessons, year groups, and subjects to reference topics
- refine relations so lessons belong only to topics

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*