### PR TITLE
Add lesson dropdown in coordination panel

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/TopicPane.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/TopicPane.tsx
@@ -3,6 +3,7 @@
 import { Flex, Text } from "@chakra-ui/react";
 import { ContentCard } from "@/components/layout/Card";
 import { TopicDropdown } from "./dropdowns/TopicDropdown/TopicDropdown";
+import { LessonDropdown } from "./dropdowns/LessonDropdown/LessonDropdown";
 import { useState } from "react";
 
 interface TopicPaneProps {
@@ -12,6 +13,7 @@ interface TopicPaneProps {
 
 export default function TopicPane({ yearGroupId, subjectId }: TopicPaneProps) {
   const [topicId, setTopicId] = useState<string | null>(null);
+  const [lessonId, setLessonId] = useState<string | null>(null);
 
   return (
     <ContentCard gridColumn="1 / span 2">
@@ -21,7 +23,17 @@ export default function TopicPane({ yearGroupId, subjectId }: TopicPaneProps) {
           yearGroupId={yearGroupId}
           subjectId={subjectId}
           value={topicId}
-          onChange={setTopicId}
+          onChange={(id) => {
+            setTopicId(id);
+            setLessonId(null);
+          }}
+        />
+
+        <Text>Lesson</Text>
+        <LessonDropdown
+          topicId={topicId}
+          value={lessonId}
+          onChange={setLessonId}
         />
       </Flex>
     </ContentCard>

--- a/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/LessonDropdown/LessonDropdown.tsx
+++ b/insight-fe/src/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/LessonDropdown/LessonDropdown.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import React, { ChangeEvent, useMemo } from "react";
+import CrudDropdown from "../CrudDropdown";
+
+import { useQuery } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+
+/* -------------------------------------------------------------------------- */
+/* GraphQL document                                                           */
+/* -------------------------------------------------------------------------- */
+const GET_LESSONS_FOR_TOPIC = typedGql("query")({
+  getTopic: [
+    { data: $("data", "IdInput!") },
+    {
+      id: true,
+      lessons: { id: true, title: true },
+    },
+  ],
+} as const);
+
+/* -------------------------------------------------------------------------- */
+/* Component                                                                  */
+/* -------------------------------------------------------------------------- */
+interface LessonDropdownProps {
+  topicId: string | null;
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+export function LessonDropdown({
+  topicId,
+  value,
+  onChange,
+}: LessonDropdownProps) {
+  /* -------- fetch -------- */
+  const { data, loading } = useQuery(GET_LESSONS_FOR_TOPIC, {
+    skip: topicId === null,
+    variables:
+      topicId !== null
+        ? { data: { id: Number(topicId), relations: ["lessons"] } }
+        : undefined,
+  });
+
+  const lessons = topicId !== null ? data?.getTopic?.lessons ?? [] : [];
+
+  /* -------- options -------- */
+  const options = useMemo(
+    () =>
+      lessons.map((les) => ({
+        label: les.title,
+        value: String(les.id),
+      })),
+    [lessons]
+  );
+
+  /* -------- render -------- */
+  return (
+    <CrudDropdown
+      options={options}
+      value={value ?? ""}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+        onChange(e.target.value || null)
+      }
+      onCreate={() => {}}
+      onUpdate={() => {}}
+      onDelete={() => {}}
+      isCreateDisabled
+      isUpdateDisabled
+      isDeleteDisabled
+      isDisabled={topicId === null}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- allow lesson selection based on chosen topic
- introduce `LessonDropdown` component and wire it into `TopicPane`

## Testing
- `npm test` *(fails: jest not found)*