### PR TITLE
Add description and JSON content to lessons

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
@@ -8,6 +8,7 @@ import {
   RelationId,
 } from 'typeorm';
 import { ObjectType, Field, ID } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
 
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { EducatorProfileEntity } from '../../user-profiles/educator-profile/educator-profile.entity';
@@ -24,7 +25,11 @@ export class LessonEntity extends AbstractBaseEntity {
 
   @Field({ nullable: true })
   @Column({ type: 'text', nullable: true })
-  content?: string;
+  description?: string;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  @Column({ type: 'jsonb', nullable: true })
+  content?: Record<string, any>;
 
   /* ---------- relationships ---------- */
 

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
@@ -1,4 +1,5 @@
 import { PartialType, InputType, Field, ID } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
 
 @InputType()
 export class CreateLessonInput {
@@ -6,7 +7,10 @@ export class CreateLessonInput {
   title: string;
 
   @Field({ nullable: true })
-  content?: string;
+  description?: string;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  content?: Record<string, any>;
 
   /**
    * Topic that this lesson belongs to


### PR DESCRIPTION
## Summary
- extend Lesson entity with description and JSON content fields
- update DTO to match

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint packages)*