### PR TITLE
Add multi-board support per slide

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -87,6 +87,10 @@ export interface DnDBoardMainProps<TCard extends BaseCardDnD> {
   onRemoveColumn?: (columnId: string) => void;
   /** Optional indicator for external drops */
   externalDropIndicator?: { columnId: string; index: number } | null;
+  /** Optional shared instance id for cross-board drag */
+  instanceId?: symbol;
+  /** Optional shared registry for cross-board drag */
+  registry?: ReturnType<typeof createRegistry>;
   /**
    * When `true` this component is *controlled*:
    *  - It never stores its own copy of the board.
@@ -109,6 +113,8 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   isLoading = false,
   onRemoveColumn,
   externalDropIndicator = null,
+  instanceId: instanceIdProp,
+  registry: registryProp,
   controlled = false,
 }: DnDBoardMainProps<TCard>) => {
   /* -----------------------------------------------------------------------
@@ -179,7 +185,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   /* -----------------------------------------------------------------------
    * 5.  Create a registry for DOM references
    * --------------------------------------------------------------------- */
-  const [registry] = useState(createRegistry);
+  const registry = useRef(registryProp ?? createRegistry()).current;
 
   /* -----------------------------------------------------------------------
    * 6.  Mutator helpers (reorderColumn, reorderCard, moveCard)
@@ -333,7 +339,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   /* -----------------------------------------------------------------------
    * 7.  Unique instance ID for all draggables / droppables in this board
    * --------------------------------------------------------------------- */
-  const [instanceId] = useState(() => Symbol("instance-id"));
+  const instanceId = useRef(instanceIdProp ?? Symbol("instance-id")).current;
 
   /* -----------------------------------------------------------------------
    * 8.  Effect: monitor for elements & handle drop logic

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -6,6 +6,7 @@ import SlideElementsBoard from "./SlideElementsBoard";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap, ColumnType } from "@/components/DnD/types";
 import { createRegistry } from "@/components/DnD/registry";
+import { ContentCard } from "../layout/Card";
 
 export interface BoardRow {
   id: string;
@@ -17,7 +18,7 @@ interface SlideElementsContainerProps {
   boards: BoardRow[];
   onChange: (
     columnMap: ColumnMap<SlideElementDnDItemProps>,
-    boards: BoardRow[],
+    boards: BoardRow[]
   ) => void;
   selectedElementId?: string | null;
   onSelectElement?: (id: string) => void;
@@ -60,42 +61,49 @@ export default function SlideElementsContainer({
       items: [],
     };
 
-    onChange(
-      { ...columnMap, [columnId]: newColumn },
-      [...boards, { id: boardId, orderedColumnIds: [columnId] }],
-    );
+    onChange({ ...columnMap, [columnId]: newColumn }, [
+      ...boards,
+      { id: boardId, orderedColumnIds: [columnId] },
+    ]);
   };
 
   const updateBoard = (
     boardId: string,
     map: ColumnMap<SlideElementDnDItemProps>,
-    ids: string[],
+    ids: string[]
   ) => {
     onChange(
       map,
       boards.map((b) =>
-        b.id === boardId ? { ...b, orderedColumnIds: ids } : b,
-      ),
+        b.id === boardId ? { ...b, orderedColumnIds: ids } : b
+      )
     );
   };
 
   return (
     <Stack gap={4}>
-      <Button size="sm" colorScheme="teal" onClick={addBoard} alignSelf="flex-start">
+      <Button
+        size="sm"
+        colorScheme="teal"
+        onClick={addBoard}
+        alignSelf="flex-start"
+      >
         Add Container
       </Button>
       {boards.map((b) => (
-        <SlideElementsBoard
-          key={b.id}
-          columnMap={columnMap}
-          orderedColumnIds={b.orderedColumnIds}
-          onChange={(map, ids) => updateBoard(b.id, map, ids)}
-          registry={registry.current}
-          instanceId={instanceId.current}
-          selectedElementId={selectedElementId}
-          onSelectElement={onSelectElement}
-          dropIndicator={dropIndicator}
-        />
+        <ContentCard minHeight={400} key={b.id}>
+          <SlideElementsBoard
+            // key={b.id}
+            columnMap={columnMap}
+            orderedColumnIds={b.orderedColumnIds}
+            onChange={(map, ids) => updateBoard(b.id, map, ids)}
+            registry={registry.current}
+            instanceId={instanceId.current}
+            selectedElementId={selectedElementId}
+            onSelectElement={onSelectElement}
+            dropIndicator={dropIndicator}
+          />
+        </ContentCard>
       ))}
     </Stack>
   );

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { Button, Stack } from "@chakra-ui/react";
+import { useRef } from "react";
+import SlideElementsBoard from "./SlideElementsBoard";
+import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
+import { ColumnMap, ColumnType } from "@/components/DnD/types";
+import { createRegistry } from "@/components/DnD/registry";
+
+export interface BoardRow {
+  id: string;
+  orderedColumnIds: string[];
+}
+
+interface SlideElementsContainerProps {
+  columnMap: ColumnMap<SlideElementDnDItemProps>;
+  boards: BoardRow[];
+  onChange: (
+    columnMap: ColumnMap<SlideElementDnDItemProps>,
+    boards: BoardRow[],
+  ) => void;
+  selectedElementId?: string | null;
+  onSelectElement?: (id: string) => void;
+  dropIndicator?: { columnId: string; index: number } | null;
+}
+
+const COLUMN_COLORS = [
+  "red.300",
+  "green.300",
+  "blue.300",
+  "orange.300",
+  "purple.300",
+  "teal.300",
+];
+
+export default function SlideElementsContainer({
+  columnMap,
+  boards,
+  onChange,
+  selectedElementId,
+  onSelectElement,
+  dropIndicator,
+}: SlideElementsContainerProps) {
+  const instanceId = useRef(Symbol("slide-container"));
+  const registry = useRef(createRegistry());
+
+  const addBoard = () => {
+    const colIdx = Object.keys(columnMap).length;
+    const color = COLUMN_COLORS[colIdx % COLUMN_COLORS.length];
+    const columnId = `col-${crypto.randomUUID()}`;
+    const boardId = crypto.randomUUID();
+
+    const newColumn: ColumnType<SlideElementDnDItemProps> = {
+      title: `Column 1`,
+      columnId,
+      styles: {
+        container: { border: `2px dashed ${color}`, width: "100%" },
+        header: { bg: color, color: "white" },
+      },
+      items: [],
+    };
+
+    onChange(
+      { ...columnMap, [columnId]: newColumn },
+      [...boards, { id: boardId, orderedColumnIds: [columnId] }],
+    );
+  };
+
+  const updateBoard = (
+    boardId: string,
+    map: ColumnMap<SlideElementDnDItemProps>,
+    ids: string[],
+  ) => {
+    onChange(
+      map,
+      boards.map((b) =>
+        b.id === boardId ? { ...b, orderedColumnIds: ids } : b,
+      ),
+    );
+  };
+
+  return (
+    <Stack gap={4}>
+      <Button size="sm" colorScheme="teal" onClick={addBoard} alignSelf="flex-start">
+        Add Container
+      </Button>
+      {boards.map((b) => (
+        <SlideElementsBoard
+          key={b.id}
+          columnMap={columnMap}
+          orderedColumnIds={b.orderedColumnIds}
+          onChange={(map, ids) => updateBoard(b.id, map, ids)}
+          registry={registry.current}
+          instanceId={instanceId.current}
+          selectedElementId={selectedElementId}
+          onSelectElement={onSelectElement}
+          dropIndicator={dropIndicator}
+        />
+      ))}
+    </Stack>
+  );
+}

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -3,7 +3,7 @@
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Box, Button, Stack } from "@chakra-ui/react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
-import { BoardState } from "@/components/DnD/DnDBoardMain";
+import { ColumnMap } from "@/components/DnD/types";
 import { DropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box";
 import {
   draggable,
@@ -19,14 +19,24 @@ import {
 } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 import { getReorderDestinationIndex } from "@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index";
 
+export interface SlideBoard {
+  id: string;
+  orderedColumnIds: string[];
+}
+
 export interface Slide {
   id: string;
   title: string;
-  board: BoardState<SlideElementDnDItemProps>;
+  columnMap: ColumnMap<SlideElementDnDItemProps>;
+  boards: SlideBoard[];
 }
 
-export const createInitialBoard = (): BoardState<SlideElementDnDItemProps> => {
+export const createInitialBoard = (): {
+  columnMap: ColumnMap<SlideElementDnDItemProps>;
+  boards: SlideBoard[];
+} => {
   const columnId = `col-${crypto.randomUUID()}`;
+  const boardId = crypto.randomUUID();
   return {
     columnMap: {
       [columnId]: {
@@ -39,8 +49,7 @@ export const createInitialBoard = (): BoardState<SlideElementDnDItemProps> => {
         items: [],
       },
     },
-    orderedColumnIds: [columnId],
-    lastOperation: null,
+    boards: [{ id: boardId, orderedColumnIds: [columnId] }],
   };
 };
 
@@ -132,10 +141,18 @@ export default function SlideSequencer({
   const addSlide = useCallback(() => {
     const id = crypto.randomUUID();
     counter.current += 1;
-    setSlides((s) => [
-      ...s,
-      { id, title: `Slide ${s.length + 1}`, board: createInitialBoard() },
-    ]);
+    setSlides((s) => {
+      const initial = createInitialBoard();
+      return [
+        ...s,
+        {
+          id,
+          title: `Slide ${s.length + 1}`,
+          columnMap: initial.columnMap,
+          boards: initial.boards,
+        },
+      ];
+    });
   }, [setSlides]);
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- support sharing instanceId and registry in `DnDBoardMain`
- allow each slide to hold multiple boards via `SlideElementsContainer`
- adjust slide sequencer to create slides with multiple boards
- update lesson editor to use new container-based layout
- refactor slide elements board for external state

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find module 'react')*