### PR TITLE
Add preview pane to lesson builder

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -5,6 +5,7 @@ import { useState, useCallback, useEffect } from "react";
 import SlideSequencer, { Slide, createInitialBoard } from "./SlideSequencer";
 import SlideElementsContainer from "./SlideElementsContainer";
 import ElementAttributesPane from "./ElementAttributesPane";
+import SlidePreview from "./SlidePreview";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface LessonState {
@@ -225,6 +226,17 @@ export default function LessonEditor() {
               selectedElementId={selectedElementId}
               onSelectElement={setSelectedElementId}
               dropIndicator={dropIndicator}
+            />
+          </Box>
+          <Box p={4} borderWidth="1px" borderRadius="md" minW="300px">
+            <Text mb={2}>Preview</Text>
+            <SlidePreview
+              columnMap={
+                lesson.slides.find((s) => s.id === selectedSlideId)!.columnMap
+              }
+              boards={
+                lesson.slides.find((s) => s.id === selectedSlideId)!.boards
+              }
             />
           </Box>
           <Box p={4} borderWidth="1px" borderRadius="md">

--- a/insight-fe/src/components/lesson/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/SlidePreview.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { Box, Flex, Stack } from "@chakra-ui/react";
+import { ColumnMap } from "@/components/DnD/types";
+import {
+  SlideElementDnDItemProps,
+  SlideElementDnDItem,
+} from "@/components/DnD/cards/SlideElementDnDCard";
+import { BoardRow } from "./SlideElementsContainer";
+
+interface SlidePreviewProps {
+  columnMap: ColumnMap<SlideElementDnDItemProps>;
+  boards: BoardRow[];
+}
+
+export default function SlidePreview({ columnMap, boards }: SlidePreviewProps) {
+  return (
+    <Stack gap={4}>
+      {boards.map((board) => (
+        <Flex key={board.id} gap={4} alignItems="flex-start">
+          {board.orderedColumnIds.map((colId) => {
+            const column = columnMap[colId];
+            if (!column) return null;
+            return (
+              <Stack
+                key={colId}
+                flex="1"
+                borderWidth="1px"
+                borderStyle="dashed"
+                borderColor="gray.300"
+                p={2}
+              >
+                {column.items.map((item) => (
+                  <Box key={item.id} mb={2}>
+                    <SlideElementDnDItem item={item} />
+                  </Box>
+                ))}
+              </Stack>
+            );
+          })}
+        </Flex>
+      ))}
+    </Stack>
+  );
+}


### PR DESCRIPTION
## Summary
- add `SlidePreview` component for rendering a read‑only slide
- display preview pane next to the drag‑and‑drop canvas in `LessonEditor`

## Testing
- `npm run lint` *(fails: `next` not found)*