### PR TITLE
Fix palette drops to respect target column

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -85,6 +85,8 @@ export interface DnDBoardMainProps<TCard extends BaseCardDnD> {
   onSubmit?: (board: BoardState<TCard>) => void;
   isLoading?: boolean;
   onRemoveColumn?: (columnId: string) => void;
+  /** Optional indicator for external drops */
+  externalDropIndicator?: { columnId: string; index: number } | null;
   /**
    * When `true` this component is *controlled*:
    *  - It never stores its own copy of the board.
@@ -106,6 +108,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   onSubmit,
   isLoading = false,
   onRemoveColumn,
+  externalDropIndicator = null,
   controlled = false,
 }: DnDBoardMainProps<TCard>) => {
   /* -----------------------------------------------------------------------
@@ -584,6 +587,12 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
               enableColumnReorder={enableColumnReorder}
               isLoading={isLoading}
               onRemoveColumn={onRemoveColumn}
+              externalDropIndex={
+                externalDropIndicator &&
+                externalDropIndicator.columnId === columnId
+                  ? externalDropIndicator.index
+                  : null
+              }
             />
           ))}
         </Board>

--- a/insight-fe/src/components/DnD/card-primitive.tsx
+++ b/insight-fe/src/components/DnD/card-primitive.tsx
@@ -30,6 +30,7 @@ function InnerCardPrimitive<TCard extends BaseCardDnD>(
     <Grid
       ref={ref}
       data-testid={`item-${item.id}`}
+      data-card-id={item.id}
       templateColumns="1fr"
       position="relative"
       sx={mergedSx}

--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -93,6 +93,8 @@ interface ColumnProps<TCard extends BaseCardDnD> {
   enableColumnReorder?: boolean;
   isLoading?: boolean;
   onRemoveColumn?: (columnId: string) => void;
+  /** Optional index to display an external drop indicator */
+  externalDropIndex?: number | null;
 }
 
 function ColumnBase<TCard extends BaseCardDnD>({
@@ -101,6 +103,7 @@ function ColumnBase<TCard extends BaseCardDnD>({
   enableColumnReorder = true,
   isLoading = false,
   onRemoveColumn,
+  externalDropIndex = null,
 }: ColumnProps<TCard>) {
   const columnId = column.columnId;
   const columnRef = useRef<HTMLDivElement | null>(null);
@@ -292,6 +295,7 @@ function ColumnBase<TCard extends BaseCardDnD>({
         direction="column"
         sx={combinedStyles}
         data-testid={`column-${columnId}`}
+        data-column-id={columnId}
       >
         <Stack ref={columnInnerRef} flexGrow={1} minH={0}>
           <Stack
@@ -331,13 +335,17 @@ function ColumnBase<TCard extends BaseCardDnD>({
                   <LoadingSpinnerCard />
                 ) : (
                   /** Render sorted or raw items: */
-                  sortedItems.map((item: TCard) => (
-                    <Card
-                      key={item.id}
-                      item={item}
-                      CardComponent={CardComponent}
-                    />
+                  sortedItems.map((item: TCard, idx: number) => (
+                    <React.Fragment key={item.id}>
+                      {externalDropIndex === idx && (
+                        <DropIndicator edge="top" gap="0.5rem" />
+                      )}
+                      <Card item={item} CardComponent={CardComponent} />
+                    </React.Fragment>
                   ))
+                )}
+                {externalDropIndex === sortedItems.length && (
+                  <DropIndicator edge="bottom" gap="0.5rem" />
                 )}
               </Stack>
             </Box>

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -15,6 +15,7 @@ interface SlideElementsBoardProps {
   onChange: (board: BoardState<SlideElementDnDItemProps>) => void;
   selectedElementId?: string | null;
   onSelectElement?: (id: string) => void;
+  dropIndicator?: { columnId: string; index: number } | null;
 }
 
 const COLUMN_COLORS = [
@@ -31,6 +32,7 @@ export default function SlideElementsBoard({
   onChange,
   selectedElementId,
   onSelectElement,
+  dropIndicator,
 }: SlideElementsBoardProps) {
   /* ------------------------------------------------------------------ */
   /*  Column helpers                                                     */
@@ -110,6 +112,7 @@ export default function SlideElementsBoard({
           enableColumnReorder={false}
           onChange={onChange}
           onRemoveColumn={removeColumn}
+          externalDropIndicator={dropIndicator}
         />
       </ContentCard>
     </>


### PR DESCRIPTION
## Summary
- ensure new cards identify with `data-card-id`
- expose `data-column-id` for columns
- drop palette elements in the column and index they were dropped on
- show drop indicator when dragging in palette items

## Testing
- `npx tsc -p insight-fe/tsconfig.json --noEmit` *(fails: missing dependencies)*
- `npm run lint` in `insight-fe` *(fails: `next` not found)*