### PR TITLE
Add more lesson builder components

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -7,6 +7,9 @@ import {
   Tr,
   Th,
   Td,
+  Image,
+  Box,
+  Code,
 } from "@chakra-ui/react";
 
 export interface SlideElementDnDItemProps {
@@ -64,6 +67,52 @@ export const SlideElementDnDItem = ({
             </Tr>
           </Tbody>
         </Table>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "image") {
+    return (
+      <ContentCard {...baseProps}>
+        <Image src="https://via.placeholder.com/150" alt="Sample image" />
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "video") {
+    return (
+      <ContentCard {...baseProps}>
+        <Box as="video" controls width="100%">
+          <source src="" />
+        </Box>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "audio") {
+    return (
+      <ContentCard {...baseProps}>
+        <Box as="audio" controls width="100%">
+          <source src="" />
+        </Box>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "code") {
+    return (
+      <ContentCard {...baseProps}>
+        <Code width="100%" whiteSpace="pre">
+          console.log("Hello world");
+        </Code>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "quiz") {
+    return (
+      <ContentCard {...baseProps}>
+        <Text>Quiz placeholder</Text>
       </ContentCard>
     );
   }

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -14,6 +14,11 @@ interface LessonState {
 const AVAILABLE_ELEMENTS = [
   { type: "text", label: "Text" },
   { type: "table", label: "Table" },
+  { type: "image", label: "Image" },
+  { type: "video", label: "Video" },
+  { type: "audio", label: "Audio" },
+  { type: "code", label: "Code Snippet" },
+  { type: "quiz", label: "Quiz" },
 ];
 
 export default function LessonEditor() {


### PR DESCRIPTION
## Summary
- add additional lesson elements (image, video, audio, code, quiz)
- show placeholders for new lesson elements

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run lint` in insight-be *(fails: cannot find @eslint/js)*