### PR TITLE
Add more lesson builder components

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -7,6 +7,9 @@ import {
   Tr,
   Th,
   Td,
+  Image,
+  Box,
+  Code,
 } from "@chakra-ui/react";
 
 export interface SlideElementDnDItemProps {
@@ -15,6 +18,11 @@ export interface SlideElementDnDItemProps {
   styles?: {
     color?: string;
     fontSize?: string;
+  };
+  attributes?: {
+    src?: string;
+    code?: string;
+    question?: string;
   };
 }
 
@@ -64,6 +72,55 @@ export const SlideElementDnDItem = ({
             </Tr>
           </Tbody>
         </Table>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "image") {
+    return (
+      <ContentCard {...baseProps}>
+        <Image
+          src={item.attributes?.src || "https://via.placeholder.com/150"}
+          alt="Image"
+        />
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "video") {
+    return (
+      <ContentCard {...baseProps}>
+        <Box as="video" controls width="100%">
+          <source src={item.attributes?.src || ""} />
+        </Box>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "audio") {
+    return (
+      <ContentCard {...baseProps}>
+        <Box as="audio" controls width="100%">
+          <source src={item.attributes?.src || ""} />
+        </Box>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "code") {
+    return (
+      <ContentCard {...baseProps}>
+        <Code width="100%" whiteSpace="pre">
+          {item.attributes?.code || "console.log(\"Hello world\");"}
+        </Code>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "quiz") {
+    return (
+      <ContentCard {...baseProps}>
+        <Text>{item.attributes?.question || "Quiz question"}</Text>
       </ContentCard>
     );
   }

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Box, Stack, Text, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import {
+  Box,
+  Stack,
+  Text,
+  FormControl,
+  FormLabel,
+  Input,
+  Textarea,
+} from "@chakra-ui/react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { useEffect, useState } from "react";
 
@@ -12,10 +20,16 @@ interface ElementAttributesPaneProps {
 export default function ElementAttributesPane({ element, onChange }: ElementAttributesPaneProps) {
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
+  const [src, setSrc] = useState(element.attributes?.src || "");
+  const [code, setCode] = useState(element.attributes?.code || "");
+  const [question, setQuestion] = useState(element.attributes?.question || "");
 
   useEffect(() => {
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
+    setSrc(element.attributes?.src || "");
+    setCode(element.attributes?.code || "");
+    setQuestion(element.attributes?.question || "");
   }, [element]);
 
   useEffect(() => {
@@ -27,28 +41,89 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
     }
   }, [color, fontSize]);
 
-  if (element.type !== "text") {
+  useEffect(() => {
+    if (["image", "video", "audio"].includes(element.type)) {
+      onChange({
+        ...element,
+        attributes: { ...element.attributes, src },
+      });
+    }
+  }, [src]);
+
+  useEffect(() => {
+    if (element.type === "code") {
+      onChange({
+        ...element,
+        attributes: { ...element.attributes, code },
+      });
+    }
+  }, [code]);
+
+  useEffect(() => {
+    if (element.type === "quiz") {
+      onChange({
+        ...element,
+        attributes: { ...element.attributes, question },
+      });
+    }
+  }, [question]);
+
+  if (element.type === "text") {
     return (
-      <Box>
-        <Text>No editable attributes</Text>
-      </Box>
+      <Stack>
+        <FormControl>
+          <FormLabel>Color</FormLabel>
+          <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Font Size (px)</FormLabel>
+          <Input
+            type="number"
+            value={parseInt(fontSize)}
+            onChange={(e) => setFontSize(e.target.value + "px")}
+          />
+        </FormControl>
+      </Stack>
+    );
+  }
+
+  if (["image", "video", "audio"].includes(element.type)) {
+    return (
+      <Stack>
+        <FormControl>
+          <FormLabel>Source</FormLabel>
+          <Input value={src} onChange={(e) => setSrc(e.target.value)} placeholder="path or URL" />
+        </FormControl>
+      </Stack>
+    );
+  }
+
+  if (element.type === "code") {
+    return (
+      <Stack>
+        <FormControl>
+          <FormLabel>Code</FormLabel>
+          <Textarea value={code} onChange={(e) => setCode(e.target.value)} />
+        </FormControl>
+      </Stack>
+    );
+  }
+
+  if (element.type === "quiz") {
+    return (
+      <Stack>
+        <FormControl>
+          <FormLabel>Question</FormLabel>
+          <Input value={question} onChange={(e) => setQuestion(e.target.value)} />
+        </FormControl>
+      </Stack>
     );
   }
 
   return (
-    <Stack>
-      <FormControl>
-        <FormLabel>Color</FormLabel>
-        <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
-      </FormControl>
-      <FormControl>
-        <FormLabel>Font Size (px)</FormLabel>
-        <Input
-          type="number"
-          value={parseInt(fontSize)}
-          onChange={(e) => setFontSize(e.target.value + "px")}
-        />
-      </FormControl>
-    </Stack>
+    <Box>
+      <Text>No editable attributes</Text>
+    </Box>
   );
+
 }

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -14,6 +14,11 @@ interface LessonState {
 const AVAILABLE_ELEMENTS = [
   { type: "text", label: "Text" },
   { type: "table", label: "Table" },
+  { type: "image", label: "Image" },
+  { type: "video", label: "Video" },
+  { type: "audio", label: "Audio" },
+  { type: "code", label: "Code Snippet" },
+  { type: "quiz", label: "Quiz" },
 ];
 
 export default function LessonEditor() {
@@ -100,6 +105,14 @@ export default function LessonEditor() {
           id: crypto.randomUUID(),
           type,
           styles: type === "text" ? { color: "#000000", fontSize: "16px" } : {},
+          attributes:
+            type === "image" || type === "video" || type === "audio"
+              ? { src: "" }
+              : type === "code"
+              ? { code: "console.log(\"Hello world\");" }
+              : type === "quiz"
+              ? { question: "" }
+              : {},
         };
         const firstColumnId = s.board.orderedColumnIds[0];
         const column = s.board.columnMap[firstColumnId];


### PR DESCRIPTION
## Summary
- add attributes field for slide elements
- update slide element card placeholders to show attributes
- allow editing of source, code, and question text in attributes pane
- create default attributes when adding new elements

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run lint` in insight-be *(fails: cannot find @eslint/js)*