### PR TITLE
Add lesson dropdown in coordination panel

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
@@ -1,5 +1,6 @@
 import { PartialType, InputType, Field, ID } from '@nestjs/graphql';
 import { GraphQLJSONObject } from 'graphql-type-json';
+import { PaginationInput } from 'src/common/utils/pagination.util';
 
 @InputType()
 export class CreateLessonInput {
@@ -36,4 +37,13 @@ export class CreateLessonInput {
 export class UpdateLessonInput extends PartialType(CreateLessonInput) {
   @Field(() => ID)
   id: number;
+}
+
+@InputType()
+export class LessonByTopicInput {
+  @Field(() => ID)
+  topicId!: string;
+
+  @Field(() => PaginationInput, { nullable: true })
+  pagination?: PaginationInput;
 }

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.ts
@@ -1,8 +1,13 @@
-import { Resolver } from '@nestjs/graphql';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { createBaseResolver } from 'src/common/base.resolver';
-import { CreateLessonInput, UpdateLessonInput } from './lesson.inputs';
+import {
+  CreateLessonInput,
+  UpdateLessonInput,
+  LessonByTopicInput,
+} from './lesson.inputs';
 import { LessonEntity } from './lesson.entity';
 import { LessonService } from './lesson.service';
+import { RbacPermissionKey } from 'src/modules/rbac/decorators/resolver-permission-key.decorator';
 
 const BaseLessonResolver = createBaseResolver<
   LessonEntity,
@@ -26,5 +31,13 @@ const BaseLessonResolver = createBaseResolver<
 export class LessonResolver extends BaseLessonResolver {
   constructor(private readonly lessonService: LessonService) {
     super(lessonService);
+  }
+
+  @RbacPermissionKey('lesson.findAllByTopic')
+  @Query(() => [LessonEntity])
+  async lessonsByTopic(
+    @Args('input') input: LessonByTopicInput,
+  ): Promise<LessonEntity[]> {
+    return this.lessonService.findByTopic(input);
   }
 }

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.service.ts
@@ -3,7 +3,11 @@ import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { BaseService } from 'src/common/base.service';
 import { LessonEntity } from './lesson.entity';
-import { CreateLessonInput, UpdateLessonInput } from './lesson.inputs';
+import {
+  CreateLessonInput,
+  UpdateLessonInput,
+  LessonByTopicInput,
+} from './lesson.inputs';
 
 @Injectable()
 export class LessonService extends BaseService<
@@ -17,5 +21,20 @@ export class LessonService extends BaseService<
     @InjectDataSource() dataSource: DataSource,
   ) {
     super(lessonRepository, dataSource);
+  }
+
+  async findByTopic(input: LessonByTopicInput): Promise<LessonEntity[]> {
+    const { topicId, pagination } = input;
+
+    const qb = this.repo
+      .createQueryBuilder('lesson')
+      .where('lesson.topicId = :topicId', { topicId });
+
+    if (pagination) {
+      if (pagination.limit !== undefined) qb.take(pagination.limit);
+      if (pagination.offset !== undefined) qb.skip(pagination.offset);
+    }
+
+    return qb.orderBy('lesson.title', 'ASC').getMany();
   }
 }

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/TopicPane.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/TopicPane.tsx
@@ -3,6 +3,7 @@
 import { Flex, Text } from "@chakra-ui/react";
 import { ContentCard } from "@/components/layout/Card";
 import { TopicDropdown } from "./dropdowns/TopicDropdown/TopicDropdown";
+import { LessonDropdown } from "./dropdowns/LessonDropdown/LessonDropdown";
 import { useState } from "react";
 
 interface TopicPaneProps {
@@ -12,6 +13,7 @@ interface TopicPaneProps {
 
 export default function TopicPane({ yearGroupId, subjectId }: TopicPaneProps) {
   const [topicId, setTopicId] = useState<string | null>(null);
+  const [lessonId, setLessonId] = useState<string | null>(null);
 
   return (
     <ContentCard gridColumn="1 / span 2">
@@ -21,7 +23,15 @@ export default function TopicPane({ yearGroupId, subjectId }: TopicPaneProps) {
           yearGroupId={yearGroupId}
           subjectId={subjectId}
           value={topicId}
-          onChange={setTopicId}
+          onChange={(id) => {
+            setTopicId(id);
+            setLessonId(null);
+          }}
+        />
+        <LessonDropdown
+          topicId={topicId}
+          value={lessonId}
+          onChange={setLessonId}
         />
       </Flex>
     </ContentCard>

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/LessonDropdown/LessonDropdown.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/LessonDropdown/LessonDropdown.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ChangeEvent, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+import CrudDropdown from "../CrudDropdown";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+
+const GET_LESSONS_BY_TOPIC = typedGql("query")({
+  lessonsByTopic: [
+    { input: $("input", "LessonByTopicInput!") },
+    { id: true, title: true },
+  ],
+} as const);
+
+interface LessonDropdownProps {
+  topicId: string | null;
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+export function LessonDropdown({ topicId, value, onChange }: LessonDropdownProps) {
+  const { data, loading } = useQuery(GET_LESSONS_BY_TOPIC, {
+    skip: !topicId,
+    variables: topicId ? { input: { topicId } } : undefined,
+  });
+
+  const lessons = topicId ? data?.lessonsByTopic ?? [] : [];
+
+  const options = useMemo(
+    () => lessons.map((l: any) => ({ label: l.title, value: String(l.id) })),
+    [lessons]
+  );
+
+  return (
+    <CrudDropdown
+      options={options}
+      value={value ?? ""}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+        onChange(e.target.value || null)
+      }
+      onCreate={() => {}}
+      onUpdate={() => {}}
+      onDelete={() => {}}
+      isCreateDisabled
+      isUpdateDisabled
+      isDeleteDisabled
+      isDisabled={!topicId}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `LessonByTopicInput` for backend
- implement `findByTopic` service and resolver query
- create `LessonDropdown` component
- incorporate lesson dropdown in coordination panel

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*
