### PR TITLE
Allow setting text in lesson builder

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -12,6 +12,10 @@ import {
 export interface SlideElementDnDItemProps {
   id: string;
   type: string;
+  /**
+   * Text content for text elements
+   */
+  text?: string;
   styles?: {
     color?: string;
     fontSize?: string;
@@ -41,7 +45,7 @@ export const SlideElementDnDItem = ({
     return (
       <ContentCard {...baseProps}>
         <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
-          Sample Text
+          {item.text || "Sample Text"}
         </Text>
       </ContentCard>
     );

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -12,20 +12,23 @@ interface ElementAttributesPaneProps {
 export default function ElementAttributesPane({ element, onChange }: ElementAttributesPaneProps) {
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
+  const [text, setText] = useState(element.text || "");
 
   useEffect(() => {
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
+    setText(element.text || "");
   }, [element]);
 
   useEffect(() => {
     if (element.type === "text") {
       onChange({
         ...element,
+        text,
         styles: { ...element.styles, color, fontSize },
       });
     }
-  }, [color, fontSize]);
+  }, [color, fontSize, text]);
 
   if (element.type !== "text") {
     return (
@@ -37,6 +40,10 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
 
   return (
     <Stack>
+      <FormControl>
+        <FormLabel>Text</FormLabel>
+        <Input value={text} onChange={(e) => setText(e.target.value)} />
+      </FormControl>
       <FormControl>
         <FormLabel>Color</FormLabel>
         <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Flex, Box, Text, Stack, Grid, HStack } from "@chakra-ui/react";
-import { useState, useCallback, useEffect } from "react";
+import { Flex, Box, Text, Grid, HStack } from "@chakra-ui/react";
+import { useState, useCallback } from "react";
 import SlideSequencer, { Slide, createInitialBoard } from "./SlideSequencer";
 import SlideElementsContainer from "./SlideElementsContainer";
 import ElementAttributesPane from "./ElementAttributesPane";

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -111,7 +111,12 @@ export default function LessonEditor() {
         const newEl: SlideElementDnDItemProps = {
           id: crypto.randomUUID(),
           type,
-          styles: type === "text" ? { color: "#000000", fontSize: "16px" } : {},
+          ...(type === "text"
+            ? {
+                text: "Sample Text",
+                styles: { color: "#000000", fontSize: "16px" },
+              }
+            : {}),
         };
 
         const firstColumn = s.boards[0].orderedColumnIds[0];


### PR DESCRIPTION
## Summary
- add text property to SlideElementDnDItemProps
- show the element text in SlideElementDnDItem
- let user edit text content in ElementAttributesPane
- set default text when dropping a text element

## Testing
- `npm run lint` *(fails: `next` not found)*