### PR TITLE
Add CRUD support to coordination dropdowns

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/KeyStageDropdown/KeyStageDropdown.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/KeyStageDropdown/KeyStageDropdown.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import React, { ChangeEvent, useEffect, useMemo } from "react";
+import React, { ChangeEvent, useEffect, useMemo, useState } from "react";
 import CrudDropdown from "../CrudDropdown";
-import { useQuery } from "@apollo/client";
+import { useQuery, useMutation, gql } from "@apollo/client";
 import { typedGql } from "@/zeus/typedDocumentNode";
 import { $ } from "@/zeus";
+import { BaseModal } from "@/components/modals/BaseModal";
+import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
+import CreateKeyStageForm from "./forms/CreateKeyStageForm";
+import UpdateKeyStageForm from "./forms/UpdateKeyStageForm";
 
 /* -------------------------------------------------------------------------- */
 /* GraphQL document                                                           */
@@ -12,9 +16,15 @@ import { $ } from "@/zeus";
 const GET_ALL_KEY_STAGES = typedGql("query")({
   getAllKeyStage: [
     { data: $("data", "FindAllInput!") }, // { all: true }
-    { id: true, name: true },
+    { id: true, name: true, description: true },
   ],
 } as const);
+
+const DELETE_KEY_STAGE = gql`
+  mutation DeleteKeyStage($data: IdInput!) {
+    deleteKeyStage(data: $data)
+  }
+`;
 
 /* -------------------------------------------------------------------------- */
 /* Component                                                                  */
@@ -25,8 +35,12 @@ interface KeyStageDropdownProps {
 }
 
 export function KeyStageDropdown({ value, onChange }: KeyStageDropdownProps) {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isUpdateOpen, setIsUpdateOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
   /* ---------- list (fetched once, cached by Apollo) ---------- */
-  const { data, loading } = useQuery(GET_ALL_KEY_STAGES, {
+  const { data, loading, refetch } = useQuery(GET_ALL_KEY_STAGES, {
     variables: { data: { all: true } },
   });
 
@@ -42,25 +56,74 @@ export function KeyStageDropdown({ value, onChange }: KeyStageDropdownProps) {
     [keyStages]
   );
 
-  useEffect(() => {
-    console.log(options);
-  }, [options]);
+  const selected = keyStages.find((ks) => String(ks.id) === value);
+
+  const [deleteKeyStage, { loading: deleting }] = useMutation(DELETE_KEY_STAGE, {
+    onCompleted: () => {
+      setIsDeleteOpen(false);
+      onChange(null);
+      refetch();
+    },
+  });
 
   /* ---------- render ---------- */
   return (
-    <CrudDropdown
-      options={options}
-      value={value ?? ""}
-      isLoading={loading}
-      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-        onChange(e.target.value || null)
-      }
-      onCreate={() => {}}
-      onUpdate={() => {}}
-      onDelete={() => {}}
-      isCreateDisabled
-      isUpdateDisabled
-      isDeleteDisabled
-    />
+    <>
+      <CrudDropdown
+        options={options}
+        value={value ?? ""}
+        isLoading={loading}
+        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+          onChange(e.target.value || null)
+        }
+        onCreate={() => setIsCreateOpen(true)}
+        onUpdate={() => setIsUpdateOpen(true)}
+        onDelete={() => setIsDeleteOpen(true)}
+        isUpdateDisabled={!value}
+        isDeleteDisabled={!value}
+      />
+
+      <BaseModal
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        title="Create Key Stage"
+      >
+        <CreateKeyStageForm
+          onSuccess={() => {
+            setIsCreateOpen(false);
+            refetch();
+          }}
+        />
+      </BaseModal>
+
+      <BaseModal
+        isOpen={isUpdateOpen}
+        onClose={() => setIsUpdateOpen(false)}
+        title="Update Key Stage"
+      >
+        <UpdateKeyStageForm
+          keyStageId={value ?? ""}
+          initialName={selected?.name ?? ""}
+          initialDescription={selected?.description ?? ""}
+          onSuccess={() => {
+            setIsUpdateOpen(false);
+            refetch();
+          }}
+        />
+      </BaseModal>
+
+      <ConfirmationModal
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+        action="delete key stage"
+        bodyText="Are you sure you want to delete this key stage?"
+        onConfirm={() => {
+          if (value) {
+            deleteKeyStage({ variables: { data: { id: Number(value) } } });
+          }
+        }}
+        isLoading={deleting}
+      />
+    </>
   );
 }

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/KeyStageDropdown/forms/CreateKeyStageForm.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/KeyStageDropdown/forms/CreateKeyStageForm.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import React from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Spinner,
+  Stack,
+} from "@chakra-ui/react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { useMutation } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+
+const CREATE_KEY_STAGE = typedGql("mutation")({
+  createKeyStage: [{ data: $("data", "CreateKeyStageInput!") }, { id: true }],
+} as const);
+
+type FormValues = { name: string; description?: string };
+
+interface CreateKeyStageFormProps {
+  onSuccess: () => void;
+}
+
+export default function CreateKeyStageForm({ onSuccess }: CreateKeyStageFormProps) {
+  const { register, handleSubmit, formState: { errors, isSubmitting } } = useForm<FormValues>({
+    defaultValues: { name: "", description: "" },
+    mode: "onChange",
+  });
+
+  const [createKeyStage, { loading }] = useMutation(CREATE_KEY_STAGE, {
+    onCompleted: onSuccess,
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    await createKeyStage({
+      variables: {
+        data: { name: values.name.trim(), description: values.description?.trim() || null },
+      },
+    });
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4}>
+      <Stack spacing={6}>
+        <FormControl isInvalid={!!errors.name}>
+          <FormLabel>Name</FormLabel>
+          <Input placeholder="Key Stage name" {...register("name", { required: "Name is required" })} />
+          <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Description</FormLabel>
+          <Input placeholder="Description" {...register("description")} />
+        </FormControl>
+        <Button type="submit" colorScheme="blue" isDisabled={isSubmitting || loading}" leftIcon={(isSubmitting || loading) ? <Spinner size="sm" /> : undefined}>
+          Create Key Stage
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/KeyStageDropdown/forms/UpdateKeyStageForm.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/KeyStageDropdown/forms/UpdateKeyStageForm.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import React from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Spinner,
+  Stack,
+} from "@chakra-ui/react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { useMutation } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+
+const UPDATE_KEY_STAGE = typedGql("mutation")({
+  updateKeyStage: [{ data: $("data", "UpdateKeyStageInput!") }, { id: true }],
+} as const);
+
+type FormValues = { name: string; description?: string };
+
+interface UpdateKeyStageFormProps {
+  keyStageId: string;
+  initialName: string;
+  initialDescription?: string | null;
+  onSuccess: () => void;
+}
+
+export default function UpdateKeyStageForm({
+  keyStageId,
+  initialName,
+  initialDescription,
+  onSuccess,
+}: UpdateKeyStageFormProps) {
+  const { register, handleSubmit, formState: { errors, isSubmitting }, reset } = useForm<FormValues>({
+    defaultValues: { name: initialName, description: initialDescription ?? "" },
+    mode: "onChange",
+  });
+
+  const [updateKeyStage, { loading }] = useMutation(UPDATE_KEY_STAGE, {
+    onCompleted: onSuccess,
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    await updateKeyStage({
+      variables: {
+        data: {
+          id: keyStageId,
+          name: values.name.trim(),
+          description: values.description?.trim() || null,
+        },
+      },
+    });
+    reset(values);
+  };
+
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4}>
+      <Stack spacing={6}>
+        <FormControl isInvalid={!!errors.name}>
+          <FormLabel>Name</FormLabel>
+          <Input placeholder="Key Stage name" {...register("name", { required: "Name is required" })} />
+          <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Description</FormLabel>
+          <Input placeholder="Description" {...register("description")} />
+        </FormControl>
+        <Button type="submit" colorScheme="blue" isDisabled={isSubmitting || loading}" leftIcon={(isSubmitting || loading) ? <Spinner size="sm" /> : undefined}>
+          Update Key Stage
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
+

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/SubjectsDropdown/forms/UpdateSubjectForm.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/SubjectsDropdown/forms/UpdateSubjectForm.tsx
@@ -1,189 +1,87 @@
-// // UpdateSubjectForm.tsx
-// "use client";
+"use client";
 
-// import React, { useEffect } from "react";
-// import {
-//   Box,
-//   Button,
-//   Checkbox,
-//   CheckboxGroup,
-//   FormControl,
-//   FormLabel,
-//   Input,
-//   SimpleGrid,
-//   Spinner,
-//   Stack,
-//   FormErrorMessage,
-// } from "@chakra-ui/react";
-// import { Controller, useForm, SubmitHandler } from "react-hook-form";
+import React, { useEffect } from "react";
+import {
+  Box,
+  Button,
+  FormControl,
+  FormErrorMessage,
+  FormLabel,
+  Input,
+  Spinner,
+  Stack,
+} from "@chakra-ui/react";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { useQuery, useMutation } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
 
-// import { useQuery, useMutation } from "@apollo/client";
-// import { typedGql } from "@/zeus/typedDocumentNode";
-// import { $ } from "@/zeus";
-// import { UpdateSubjectInput } from "@/__generated__/schema-types";
+const GET_SUBJECT = typedGql("query")({
+  getSubject: [
+    { data: $("data", "IdInput!") },
+    { id: true, name: true },
+  ],
+} as const);
 
-// /* -------------------------------------------------------------------------- */
-// /* GraphQL documents                                                          */
-// /* -------------------------------------------------------------------------- */
+const UPDATE_SUBJECT = typedGql("mutation")({
+  updateSubject: [{ data: $("data", "UpdateSubjectInput!") }, { id: true }],
+} as const);
 
-// const GET_SUBJECT = typedGql("query")({
-//   getSubject: [
-//     { data: $("data", "IdInput!") }, // { id, relations }
-//     {
-//       id: true,
-//       name: true,
-//       yearGroups: { id: true, year: true },
-//     },
-//   ],
-// } as const);
+type FormValues = { name: string };
 
-// const GET_ALL_YEAR_GROUPS = typedGql("query")({
-//   getAllYearGroup: [
-//     { data: $("data", "IdRequestDto!") }, // { all: true }
-//     { id: true, year: true },
-//   ],
-// } as const);
+interface UpdateSubjectFormProps {
+  subjectId: string;
+  onSuccess: () => void;
+}
 
-// const UPDATE_SUBJECT = typedGql("mutation")({
-//   updateSubject: [{ data: $("data", "UpdateSubjectInput!") }, { id: true }],
-// } as const);
+export default function UpdateSubjectForm({ subjectId, onSuccess }: UpdateSubjectFormProps) {
+  const { data, loading: loadingSubject } = useQuery(GET_SUBJECT, {
+    variables: { data: { id: Number(subjectId) } },
+  });
 
-// /* -------------------------------------------------------------------------- */
-// /* Component                                                                  */
-// /* -------------------------------------------------------------------------- */
+  const { register, handleSubmit, formState: { errors, isSubmitting }, reset } = useForm<FormValues>({
+    defaultValues: { name: "" },
+  });
 
-// type FormValues = { name: string; yearGroupIds: string[] };
+  useEffect(() => {
+    if (data?.getSubject) {
+      reset({ name: data.getSubject.name ?? "" });
+    }
+  }, [data, reset]);
 
-// interface UpdateSubjectFormProps {
-//   subjectId: string; // GraphQL ID (string)
-//   onSuccess: () => void; // callback after successful update
-// }
+  const [updateSubject, { loading }] = useMutation(UPDATE_SUBJECT, {
+    onCompleted: onSuccess,
+  });
 
-// export default function UpdateSubjectForm({
-//   subjectId,
-//   onSuccess,
-// }: UpdateSubjectFormProps) {
-//   /* --------------------------- Queries --------------------------- */
-//   const { data: subjectData, loading: loadingSubject } = useQuery(GET_SUBJECT, {
-//     variables: {
-//       data: { id: Number(subjectId), relations: ["yearGroups"] },
-//     },
-//   });
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    await updateSubject({
+      variables: { data: { id: Number(subjectId), name: values.name.trim() } },
+    });
+  };
 
-//   const { data: yearGroupsData, loading: loadingYGs } = useQuery(
-//     GET_ALL_YEAR_GROUPS,
-//     {
-//       variables: { data: { id: Number(subjectId) } },
-//     }
-//   );
+  const isLoading = loadingSubject || loading;
 
-//   const subject = subjectData?.getSubject;
-//   const yearGroups = yearGroupsData?.getAllYearGroup ?? [];
+  return (
+    <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4}>
+      <Stack spacing={6}>
+        <FormControl isInvalid={!!errors.name}>
+          <FormLabel>Subject name</FormLabel>
+          <Input
+            placeholder="Subject name"
+            {...register("name", { required: "Name is required" })}
+          />
+          <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
+        </FormControl>
+        <Button
+          type="submit"
+          colorScheme="blue"
+          isDisabled={isSubmitting || isLoading}
+          leftIcon={isSubmitting || isLoading ? <Spinner size="sm" /> : undefined}
+        >
+          Update Subject
+        </Button>
+      </Stack>
+    </Box>
+  );
+}
 
-//   /* --------------------------- Form ------------------------------ */
-//   const {
-//     register,
-//     handleSubmit,
-//     control,
-//     reset,
-//     setError,
-//     formState: { errors, isSubmitting },
-//   } = useForm<FormValues>({
-//     defaultValues: { name: "", yearGroupIds: [] },
-//   });
-
-//   /* Populate form once subject data arrives */
-//   useEffect(() => {
-//     if (subject) {
-//       reset({
-//         name: subject.name ?? "",
-//         yearGroupIds: subject.yearGroups?.map((yg) => String(yg.id)) ?? [],
-//       });
-//     }
-//   }, [subject, reset]);
-
-//   /* ------------------------ Mutation ----------------------------- */
-//   const [updateSubject, { loading: mutating }] = useMutation(UPDATE_SUBJECT);
-
-//   const onSubmit: SubmitHandler<FormValues> = async (values) => {
-//     try {
-//       await updateSubject({
-//         variables: {
-//           data: {
-//             id: subjectId,
-//             name: values.name.trim(),
-//             relationIds: [
-//               { relation: "yearGroups", ids: values.yearGroupIds.map(Number) },
-//             ],
-//           } as UpdateSubjectInput,
-//         },
-//       });
-//       onSuccess();
-//     } catch (e) {
-//       setError("root", { message: (e as Error).message });
-//     }
-//   };
-
-//   const isLoading = loadingSubject || loadingYGs || mutating;
-
-//   /* ------------------------ Render ------------------------------- */
-//   if (loadingSubject) {
-//     return (
-//       <Box p={4}>
-//         <Spinner size="lg" />
-//       </Box>
-//     );
-//   }
-
-//   return (
-//     <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4}>
-//       <Stack spacing={6}>
-//         {/* Name ------------------------------------------------------ */}
-//         <FormControl isRequired isInvalid={!!errors.name}>
-//           <FormLabel>Subject name</FormLabel>
-//           <Input
-//             placeholder="e.g. Maths"
-//             {...register("name", { required: "Name is required" })}
-//           />
-//           <FormErrorMessage>{errors.name?.message}</FormErrorMessage>
-//         </FormControl>
-
-//         {/* Year-groups ---------------------------------------------- */}
-//         <FormControl isRequired isInvalid={!!errors.yearGroupIds}>
-//           <FormLabel>Year groups that offer this subject</FormLabel>
-//           <Controller
-//             control={control}
-//             name="yearGroupIds"
-//             rules={{
-//               validate: (v) => v.length > 0 || "Select at least one year group",
-//             }}
-//             render={({ field }) => (
-//               <CheckboxGroup {...field}>
-//                 <SimpleGrid columns={{ base: 2, md: 3 }} spacing={2}>
-//                   {yearGroups.map((yg) => (
-//                     <Checkbox key={String(yg.id)} value={String(yg.id)}>
-//                       {yg.year}
-//                     </Checkbox>
-//                   ))}
-//                 </SimpleGrid>
-//               </CheckboxGroup>
-//             )}
-//           />
-//           <FormErrorMessage>
-//             {(errors.yearGroupIds as any)?.message}
-//           </FormErrorMessage>
-//         </FormControl>
-
-//         {/* Submit ---------------------------------------------------- */}
-//         <Button
-//           type="submit"
-//           colorScheme="blue"
-//           isDisabled={isLoading}
-//           leftIcon={isLoading ? <Spinner size="sm" /> : undefined}
-//         >
-//           Update subject
-//         </Button>
-//       </Stack>
-//     </Box>
-//   );
-// }

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/YearGroup/YearDropdown.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/YearGroup/YearDropdown.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import React, { ChangeEvent, useMemo } from "react";
+import React, { ChangeEvent, useMemo, useState } from "react";
 import CrudDropdown from "../CrudDropdown";
 
-import { useQuery } from "@apollo/client";
+import { useQuery, useMutation, gql } from "@apollo/client";
 import { typedGql } from "@/zeus/typedDocumentNode";
 import { $ } from "@/zeus";
+import { BaseModal } from "@/components/modals/BaseModal";
+import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
+import { CreateYearGroupForm } from "./forms/CreateYearGroupForm";
+import { UpdateYearGroupForm } from "./forms/UpdateYearGroupForm";
 
 /* -------------------------------------------------------------------------- */
 /* GraphQL document                                                           */
@@ -19,6 +23,20 @@ const GET_YEAR_GROUPS_FOR_KEY_STAGE = typedGql("query")({
     },
   ],
 } as const);
+
+const CREATE_YEAR_GROUP = typedGql("mutation")({
+  createYearGroup: [{ data: $("data", "CreateYearGroupInput!") }, { id: true }],
+} as const);
+
+const UPDATE_YEAR_GROUP = typedGql("mutation")({
+  updateYearGroup: [{ data: $("data", "UpdateYearGroupInput!") }, { id: true }],
+} as const);
+
+const DELETE_YEAR_GROUP = gql`
+  mutation DeleteYearGroup($data: IdInput!) {
+    deleteYearGroup(data: $data)
+  }
+`;
 
 /* -------------------------------------------------------------------------- */
 /* Component                                                                  */
@@ -34,8 +52,12 @@ export function YearDropdown({
   value,
   onChange,
 }: YearDropdownProps) {
+  const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isUpdateOpen, setIsUpdateOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
   /* -------- fetch -------- */
-  const { data, loading } = useQuery(GET_YEAR_GROUPS_FOR_KEY_STAGE, {
+  const { data, loading, refetch } = useQuery(GET_YEAR_GROUPS_FOR_KEY_STAGE, {
     skip: keyStageId === null,
     variables:
       keyStageId !== null
@@ -56,22 +78,93 @@ export function YearDropdown({
     [yearGroups]
   );
 
+  const selected = yearGroups.find((yg) => String(yg.id) === value);
+
+  const [createYearGroup] = useMutation(CREATE_YEAR_GROUP, {
+    onCompleted: () => {
+      setIsCreateOpen(false);
+      refetch();
+    },
+  });
+
+  const [updateYearGroup] = useMutation(UPDATE_YEAR_GROUP, {
+    onCompleted: () => {
+      setIsUpdateOpen(false);
+      refetch();
+    },
+  });
+
+  const [deleteYearGroup, { loading: deleting }] = useMutation(DELETE_YEAR_GROUP, {
+    onCompleted: () => {
+      setIsDeleteOpen(false);
+      onChange(null);
+      refetch();
+    },
+  });
+
   /* -------- render -------- */
   return (
-    <CrudDropdown
-      options={options}
-      value={value ?? ""}
-      isLoading={loading}
-      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
-        onChange(e.target.value || null)
-      }
-      onCreate={() => {}}
-      onUpdate={() => {}}
-      onDelete={() => {}}
-      isCreateDisabled
-      isUpdateDisabled
-      isDeleteDisabled
-      isDisabled={keyStageId === null}
-    />
+    <>
+      <CrudDropdown
+        options={options}
+        value={value ?? ""}
+        isLoading={loading}
+        onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+          onChange(e.target.value || null)
+        }
+        onCreate={() => setIsCreateOpen(true)}
+        onUpdate={() => setIsUpdateOpen(true)}
+        onDelete={() => setIsDeleteOpen(true)}
+        isCreateDisabled={keyStageId === null}
+        isUpdateDisabled={!value}
+        isDeleteDisabled={!value}
+        isDisabled={keyStageId === null}
+      />
+
+      <BaseModal
+        isOpen={isCreateOpen}
+        onClose={() => setIsCreateOpen(false)}
+        title="Create Year Group"
+      >
+        <CreateYearGroupForm
+          onSubmit={async (data) => {
+            await createYearGroup({
+              variables: {
+                data: {
+                  ...data,
+                  keyStageId: keyStageId ? Number(keyStageId) : undefined,
+                },
+              },
+            });
+          }}
+        />
+      </BaseModal>
+
+      <BaseModal
+        isOpen={isUpdateOpen}
+        onClose={() => setIsUpdateOpen(false)}
+        title="Update Year Group"
+      >
+        <UpdateYearGroupForm
+          initialData={{ id: Number(value), year: selected?.year }}
+          onSubmit={async (data) => {
+            await updateYearGroup({ variables: { data } });
+          }}
+        />
+      </BaseModal>
+
+      <ConfirmationModal
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+        action="delete year group"
+        bodyText="Are you sure you want to delete this year group?"
+        onConfirm={() => {
+          if (value) {
+            deleteYearGroup({ variables: { data: { id: Number(value) } } });
+          }
+        }}
+        isLoading={deleting}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add create/update forms for key stages
- enable create/update/delete in KeyStageDropdown
- enable full CRUD in YearDropdown, SubjectDropdown, and ClassDropdown
- add minimal subject update form

## Testing
- `npm --version`
- `npm run lint` *(fails: next not found)*