### PR TITLE
Add drag-and-drop boards for lesson slides

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -67,6 +67,13 @@ interface DnDBoardMainProps<TCard extends BaseCardDnD> {
   orderedColumnIds: string[];
   CardComponent: React.ComponentType<{ item: TCard }>;
   enableColumnReorder?: boolean;
+  /**
+   * Optional callback fired whenever the board state changes
+   */
+  onChange?: (boardData: BoardState<TCard>) => void;
+  /**
+   * Optional callback rendered as a submit button
+   */
   onSubmit?: (boardData: any) => void;
   isLoading?: boolean;
 }
@@ -77,6 +84,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   orderedColumnIds,
   CardComponent,
   enableColumnReorder = true,
+  onChange,
   onSubmit,
   isLoading = false,
 }: DnDBoardMainProps<TCard>) => {
@@ -262,7 +270,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
           finishIndex,
         };
 
-        return {
+        const newData = {
           ...data,
           // Use Atlaskit's reorder utility to reorder the array
           orderedColumnIds: reorder({
@@ -274,7 +282,9 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
             outcome,
             trigger,
           },
-        };
+        } as BoardState<TCard>;
+        onChange?.(newData);
+        return newData;
       });
     },
     []
@@ -323,14 +333,16 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
           finishIndex,
         };
 
-        return {
+        const newData = {
           ...data,
           columnMap: updatedMap,
           lastOperation: {
             trigger,
             outcome,
           },
-        };
+        } as BoardState<TCard>;
+        onChange?.(newData);
+        return newData;
       });
     },
     []
@@ -389,14 +401,16 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
           itemIndexInFinishColumn: newIndexInDestination,
         };
 
-        return {
+        const newData = {
           ...data,
           columnMap: updatedMap,
           lastOperation: {
             outcome,
             trigger,
           },
-        };
+        } as BoardState<TCard>;
+        onChange?.(newData);
+        return newData;
       });
     },
     []

--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -1,0 +1,21 @@
+import { ContentCard } from "@/components/layout/Card";
+import { Text } from "@chakra-ui/react";
+
+export interface SlideElementDnDItemProps {
+  id: string;
+  type: string;
+}
+
+export const SlideElementDnDItem = ({
+  item,
+}: {
+  item: SlideElementDnDItemProps;
+}) => {
+  return (
+    <ContentCard id={item.id} key={item.id} cursor="grab">
+      <Text fontSize={14} fontWeight="bold">
+        {item.type}
+      </Text>
+    </ContentCard>
+  );
+};

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -3,6 +3,8 @@
 import { Flex, Box, Text, Stack } from "@chakra-ui/react";
 import { useState, useCallback } from "react";
 import SlideSequencer, { Slide } from "./SlideSequencer";
+import SlideElementsBoard from "./SlideElementsBoard";
+import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface LessonState {
   slides: Slide[];
@@ -39,8 +41,8 @@ export default function LessonEditor() {
     setLesson((prev) => {
       const slides = prev.slides.map((s) => {
         if (s.id !== selectedSlideId) return s;
-        const newEl = { id: Date.now().toString(), type };
-        return { ...s, elements: [...s.elements, newEl] };
+        const newEl: SlideElementDnDItemProps = { id: Date.now().toString(), type };
+        return { ...s, elements: [...(s.elements as SlideElementDnDItemProps[]), newEl] };
       });
       return { ...prev, slides };
     });
@@ -65,13 +67,17 @@ export default function LessonEditor() {
             onDrop={handleDropElement}
           >
             <Text mb={2}>Slide Elements</Text>
-            {lesson.slides
-              .find((s) => s.id === selectedSlideId)
-              ?.elements.map((el) => (
-                <Box key={el.id} p={2} mb={2} borderWidth="1px" borderRadius="md">
-                  {el.type}
-                </Box>
-              ))}
+            <SlideElementsBoard
+              elements={(lesson.slides.find((s) => s.id === selectedSlideId)?.elements || []) as SlideElementDnDItemProps[]}
+              onChange={(els) =>
+                setLesson((prev) => ({
+                  ...prev,
+                  slides: prev.slides.map((s) =>
+                    s.id === selectedSlideId ? { ...s, elements: els } : s
+                  ),
+                }))
+              }
+            />
           </Box>
           <Box p={4} borderWidth="1px" borderRadius="md">
             <Text mb={2}>Palette</Text>

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useMemo } from "react";
+import { DnDBoardMain, BoardState } from "@/components/DnD/DnDBoardMain";
+import { ColumnType } from "@/components/DnD/types";
+import {
+  SlideElementDnDItemProps,
+  SlideElementDnDItem,
+} from "@/components/DnD/cards/SlideElementDnDCard";
+
+interface SlideElementsBoardProps {
+  elements: SlideElementDnDItemProps[];
+  onChange: (elements: SlideElementDnDItemProps[]) => void;
+}
+
+export default function SlideElementsBoard({
+  elements,
+  onChange,
+}: SlideElementsBoardProps) {
+  const columnMap = useMemo<Record<string, ColumnType<SlideElementDnDItemProps>>>(
+    () => ({
+      elements: {
+        title: "Elements",
+        columnId: "elements",
+        styles: {
+          container: { border: "2px dashed gray", width: "100%" },
+          header: { bg: "gray.200" },
+        },
+        items: elements,
+      },
+    }),
+    [elements]
+  );
+
+  const orderedColumnIds = ["elements"];
+
+  const handleChange = (board: BoardState<SlideElementDnDItemProps>) => {
+    onChange(board.columnMap.elements.items as SlideElementDnDItemProps[]);
+  };
+
+  return (
+    <DnDBoardMain<SlideElementDnDItemProps>
+      columnMap={columnMap}
+      orderedColumnIds={orderedColumnIds}
+      CardComponent={SlideElementDnDItem}
+      enableColumnReorder={false}
+      onChange={handleChange}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- extend `DnDBoardMain` with an `onChange` callback
- add `SlideElementDnDCard` for rendering slide elements
- create `SlideElementsBoard` wrapper around `DnDBoardMain`
- integrate drag-and-drop board into `LessonEditor`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p insight-fe` *(fails: cannot find modules)*