### PR TITLE
Implement row container element

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -5,7 +5,10 @@ import { useState, useCallback, useEffect } from "react";
 import SlideSequencer, { Slide, createInitialBoard } from "./SlideSequencer";
 import SlideElementsBoard from "./SlideElementsBoard";
 import ElementAttributesPane from "./ElementAttributesPane";
-import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
+import {
+  SlideElementDnDItemProps,
+  createRowContainerBoard,
+} from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface LessonState {
   slides: Slide[];
@@ -14,6 +17,7 @@ interface LessonState {
 const AVAILABLE_ELEMENTS = [
   { type: "text", label: "Text" },
   { type: "table", label: "Table" },
+  { type: "row", label: "Row Container" },
 ];
 
 export default function LessonEditor() {
@@ -101,6 +105,9 @@ export default function LessonEditor() {
           type,
           styles: type === "text" ? { color: "#000000", fontSize: "16px" } : {},
         };
+        if (type === "row") {
+          newEl.board = createRowContainerBoard();
+        }
         const firstColumnId = s.board.orderedColumnIds[0];
         const column = s.board.columnMap[firstColumnId];
         const updatedColumn = {

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -68,6 +68,25 @@ export default function SlideElementsBoard({
     });
   };
 
+  const updateItem = useCallback(
+    (updated: SlideElementDnDItemProps) => {
+      const newMap = { ...board.columnMap };
+      for (const colId of board.orderedColumnIds) {
+        const col = newMap[colId];
+        const idx = col.items.findIndex((i) => i.id === updated.id);
+        if (idx !== -1) {
+          newMap[colId] = {
+            ...col,
+            items: [...col.items.slice(0, idx), updated, ...col.items.slice(idx + 1)],
+          };
+          break;
+        }
+      }
+      onChange({ ...board, columnMap: newMap });
+    },
+    [board, onChange]
+  );
+
   /* ------------------------------------------------------------------ */
   /*  Card wrapper                                                       */
   /* ------------------------------------------------------------------ */
@@ -85,9 +104,10 @@ export default function SlideElementsBoard({
         item={item}
         onSelect={() => onSelectElement?.(item.id)}
         isSelected={selectedElementId === item.id}
+        onChange={updateItem}
       />
     ),
-    [selectedElementId, onSelectElement]
+    [selectedElementId, onSelectElement, updateItem]
   );
 
   /* ------------------------------------------------------------------ */


### PR DESCRIPTION
## Summary
- add helper to build row containers with 3 columns
- support nested row containers in drag-n-drop item card
- allow editing nested containers in the slide elements board
- handle dropping new row containers in lesson editor

## Testing
- `npm run lint` *(fails: next not found)*