### PR TITLE
Add UUIDs for DnD items and clean up logs

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -160,7 +160,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
       liveRegion.announce(
         `You've moved ${sourceColumn.title} from position ${
           startIndex + 1
-        } to position ${finishIndex + 1} of ${orderedColumnIds.length}.`
+        } to position ${finishIndex + 1} of ${orderedColumnIds.length}.`,
       );
 
       return;
@@ -188,7 +188,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
       liveRegion.announce(
         `You've moved ${item.id} from position ${startIndex + 1} to position ${
           finishIndex + 1
-        } of ${column.items.length} in the ${column.title} column.`
+        } of ${column.items.length} in the ${column.title} column.`,
       );
 
       return;
@@ -227,7 +227,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
           itemIndexInStartColumn + 1
         } to position ${finishPosition} in the ${
           destinationColumn.title
-        } column.`
+        } column.`,
       );
 
       return;
@@ -289,7 +289,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
         return newData;
       });
     },
-    []
+    [],
   );
 
   /**
@@ -347,7 +347,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
         return newData;
       });
     },
-    []
+    [],
   );
 
   /**
@@ -415,7 +415,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
         return newData;
       });
     },
-    []
+    [],
   );
 
   // Unique ID to ensure only our instance's draggables/droppables monitor each other.
@@ -436,9 +436,6 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
         onDrop(args) {
           const { location, source } = args;
 
-          console.log("location", location);
-          console.log("source", source);
-
           // If no drop targets, do nothing
           if (!location.current.dropTargets.length) {
             return;
@@ -447,15 +444,15 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
           // Determine whether a column or card was dropped
           if (source.data.type === "column") {
             const startIndex = data.orderedColumnIds.findIndex(
-              (columnId) => columnId === source.data.columnId
+              (columnId) => columnId === source.data.columnId,
             );
 
             const target = location.current.dropTargets[0];
             const indexOfTarget = data.orderedColumnIds.findIndex(
-              (id) => id === target.data.columnId
+              (id) => id === target.data.columnId,
             );
             const closestEdgeOfTarget: Edge | null = extractClosestEdge(
-              target.data
+              target.data,
             );
 
             const finishIndex = getReorderDestinationIndex({
@@ -479,7 +476,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
             invariant(typeof sourceId === "string");
             const sourceColumn = data.columnMap[sourceId];
             const itemIndex = sourceColumn.items.findIndex(
-              (item) => item.id === itemId
+              (item) => item.id === itemId,
             );
 
             // If there is only one drop target, it's a column drop
@@ -528,10 +525,10 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
 
               // Find the index of the card that was hovered
               const indexOfTarget = destinationColumn.items.findIndex(
-                (item) => item.id === destinationCardRecord.data.itemId
+                (item) => item.id === destinationCardRecord.data.itemId,
               );
               const closestEdgeOfTarget: Edge | null = extractClosestEdge(
-                destinationCardRecord.data
+                destinationCardRecord.data,
               );
 
               // Reorder in the same column
@@ -567,7 +564,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
             }
           }
         },
-      })
+      }),
     );
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [data, instanceId, moveCard, reorderCard, reorderColumn]);

--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -1,18 +1,75 @@
 import { ContentCard } from "@/components/layout/Card";
-import { Text } from "@chakra-ui/react";
+import {
+  Text,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from "@chakra-ui/react";
 
 export interface SlideElementDnDItemProps {
   id: string;
   type: string;
+  styles?: {
+    color?: string;
+    fontSize?: string;
+  };
+}
+
+interface SlideElementDnDItemComponentProps {
+  item: SlideElementDnDItemProps;
+  onSelect?: () => void;
+  isSelected?: boolean;
 }
 
 export const SlideElementDnDItem = ({
   item,
-}: {
-  item: SlideElementDnDItemProps;
-}) => {
+  onSelect,
+  isSelected,
+}: SlideElementDnDItemComponentProps) => {
+  const baseProps = {
+    id: item.id,
+    cursor: "grab" as const,
+    borderWidth: isSelected ? "2px" : undefined,
+    borderColor: isSelected ? "blue.400" : undefined,
+    onClick: onSelect,
+  };
+
+  if (item.type === "text") {
+    return (
+      <ContentCard {...baseProps}>
+        <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
+          Sample Text
+        </Text>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "table") {
+    return (
+      <ContentCard {...baseProps}>
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Header 1</Th>
+              <Th>Header 2</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Cell</Td>
+              <Td>Cell</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </ContentCard>
+    );
+  }
+
   return (
-    <ContentCard id={item.id} key={item.id} cursor="grab">
+    <ContentCard {...baseProps}>
       <Text fontSize={14} fontWeight="bold">
         {item.type}
       </Text>

--- a/insight-fe/src/components/DnD/registry.tsx
+++ b/insight-fe/src/components/DnD/registry.tsx
@@ -40,7 +40,7 @@ export function createRegistry() {
   }): CleanupFn {
     columns.set(columnId, entry);
     return function cleanup() {
-      cards.delete(columnId);
+      columns.delete(columnId);
     };
   }
 

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { Box, Stack, Text, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
+import { useEffect, useState } from "react";
+
+interface ElementAttributesPaneProps {
+  element: SlideElementDnDItemProps;
+  onChange: (updated: SlideElementDnDItemProps) => void;
+}
+
+export default function ElementAttributesPane({ element, onChange }: ElementAttributesPaneProps) {
+  const [color, setColor] = useState(element.styles?.color || "#000000");
+  const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
+
+  useEffect(() => {
+    setColor(element.styles?.color || "#000000");
+    setFontSize(element.styles?.fontSize || "16px");
+  }, [element]);
+
+  useEffect(() => {
+    if (element.type === "text") {
+      onChange({
+        ...element,
+        styles: { ...element.styles, color, fontSize },
+      });
+    }
+  }, [color, fontSize]);
+
+  if (element.type !== "text") {
+    return (
+      <Box>
+        <Text>No editable attributes</Text>
+      </Box>
+    );
+  }
+
+  return (
+    <Stack>
+      <FormControl>
+        <FormLabel>Color</FormLabel>
+        <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+      </FormControl>
+      <FormControl>
+        <FormLabel>Font Size (px)</FormLabel>
+        <Input
+          type="number"
+          value={parseInt(fontSize)}
+          onChange={(e) => setFontSize(e.target.value + "px")}
+        />
+      </FormControl>
+    </Stack>
+  );
+}

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -11,6 +11,8 @@ import { ColumnType } from "@/components/DnD/types";
 interface SlideElementsBoardProps {
   board: BoardState<SlideElementDnDItemProps>;
   onChange: (board: BoardState<SlideElementDnDItemProps>) => void;
+  selectedElementId?: string | null;
+  onSelectElement?: (id: string) => void;
 }
 
 const COLUMN_COLORS = [
@@ -22,11 +24,16 @@ const COLUMN_COLORS = [
   "teal.300",
 ];
 
-export default function SlideElementsBoard({ board, onChange }: SlideElementsBoardProps) {
+export default function SlideElementsBoard({
+  board,
+  onChange,
+  selectedElementId,
+  onSelectElement,
+}: SlideElementsBoardProps) {
   const addColumn = () => {
     const idx = board.orderedColumnIds.length;
     const color = COLUMN_COLORS[idx % COLUMN_COLORS.length];
-    const id = `col-${Date.now()}`;
+    const id = `col-${crypto.randomUUID()}`;
     const newColumn: ColumnType<SlideElementDnDItemProps> = {
       title: `Column ${idx + 1}`,
       columnId: id,
@@ -54,6 +61,14 @@ export default function SlideElementsBoard({ board, onChange }: SlideElementsBoa
     });
   };
 
+  const CardWrapper = ({ item }: { item: SlideElementDnDItemProps }) => (
+    <SlideElementDnDItem
+      item={item}
+      onSelect={() => onSelectElement?.(item.id)}
+      isSelected={selectedElementId === item.id}
+    />
+  );
+
   return (
     <>
       <HStack mb={2} justify="flex-end">
@@ -64,7 +79,7 @@ export default function SlideElementsBoard({ board, onChange }: SlideElementsBoa
       <DnDBoardMain<SlideElementDnDItemProps>
         columnMap={board.columnMap}
         orderedColumnIds={board.orderedColumnIds}
-        CardComponent={SlideElementDnDItem}
+        CardComponent={CardWrapper}
         enableColumnReorder={false}
         onChange={onChange}
         onRemoveColumn={removeColumn}


### PR DESCRIPTION
## Summary
- ensure column, slide and element IDs use `crypto.randomUUID`
- remove leftover console logging
- fix registry cleanup for columns

## Testing
- `npm run lint` *(fails: `next: not found`)*
- `npm test` *(fails: missing script)*