### PR TITLE
Improve slide preview layout

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -253,8 +253,13 @@ export default function LessonEditor() {
                 dropIndicator={dropIndicator}
               />
             </Box>
-            <Box p={4} borderWidth="1px" borderRadius="md" minW="300px">
-              <Text mb={2}>Preview</Text>
+            <Box
+              p={4}
+              borderWidth="1px"
+              borderRadius="md"
+              minW="300px"
+              bgColor="white"
+            >
               <SlidePreview
                 columnMap={
                   lesson.slides.find((s) => s.id === selectedSlideId)!.columnMap

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import {
+  Box,
+  Text,
+  Table,
+  Thead,
+  Tbody,
+  Tr,
+  Th,
+  Td,
+} from "@chakra-ui/react";
+import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
+
+interface SlideElementRendererProps {
+  item: SlideElementDnDItemProps;
+}
+
+export default function SlideElementRenderer({ item }: SlideElementRendererProps) {
+  if (item.type === "text") {
+    return (
+      <Text color={item.styles?.color} fontSize={item.styles?.fontSize} data-testid="text-element">
+        {item.text || "Sample Text"}
+      </Text>
+    );
+  }
+
+  if (item.type === "table") {
+    return (
+      <Table size="sm" data-testid="table-element">
+        <Thead>
+          <Tr>
+            <Th>Header 1</Th>
+            <Th>Header 2</Th>
+          </Tr>
+        </Thead>
+        <Tbody>
+          <Tr>
+            <Td>Cell</Td>
+            <Td>Cell</Td>
+          </Tr>
+        </Tbody>
+      </Table>
+    );
+  }
+
+  return (
+    <Box data-testid="unknown-element">
+      <Text fontSize={14} fontWeight="bold">
+        {item.type}
+      </Text>
+    </Box>
+  );
+}

--- a/insight-fe/src/components/lesson/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/SlidePreview.tsx
@@ -1,11 +1,9 @@
 "use client";
 
-import { Box, Flex, Stack } from "@chakra-ui/react";
+import { Box, Stack } from "@chakra-ui/react";
 import { ColumnMap } from "@/components/DnD/types";
-import {
-  SlideElementDnDItemProps,
-  SlideElementDnDItem,
-} from "@/components/DnD/cards/SlideElementDnDCard";
+import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
+import SlideElementRenderer from "./SlideElementRenderer";
 import { BoardRow } from "./SlideElementsContainer";
 
 interface SlidePreviewProps {
@@ -17,28 +15,26 @@ export default function SlidePreview({ columnMap, boards }: SlidePreviewProps) {
   return (
     <Stack gap={4}>
       {boards.map((board) => (
-        <Flex key={board.id} gap={4} alignItems="flex-start">
+        <Box
+          key={board.id}
+          display="grid"
+          gridTemplateColumns={`repeat(${board.orderedColumnIds.length}, 1fr)`}
+          gap={4}
+        >
           {board.orderedColumnIds.map((colId) => {
             const column = columnMap[colId];
             if (!column) return null;
             return (
-              <Stack
-                key={colId}
-                flex="1"
-                borderWidth="1px"
-                borderStyle="dashed"
-                borderColor="gray.300"
-                p={2}
-              >
+              <Stack key={colId} gap={2} data-column-id={colId}>
                 {column.items.map((item) => (
-                  <Box key={item.id} mb={2}>
-                    <SlideElementDnDItem item={item} />
+                  <Box key={item.id} mb={2} data-card-id={item.id}>
+                    <SlideElementRenderer item={item} />
                   </Box>
                 ))}
               </Stack>
             );
           })}
-        </Flex>
+        </Box>
       ))}
     </Stack>
   );


### PR DESCRIPTION
## Summary
- render slide elements using new `SlideElementRenderer`
- show board preview as responsive grid

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*