### PR TITLE
Add topic management dropdown

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/CoordinationPanelClientInner.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/CoordinationPanelClientInner.tsx
@@ -9,6 +9,7 @@ import { SubjectDropdown } from "./_components/dropdowns/SubjectsDropdown/Subjec
 import { ClassDropdown } from "./_components/dropdowns/ClassDropdown/ClassDropdown";
 import { ContentGrid } from "@/components/ContentGrid";
 import ClassMembersPane from "./_components/ClassMembersPane";
+import TopicPane from "./_components/TopicPane";
 
 export default function CoordinationPanelClientInner() {
   const [keyStageId, setKeyStageId] = useState<string | null>(null);
@@ -19,7 +20,7 @@ export default function CoordinationPanelClientInner() {
   console.log("PARENT RENDERING");
 
   return (
-    <Grid templateColumns="1fr 1fr">
+    <Grid templateColumns="1fr 1fr" gap={4}>
       <ContentCard>
         <Flex gap={8} flexDir="column">
           {/* ------------------- 1. key stage ------------------- */}
@@ -72,6 +73,7 @@ export default function CoordinationPanelClientInner() {
         classId={classId}
         setClassId={setClassId}
       />
+      <TopicPane yearGroupId={yearGroupId} subjectId={subjectId} />
     </Grid>
   );
 }

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/TopicPane.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/TopicPane.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Flex, Text } from "@chakra-ui/react";
+import { ContentCard } from "@/components/layout/Card";
+import { TopicDropdown } from "./dropdowns/TopicDropdown/TopicDropdown";
+import { useState } from "react";
+
+interface TopicPaneProps {
+  yearGroupId: string | null;
+  subjectId: string | null;
+}
+
+export default function TopicPane({ yearGroupId, subjectId }: TopicPaneProps) {
+  const [topicId, setTopicId] = useState<string | null>(null);
+
+  return (
+    <ContentCard gridColumn="1 / span 2">
+      <Flex flexDir="column" gap={2}>
+        <Text>Topic</Text>
+        <TopicDropdown
+          yearGroupId={yearGroupId}
+          subjectId={subjectId}
+          value={topicId}
+          onChange={setTopicId}
+        />
+      </Flex>
+    </ContentCard>
+  );
+}

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/TopicDropdown/TopicDropdown.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/TopicDropdown/TopicDropdown.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { ChangeEvent, useMemo, useState } from "react";
+import CrudDropdown from "../CrudDropdown";
+import { BaseModal } from "@/components/modals/BaseModal";
+import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
+import CreateTopicForm from "./forms/CreateTopicForm";
+import UpdateTopicForm from "./forms/UpdateTopicForm";
+import { gql, useQuery, useMutation } from "@apollo/client";
+
+const GET_TOPICS_BY_YEAR_SUBJECT = gql`
+  query TopicsByYearAndSubject($input: TopicByYearSubjectInput!) {
+    topicsByYearAndSubject(input: $input) {
+      id
+      name
+    }
+  }
+`;
+
+const DELETE_TOPIC = gql`
+  mutation DeleteTopic($data: IdInput!) {
+    deleteTopic(data: $data)
+  }
+`;
+
+interface TopicDropdownProps {
+  yearGroupId: string | null;
+  subjectId: string | null;
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+export function TopicDropdown({
+  yearGroupId,
+  subjectId,
+  value,
+  onChange,
+}: TopicDropdownProps) {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isUpdateOpen, setIsUpdateOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  const variables = useMemo(
+    () =>
+      yearGroupId && subjectId
+        ? { input: { yearGroupId, subjectId } }
+        : undefined,
+    [yearGroupId, subjectId]
+  );
+
+  const { data, loading, refetch } = useQuery(GET_TOPICS_BY_YEAR_SUBJECT, {
+    variables,
+    skip: !(yearGroupId && subjectId),
+  });
+
+  const [deleteTopic, { loading: deleting }] = useMutation(DELETE_TOPIC, {
+    onCompleted: () => {
+      setIsDeleteOpen(false);
+      refetch();
+      onChange(null);
+    },
+  });
+
+  const topics = yearGroupId && subjectId ? data?.topicsByYearAndSubject ?? [] : [];
+  const selectedTopic = topics.find((t: any) => String(t.id) === value);
+
+  const options = useMemo(
+    () => topics.map((t: any) => ({ label: t.name, value: String(t.id) })),
+    [topics]
+  );
+
+  return (
+    <>
+      <CrudDropdown
+        options={options}
+        value={value ?? ""}
+        isLoading={loading}
+        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+          onChange(e.target.value || null)
+        }
+        onCreate={() => setIsCreateOpen(true)}
+        onUpdate={() => setIsUpdateOpen(true)}
+        onDelete={() => setIsDeleteOpen(true)}
+        isUpdateDisabled={!value}
+        isDeleteDisabled={!value}
+        isDisabled={!(yearGroupId && subjectId)}
+      />
+
+      <BaseModal
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        title="Create Topic"
+      >
+        <CreateTopicForm
+          yearGroupId={yearGroupId ?? ""}
+          subjectId={subjectId ?? ""}
+          onSuccess={() => {
+            setIsCreateOpen(false);
+            refetch();
+          }}
+        />
+      </BaseModal>
+
+      <BaseModal
+        isOpen={isUpdateOpen}
+        onClose={() => setIsUpdateOpen(false)}
+        title="Update Topic"
+      >
+        <UpdateTopicForm
+          topicId={value ?? ""}
+          initialName={selectedTopic?.name ?? ""}
+          onSuccess={() => {
+            setIsUpdateOpen(false);
+            refetch();
+          }}
+        />
+      </BaseModal>
+
+      <ConfirmationModal
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+        action="delete topic"
+        bodyText="Are you sure you want to delete this topic?"
+        onConfirm={() => {
+          if (value) {
+            deleteTopic({ variables: { data: { id: Number(value) } } });
+          }
+        }}
+        isLoading={deleting}
+      />
+    </>
+  );
+}

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/TopicDropdown/forms/CreateTopicForm.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/TopicDropdown/forms/CreateTopicForm.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import React from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Spinner,
+  Stack,
+} from "@chakra-ui/react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { gql, useMutation } from "@apollo/client";
+
+const CREATE_TOPIC = gql`
+  mutation CreateTopic($data: CreateTopicInput!) {
+    createTopic(data: $data) {
+      id
+    }
+  }
+`;
+
+type FormValues = { name: string };
+
+interface CreateTopicFormProps {
+  yearGroupId: string;
+  subjectId: string;
+  onSuccess: () => void;
+}
+
+export default function CreateTopicForm({
+  yearGroupId,
+  subjectId,
+  onSuccess,
+}: CreateTopicFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isValid, isSubmitting },
+  } = useForm<FormValues>({
+    defaultValues: { name: "" },
+    mode: "onChange",
+  });
+
+  const [createTopic, { loading }] = useMutation(CREATE_TOPIC, {
+    onCompleted: onSuccess,
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    await createTopic({
+      variables: {
+        data: {
+          name: values.name.trim(),
+          relationIds: [
+            { relation: "yearGroup", ids: [yearGroupId] },
+            { relation: "subject", ids: [subjectId] },
+          ],
+        },
+      },
+    });
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4}>
+      <Stack spacing={6}>
+        <FormControl isInvalid={!!errors.name}>
+          <FormLabel>Topic name</FormLabel>
+          <Input
+            placeholder="Topic name"
+            {...register("name", { required: "Name is required" })}
+          />
+          <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
+        </FormControl>
+        <Button
+          type="submit"
+          colorScheme="blue"
+          isDisabled={!isValid || isSubmitting || loading}
+          leftIcon={isSubmitting || loading ? <Spinner size="sm" /> : undefined}
+        >
+          Create Topic
+        </Button>
+      </Stack>
+    </Box>
+  );
+}

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/TopicDropdown/forms/UpdateTopicForm.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/TopicDropdown/forms/UpdateTopicForm.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import React from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Spinner,
+  Stack,
+} from "@chakra-ui/react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { gql, useMutation } from "@apollo/client";
+
+const UPDATE_TOPIC = gql`
+  mutation UpdateTopic($data: UpdateTopicInput!) {
+    updateTopic(data: $data) {
+      id
+    }
+  }
+`;
+
+type FormValues = { name: string };
+
+interface UpdateTopicFormProps {
+  topicId: string;
+  initialName: string;
+  onSuccess: () => void;
+}
+
+export default function UpdateTopicForm({
+  topicId,
+  initialName,
+  onSuccess,
+}: UpdateTopicFormProps) {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<FormValues>({
+    defaultValues: { name: initialName },
+    mode: "onChange",
+  });
+
+  const [updateTopic, { loading }] = useMutation(UPDATE_TOPIC, {
+    onCompleted: onSuccess,
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    await updateTopic({
+      variables: {
+        data: { id: topicId, name: values.name.trim() },
+      },
+    });
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4}>
+      <Stack spacing={6}>
+        <FormControl isInvalid={!!errors.name}>
+          <FormLabel>Topic name</FormLabel>
+          <Input
+            placeholder="Topic name"
+            {...register("name", { required: "Name is required" })}
+          />
+          <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
+        </FormControl>
+        <Button
+          type="submit"
+          colorScheme="blue"
+          isDisabled={isSubmitting || loading}
+          leftIcon={isSubmitting || loading ? <Spinner size="sm" /> : undefined}
+        >
+          Update Topic
+        </Button>
+      </Stack>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- add a new pane with TopicDropdown in coordination panel
- implement TopicDropdown component with CRUD actions
- include Create/Update forms for topics

## Testing
- `npm test` *(fails: jest not found)*