### PR TITLE
Add assignment relations to backend

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/assignment/assignment.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/assignment/assignment.entity.ts
@@ -1,11 +1,20 @@
 // src/modules/education/assignment.entity.ts
 
-import { Entity, Column, ManyToOne, OneToMany } from 'typeorm';
+import {
+  Entity,
+  Column,
+  ManyToOne,
+  OneToMany,
+  ManyToMany,
+  JoinTable,
+} from 'typeorm';
 import { ObjectType, Field, ID } from '@nestjs/graphql';
 
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { ClassEntity } from '../class/class.entity';
 import { LessonEntity } from '../lesson/lesson.entity';
+import { EducatorProfileEntity } from '../../user-profiles/educator-profile/educator-profile.entity';
+import { StudentProfileEntity } from '../../user-profiles/student-profile/student-profile.entity';
 import { AssignmentSubmissionEntity } from '../assignment-submission/assignment-submission.entity';
 
 @ObjectType()
@@ -13,7 +22,7 @@ import { AssignmentSubmissionEntity } from '../assignment-submission/assignment-
 export class AssignmentEntity extends AbstractBaseEntity {
   @Field()
   @Column()
-  title: string; // e.g. "Homework: Fractions Practice"
+  name: string; // e.g. "Homework: Fractions Practice"
 
   @Field({ nullable: true })
   @Column({ nullable: true })
@@ -24,10 +33,33 @@ export class AssignmentEntity extends AbstractBaseEntity {
   @ManyToOne(() => ClassEntity, (cls) => cls.assignments, { eager: true })
   class: ClassEntity;
 
-  // The lesson upon which the assignment is based
-  @Field(() => LessonEntity)
-  @ManyToOne(() => LessonEntity, { eager: true })
-  lesson: LessonEntity;
+  // Optional lessons this assignment references
+  @Field(() => [LessonEntity], { nullable: true })
+  @ManyToMany(() => LessonEntity, { eager: true })
+  @JoinTable({
+    name: 'assignment_lessons',
+    joinColumn: { name: 'assignment_id' },
+    inverseJoinColumn: { name: 'lesson_id' },
+  })
+  lessons?: LessonEntity[];
+
+  @Field(() => [EducatorProfileEntity], { nullable: true })
+  @ManyToMany(() => EducatorProfileEntity, { eager: true })
+  @JoinTable({
+    name: 'assignment_educators',
+    joinColumn: { name: 'assignment_id' },
+    inverseJoinColumn: { name: 'educator_profile_id' },
+  })
+  educators?: EducatorProfileEntity[];
+
+  @Field(() => [StudentProfileEntity], { nullable: true })
+  @ManyToMany(() => StudentProfileEntity, { eager: true })
+  @JoinTable({
+    name: 'assignment_students',
+    joinColumn: { name: 'assignment_id' },
+    inverseJoinColumn: { name: 'student_profile_id' },
+  })
+  students?: StudentProfileEntity[];
 
   @Field(() => Date, { nullable: true })
   @Column({ type: 'timestamp', nullable: true })

--- a/insight-be/src/modules/timbuktu/administrative/assignment/assignment.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/assignment/assignment.inputs.ts
@@ -1,9 +1,10 @@
 import { PartialType, InputType, Field, ID } from '@nestjs/graphql';
+import { HasRelationsInput } from 'src/common/base.inputs';
 
 @InputType()
-export class CreateAssignmentInput {
+export class CreateAssignmentInput extends HasRelationsInput {
   @Field()
-  title: string;
+  name: string;
 
   @Field({ nullable: true })
   description?: string;
@@ -14,11 +15,14 @@ export class CreateAssignmentInput {
   @Field(() => ID)
   classId: number;
 
-  /**
-   * The lesson upon which this assignment is based
-   */
-  @Field(() => ID)
-  lessonId: number;
+  @Field(() => [ID], { nullable: 'itemsAndList' })
+  lessonIds?: number[];
+
+  @Field(() => [ID], { nullable: 'itemsAndList' })
+  educatorIds?: number[];
+
+  @Field(() => [ID], { nullable: 'itemsAndList' })
+  studentIds?: number[];
 
   /**
    * The due date

--- a/insight-be/src/modules/timbuktu/administrative/assignment/assignment.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/assignment/assignment.service.ts
@@ -21,4 +21,55 @@ export class AssignmentService extends BaseService<
   ) {
     super(assignmentRepository, dataSource);
   }
+
+  async create(data: CreateAssignmentInput): Promise<AssignmentEntity> {
+    const relationIds = [] as { relation: string; ids: number[] }[];
+    if (data.classId) {
+      relationIds.push({ relation: 'class', ids: [data.classId] });
+    }
+
+    if (data.lessonIds?.length) {
+      relationIds.push({ relation: 'lessons', ids: data.lessonIds });
+    }
+    if (data.educatorIds?.length) {
+      relationIds.push({ relation: 'educators', ids: data.educatorIds });
+    }
+    if (data.studentIds?.length) {
+      relationIds.push({ relation: 'students', ids: data.studentIds });
+    }
+
+    const scalar = {
+      name: data.name,
+      description: data.description,
+      dueDate: data.dueDate,
+    } as any;
+
+    return super.create({ ...(scalar as any), relationIds } as any);
+  }
+
+  async update(data: UpdateAssignmentInput): Promise<AssignmentEntity> {
+    const relationIds = [] as { relation: string; ids: number[] }[];
+    if (data.classId) {
+      relationIds.push({ relation: 'class', ids: [data.classId] });
+    }
+
+    if (data.lessonIds?.length) {
+      relationIds.push({ relation: 'lessons', ids: data.lessonIds });
+    }
+    if (data.educatorIds?.length) {
+      relationIds.push({ relation: 'educators', ids: data.educatorIds });
+    }
+    if (data.studentIds?.length) {
+      relationIds.push({ relation: 'students', ids: data.studentIds });
+    }
+
+    const scalar = {
+      id: data.id,
+      name: data.name,
+      description: data.description,
+      dueDate: data.dueDate,
+    } as any;
+
+    return super.update({ ...(scalar as any), relationIds } as any);
+  }
 }


### PR DESCRIPTION
## Summary
- support educator, student, and lesson links on assignments
- convert create/update inputs to include relation ids

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*