### PR TITLE
Add attribute editing for lesson builder elements

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -1,18 +1,75 @@
 import { ContentCard } from "@/components/layout/Card";
-import { Text } from "@chakra-ui/react";
+import {
+  Text,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from "@chakra-ui/react";
 
 export interface SlideElementDnDItemProps {
   id: string;
   type: string;
+  styles?: {
+    color?: string;
+    fontSize?: string;
+  };
+}
+
+interface SlideElementDnDItemComponentProps {
+  item: SlideElementDnDItemProps;
+  onSelect?: () => void;
+  isSelected?: boolean;
 }
 
 export const SlideElementDnDItem = ({
   item,
-}: {
-  item: SlideElementDnDItemProps;
-}) => {
+  onSelect,
+  isSelected,
+}: SlideElementDnDItemComponentProps) => {
+  const baseProps = {
+    id: item.id,
+    cursor: "grab" as const,
+    borderWidth: isSelected ? "2px" : undefined,
+    borderColor: isSelected ? "blue.400" : undefined,
+    onClick: onSelect,
+  };
+
+  if (item.type === "text") {
+    return (
+      <ContentCard {...baseProps}>
+        <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
+          Sample Text
+        </Text>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "table") {
+    return (
+      <ContentCard {...baseProps}>
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Header 1</Th>
+              <Th>Header 2</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Cell</Td>
+              <Td>Cell</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </ContentCard>
+    );
+  }
+
   return (
-    <ContentCard id={item.id} key={item.id} cursor="grab">
+    <ContentCard {...baseProps}>
       <Text fontSize={14} fontWeight="bold">
         {item.type}
       </Text>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Box, Stack, Text, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
+import { useEffect, useState } from "react";
+
+interface ElementAttributesPaneProps {
+  element: SlideElementDnDItemProps;
+  onChange: (updated: SlideElementDnDItemProps) => void;
+}
+
+export default function ElementAttributesPane({ element, onChange }: ElementAttributesPaneProps) {
+  const [color, setColor] = useState(element.styles?.color || "#000000");
+  const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
+
+  useEffect(() => {
+    setColor(element.styles?.color || "#000000");
+    setFontSize(element.styles?.fontSize || "16px");
+  }, [element]);
+
+  useEffect(() => {
+    if (element.type === "text") {
+      onChange({
+        ...element,
+        styles: { ...element.styles, color, fontSize },
+      });
+    }
+  }, [color, fontSize]);
+
+  if (element.type !== "text") {
+    return (
+      <Box>
+        <Text>No editable attributes</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack>
+      <FormControl>
+        <FormLabel>Color</FormLabel>
+        <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+      </FormControl>
+      <FormControl>
+        <FormLabel>Font Size (px)</FormLabel>
+        <Input
+          type="number"
+          value={parseInt(fontSize)}
+          onChange={(e) => setFontSize(e.target.value + "px")}
+        />
+      </FormControl>
+    </Stack>
+  );
+}

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -4,6 +4,7 @@ import { Flex, Box, Text, Stack } from "@chakra-ui/react";
 import { useState, useCallback } from "react";
 import SlideSequencer, { Slide, createInitialBoard } from "./SlideSequencer";
 import SlideElementsBoard from "./SlideElementsBoard";
+import ElementAttributesPane from "./ElementAttributesPane";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface LessonState {
@@ -12,7 +13,7 @@ interface LessonState {
 
 const AVAILABLE_ELEMENTS = [
   { type: "text", label: "Text" },
-  { type: "image", label: "Image" },
+  { type: "table", label: "Table" },
 ];
 
 export default function LessonEditor() {
@@ -20,6 +21,7 @@ export default function LessonEditor() {
     slides: [{ id: "1", title: "Slide 1", board: createInitialBoard() }],
   });
   const [selectedSlideId, setSelectedSlideId] = useState<string | null>("1");
+  const [selectedElementId, setSelectedElementId] = useState<string | null>(null);
 
   const setSlides = useCallback(
     (updater: React.SetStateAction<Slide[]>) => {
@@ -34,6 +36,48 @@ export default function LessonEditor() {
     []
   );
 
+  const selectedSlide = lesson.slides.find((s) => s.id === selectedSlideId);
+
+  const getSelectedElement = (): SlideElementDnDItemProps | null => {
+    if (!selectedSlide || !selectedElementId) return null;
+    for (const colId of selectedSlide.board.orderedColumnIds) {
+      const col = selectedSlide.board.columnMap[colId];
+      const item = col.items.find((i) => i.id === selectedElementId);
+      if (item) return item;
+    }
+    return null;
+  };
+
+  const updateElement = (updated: SlideElementDnDItemProps) => {
+    if (!selectedSlideId) return;
+    setLesson((prev) => ({
+      ...prev,
+      slides: prev.slides.map((slide) => {
+        if (slide.id !== selectedSlideId) return slide;
+        const newMap = { ...slide.board.columnMap } as typeof slide.board.columnMap;
+        for (const colId of slide.board.orderedColumnIds) {
+          const col = newMap[colId];
+          const idx = col.items.findIndex((i) => i.id === updated.id);
+          if (idx !== -1) {
+            newMap[colId] = {
+              ...col,
+              items: [
+                ...col.items.slice(0, idx),
+                updated,
+                ...col.items.slice(idx + 1),
+              ],
+            };
+            break;
+          }
+        }
+        return {
+          ...slide,
+          board: { ...slide.board, columnMap: newMap },
+        };
+      }),
+    }));
+  };
+
   const handleDropElement = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const type = e.dataTransfer.getData("text/plain");
@@ -41,7 +85,11 @@ export default function LessonEditor() {
     setLesson((prev) => {
       const slides = prev.slides.map((s) => {
         if (s.id !== selectedSlideId) return s;
-        const newEl: SlideElementDnDItemProps = { id: Date.now().toString(), type };
+        const newEl: SlideElementDnDItemProps = {
+          id: Date.now().toString(),
+          type,
+          styles: type === "text" ? { color: "#000000", fontSize: "16px" } : {},
+        };
         const firstColumnId = s.board.orderedColumnIds[0];
         const column = s.board.columnMap[firstColumnId];
         const updatedColumn = {
@@ -91,6 +139,8 @@ export default function LessonEditor() {
                   ),
                 }))
               }
+              selectedElementId={selectedElementId}
+              onSelectElement={setSelectedElementId}
             />
           </Box>
           <Box p={4} borderWidth="1px" borderRadius="md">
@@ -109,6 +159,15 @@ export default function LessonEditor() {
                 </Box>
               ))}
             </Stack>
+          </Box>
+          <Box p={4} borderWidth="1px" borderRadius="md" minW="200px">
+            <Text mb={2}>Attributes</Text>
+            {getSelectedElement() && (
+              <ElementAttributesPane
+                element={getSelectedElement()!}
+                onChange={updateElement}
+              />
+            )}
           </Box>
         </Flex>
       )}

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -11,6 +11,8 @@ import { ColumnType } from "@/components/DnD/types";
 interface SlideElementsBoardProps {
   board: BoardState<SlideElementDnDItemProps>;
   onChange: (board: BoardState<SlideElementDnDItemProps>) => void;
+  selectedElementId?: string | null;
+  onSelectElement?: (id: string) => void;
 }
 
 const COLUMN_COLORS = [
@@ -22,7 +24,12 @@ const COLUMN_COLORS = [
   "teal.300",
 ];
 
-export default function SlideElementsBoard({ board, onChange }: SlideElementsBoardProps) {
+export default function SlideElementsBoard({
+  board,
+  onChange,
+  selectedElementId,
+  onSelectElement,
+}: SlideElementsBoardProps) {
   const addColumn = () => {
     const idx = board.orderedColumnIds.length;
     const color = COLUMN_COLORS[idx % COLUMN_COLORS.length];
@@ -54,6 +61,14 @@ export default function SlideElementsBoard({ board, onChange }: SlideElementsBoa
     });
   };
 
+  const CardWrapper = ({ item }: { item: SlideElementDnDItemProps }) => (
+    <SlideElementDnDItem
+      item={item}
+      onSelect={() => onSelectElement?.(item.id)}
+      isSelected={selectedElementId === item.id}
+    />
+  );
+
   return (
     <>
       <HStack mb={2} justify="flex-end">
@@ -64,7 +79,7 @@ export default function SlideElementsBoard({ board, onChange }: SlideElementsBoa
       <DnDBoardMain<SlideElementDnDItemProps>
         columnMap={board.columnMap}
         orderedColumnIds={board.orderedColumnIds}
-        CardComponent={SlideElementDnDItem}
+        CardComponent={CardWrapper}
         enableColumnReorder={false}
         onChange={onChange}
         onRemoveColumn={removeColumn}


### PR DESCRIPTION
## Summary
- support text/table elements in palette
- show attributes pane for selected element
- allow selecting elements on the board
- store style settings in board state

## Testing
- `npm run lint` *(fails: `next: not found`)*