### PR TITLE
Add dynamic column management to lesson builder

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -76,6 +76,7 @@ interface DnDBoardMainProps<TCard extends BaseCardDnD> {
    */
   onSubmit?: (boardData: any) => void;
   isLoading?: boolean;
+  onRemoveColumn?: (columnId: string) => void;
 }
 
 // access thej passed in interface
@@ -87,6 +88,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   onChange,
   onSubmit,
   isLoading = false,
+  onRemoveColumn,
 }: DnDBoardMainProps<TCard>) => {
   /**
    * Main piece of local state, storing:
@@ -607,6 +609,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
                 CardComponent={CardComponent}
                 enableColumnReorder={enableColumnReorder}
                 isLoading={isLoading}
+                onRemoveColumn={onRemoveColumn}
               />
             );
           })}

--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -8,7 +8,8 @@ import React, {
 } from "react";
 import { createPortal } from "react-dom";
 import invariant from "tiny-invariant";
-import { Box, Flex, Heading, HStack, Spinner, Stack } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, Spinner, Stack, IconButton } from "@chakra-ui/react";
+import { X } from "lucide-react";
 import { autoScrollForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
 import {
   attachClosestEdge,
@@ -91,6 +92,7 @@ interface ColumnProps<TCard extends BaseCardDnD> {
   /** Toggle whether the user can drag / reorder whole columns */
   enableColumnReorder?: boolean;
   isLoading?: boolean;
+  onRemoveColumn?: (columnId: string) => void;
 }
 
 function ColumnBase<TCard extends BaseCardDnD>({
@@ -98,6 +100,7 @@ function ColumnBase<TCard extends BaseCardDnD>({
   CardComponent,
   enableColumnReorder = true,
   isLoading = false,
+  onRemoveColumn,
 }: ColumnProps<TCard>) {
   const columnId = column.columnId;
   const columnRef = useRef<HTMLDivElement | null>(null);
@@ -308,6 +311,15 @@ function ColumnBase<TCard extends BaseCardDnD>({
               <Heading as="span" size="xs">
                 {column.title}
               </Heading>
+              {onRemoveColumn && (
+                <IconButton
+                  aria-label="Remove column"
+                  icon={<X size={12} />}
+                  size="xs"
+                  variant="ghost"
+                  onClick={() => onRemoveColumn(columnId)}
+                />
+              )}
             </HStack>
 
             <Box ref={scrollableRef} sx={scrollContainerStyles}>

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -1,50 +1,74 @@
 "use client";
 
-import { useMemo } from "react";
+import { Button, HStack } from "@chakra-ui/react";
 import { DnDBoardMain, BoardState } from "@/components/DnD/DnDBoardMain";
-import { ColumnType } from "@/components/DnD/types";
 import {
   SlideElementDnDItemProps,
   SlideElementDnDItem,
 } from "@/components/DnD/cards/SlideElementDnDCard";
+import { ColumnType } from "@/components/DnD/types";
 
 interface SlideElementsBoardProps {
-  elements: SlideElementDnDItemProps[];
-  onChange: (elements: SlideElementDnDItemProps[]) => void;
+  board: BoardState<SlideElementDnDItemProps>;
+  onChange: (board: BoardState<SlideElementDnDItemProps>) => void;
 }
 
-export default function SlideElementsBoard({
-  elements,
-  onChange,
-}: SlideElementsBoardProps) {
-  const columnMap = useMemo<Record<string, ColumnType<SlideElementDnDItemProps>>>(
-    () => ({
-      elements: {
-        title: "Elements",
-        columnId: "elements",
-        styles: {
-          container: { border: "2px dashed gray", width: "100%" },
-          header: { bg: "gray.200" },
-        },
-        items: elements,
+const COLUMN_COLORS = [
+  "red.300",
+  "green.300",
+  "blue.300",
+  "orange.300",
+  "purple.300",
+  "teal.300",
+];
+
+export default function SlideElementsBoard({ board, onChange }: SlideElementsBoardProps) {
+  const addColumn = () => {
+    const idx = board.orderedColumnIds.length;
+    const color = COLUMN_COLORS[idx % COLUMN_COLORS.length];
+    const id = `col-${Date.now()}`;
+    const newColumn: ColumnType<SlideElementDnDItemProps> = {
+      title: `Column ${idx + 1}`,
+      columnId: id,
+      styles: {
+        container: { border: `2px dashed ${color}`, width: "100%" },
+        header: { bg: color, color: "white" },
       },
-    }),
-    [elements]
-  );
+      items: [],
+    };
+    onChange({
+      ...board,
+      columnMap: { ...board.columnMap, [id]: newColumn },
+      orderedColumnIds: [...board.orderedColumnIds, id],
+    });
+  };
 
-  const orderedColumnIds = ["elements"];
-
-  const handleChange = (board: BoardState<SlideElementDnDItemProps>) => {
-    onChange(board.columnMap.elements.items as SlideElementDnDItemProps[]);
+  const removeColumn = (columnId: string) => {
+    if (board.orderedColumnIds.length <= 1) return;
+    const newMap = { ...board.columnMap };
+    delete newMap[columnId];
+    onChange({
+      ...board,
+      columnMap: newMap,
+      orderedColumnIds: board.orderedColumnIds.filter((id) => id !== columnId),
+    });
   };
 
   return (
-    <DnDBoardMain<SlideElementDnDItemProps>
-      columnMap={columnMap}
-      orderedColumnIds={orderedColumnIds}
-      CardComponent={SlideElementDnDItem}
-      enableColumnReorder={false}
-      onChange={handleChange}
-    />
+    <>
+      <HStack mb={2} justify="flex-end">
+        <Button size="sm" colorScheme="teal" onClick={addColumn}>
+          Add Column
+        </Button>
+      </HStack>
+      <DnDBoardMain<SlideElementDnDItemProps>
+        columnMap={board.columnMap}
+        orderedColumnIds={board.orderedColumnIds}
+        CardComponent={SlideElementDnDItem}
+        enableColumnReorder={false}
+        onChange={onChange}
+        onRemoveColumn={removeColumn}
+      />
+    </>
   );
 }

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -2,6 +2,10 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { Box, Button, Stack } from '@chakra-ui/react';
+import {
+  SlideElementDnDItemProps,
+} from '@/components/DnD/cards/SlideElementDnDCard';
+import { BoardState } from '@/components/DnD/DnDBoardMain';
 import { DropIndicator } from '@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box';
 import {
   draggable,
@@ -20,8 +24,24 @@ import { getReorderDestinationIndex } from '@atlaskit/pragmatic-drag-and-drop-hi
 export interface Slide {
   id: string;
   title: string;
-  elements: any[];
+  board: BoardState<SlideElementDnDItemProps>;
 }
+
+export const createInitialBoard = (): BoardState<SlideElementDnDItemProps> => ({
+  columnMap: {
+    column1: {
+      title: 'Column 1',
+      columnId: 'column1',
+      styles: {
+        container: { border: '2px dashed red', width: '100%' },
+        header: { bg: 'red.300', color: 'white' },
+      },
+      items: [],
+    },
+  },
+  orderedColumnIds: ['column1'],
+  lastOperation: null,
+});
 
 interface SlideItemProps {
   slide: Slide;
@@ -98,7 +118,10 @@ export default function SlideSequencer({
   const addSlide = useCallback(() => {
     const id = String(Date.now()) + counter.current;
     counter.current += 1;
-    setSlides((s) => [...s, { id, title: `Slide ${s.length + 1}`, elements: [] }]);
+    setSlides((s) => [
+      ...s,
+      { id, title: `Slide ${s.length + 1}`, board: createInitialBoard() },
+    ]);
   }, [setSlides]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- allow slides to store a DnD board state instead of a flat element list
- enable adding and removing columns within `SlideElementsBoard`
- support column removal in the generic DnD board components
- adjust lesson editor logic to work with the new board data structure

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*