### PR TITLE
Add basic slide builder with drag and drop

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -1,0 +1,7 @@
+"use client";
+
+import LessonEditor from "@/components/lesson/LessonEditor";
+
+export const LessonBuilderPageClient = () => {
+  return <LessonEditor />;
+};

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/page.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/page.tsx
@@ -1,3 +1,5 @@
+import { LessonBuilderPageClient } from "./LessonBuilderPageClient";
+
 export default function LessonBuilderPage() {
-  return <div>Lesson Builder</div>;
+  return <LessonBuilderPageClient />;
 }

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { Flex, Box, Text, Stack } from "@chakra-ui/react";
+import { useState, useCallback } from "react";
+import SlideSequencer, { Slide } from "./SlideSequencer";
+
+interface LessonState {
+  slides: Slide[];
+}
+
+const AVAILABLE_ELEMENTS = [
+  { type: "text", label: "Text" },
+  { type: "image", label: "Image" },
+];
+
+export default function LessonEditor() {
+  const [lesson, setLesson] = useState<LessonState>({
+    slides: [{ id: "1", title: "Slide 1", elements: [] }],
+  });
+  const [selectedSlideId, setSelectedSlideId] = useState<string | null>("1");
+
+  const setSlides = useCallback(
+    (updater: React.SetStateAction<Slide[]>) => {
+      setLesson((prev) => ({
+        ...prev,
+        slides:
+          typeof updater === "function"
+            ? (updater as (prev: Slide[]) => Slide[])(prev.slides)
+            : updater,
+      }));
+    },
+    []
+  );
+
+  const handleDropElement = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const type = e.dataTransfer.getData("text/plain");
+    if (!selectedSlideId) return;
+    setLesson((prev) => {
+      const slides = prev.slides.map((s) => {
+        if (s.id !== selectedSlideId) return s;
+        const newEl = { id: Date.now().toString(), type };
+        return { ...s, elements: [...s.elements, newEl] };
+      });
+      return { ...prev, slides };
+    });
+  };
+
+  return (
+    <Flex gap={6} alignItems="flex-start">
+      <SlideSequencer
+        slides={lesson.slides}
+        setSlides={setSlides as any}
+        selectedSlideId={selectedSlideId}
+        onSelect={setSelectedSlideId}
+      />
+      {selectedSlideId && (
+        <Flex gap={4} flex={1}>
+          <Box
+            flex="1"
+            p={4}
+            borderWidth="1px"
+            borderRadius="md"
+            onDragOver={(e) => e.preventDefault()}
+            onDrop={handleDropElement}
+          >
+            <Text mb={2}>Slide Elements</Text>
+            {lesson.slides
+              .find((s) => s.id === selectedSlideId)
+              ?.elements.map((el) => (
+                <Box key={el.id} p={2} mb={2} borderWidth="1px" borderRadius="md">
+                  {el.type}
+                </Box>
+              ))}
+          </Box>
+          <Box p={4} borderWidth="1px" borderRadius="md">
+            <Text mb={2}>Palette</Text>
+            <Stack>
+              {AVAILABLE_ELEMENTS.map((el) => (
+                <Box
+                  key={el.type}
+                  p={2}
+                  borderWidth="1px"
+                  borderRadius="md"
+                  draggable
+                  onDragStart={(e) => e.dataTransfer.setData("text/plain", el.type)}
+                >
+                  {el.label}
+                </Box>
+              ))}
+            </Stack>
+          </Box>
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -17,17 +17,20 @@ import {
 } from '@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge';
 import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index';
 
-interface Slide {
+export interface Slide {
   id: string;
   title: string;
+  elements: any[];
 }
 
 interface SlideItemProps {
   slide: Slide;
   instanceId: symbol;
+  onSelect: (id: string) => void;
+  isSelected: boolean;
 }
 
-function SlideItem({ slide, instanceId }: SlideItemProps) {
+function SlideItem({ slide, instanceId, onSelect, isSelected }: SlideItemProps) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
 
@@ -64,9 +67,10 @@ function SlideItem({ slide, instanceId }: SlideItemProps) {
       p={3}
       borderWidth="1px"
       borderRadius="md"
-      bg="white"
+      bg={isSelected ? "teal.100" : "white"}
       position="relative"
       cursor="grab"
+      onClick={() => onSelect(slide.id)}
     >
       {slide.title}
       {closestEdge && <DropIndicator edge={closestEdge} gap="4px" />}
@@ -74,19 +78,28 @@ function SlideItem({ slide, instanceId }: SlideItemProps) {
   );
 }
 
-export default function SlideSequencer() {
-  const [slides, setSlides] = useState<Slide[]>([
-    { id: '1', title: 'Slide 1' },
-  ]);
-  const counter = useRef(2);
+export interface SlideSequencerProps {
+  slides: Slide[];
+  setSlides: React.Dispatch<React.SetStateAction<Slide[]>>;
+  selectedSlideId: string | null;
+  onSelect: (id: string) => void;
+}
+
+export default function SlideSequencer({
+  slides,
+  setSlides,
+  selectedSlideId,
+  onSelect,
+}: SlideSequencerProps) {
+  const counter = useRef(slides.length + 1);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const instanceId = useRef(Symbol('slide-sequencer'));
 
   const addSlide = useCallback(() => {
     const id = String(Date.now()) + counter.current;
     counter.current += 1;
-    setSlides((s) => [...s, { id, title: `Slide ${s.length + 1}` }]);
-  }, []);
+    setSlides((s) => [...s, { id, title: `Slide ${s.length + 1}`, elements: [] }]);
+  }, [setSlides]);
 
   useEffect(() => {
     if (!containerRef.current) return;
@@ -145,7 +158,7 @@ export default function SlideSequencer() {
         }
       },
     });
-  }, [slides]);
+  }, [slides, setSlides]);
 
   return (
     <Stack spacing={4}>
@@ -158,6 +171,8 @@ export default function SlideSequencer() {
             key={slide.id}
             slide={slide}
             instanceId={instanceId.current}
+            onSelect={onSelect}
+            isSelected={selectedSlideId === slide.id}
           />
         ))}
       </Stack>


### PR DESCRIPTION
## Summary
- expand `SlideSequencer` to be controlled by parent components
- add `LessonEditor` component for editing slides
- integrate lesson editor into lesson builder page

## Testing
- `npm run lint` *(fails: `next` not found)*