### PR TITLE
Refactor lesson builder state

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Flex, Box, Text, Grid, HStack } from "@chakra-ui/react";
-import { useState, useCallback } from "react";
+import { useCallback, useReducer, useMemo } from "react";
 import SlideSequencer, { Slide, createInitialBoard } from "./SlideSequencer";
 import SlideElementsContainer from "./SlideElementsContainer";
 import ElementAttributesPane from "./ElementAttributesPane";
@@ -10,6 +10,43 @@ import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnD
 
 interface LessonState {
   slides: Slide[];
+  selectedSlideId: string | null;
+  selectedElementId: string | null;
+  dropIndicator: { columnId: string; index: number } | null;
+}
+
+type Action =
+  | { type: "setSlides"; updater: React.SetStateAction<Slide[]> }
+  | { type: "selectSlide"; id: string | null }
+  | { type: "selectElement"; id: string | null }
+  | { type: "setDropIndicator"; indicator: { columnId: string; index: number } | null }
+  | { type: "updateSlide"; slideId: string; updater: (slide: Slide) => Slide };
+
+function reducer(state: LessonState, action: Action): LessonState {
+  switch (action.type) {
+    case "setSlides": {
+      const slides =
+        typeof action.updater === "function"
+          ? (action.updater as (prev: Slide[]) => Slide[])(state.slides)
+          : action.updater;
+      return { ...state, slides };
+    }
+    case "selectSlide":
+      return { ...state, selectedSlideId: action.id, selectedElementId: null };
+    case "selectElement":
+      return { ...state, selectedElementId: action.id };
+    case "setDropIndicator":
+      return { ...state, dropIndicator: action.indicator };
+    case "updateSlide":
+      return {
+        ...state,
+        slides: state.slides.map((s) =>
+          s.id === action.slideId ? action.updater(s) : s
+        ),
+      };
+    default:
+      return state;
+  }
 }
 
 const AVAILABLE_ELEMENTS = [
@@ -18,181 +55,181 @@ const AVAILABLE_ELEMENTS = [
 ];
 
 export default function LessonEditor() {
-  const [lesson, setLesson] = useState<LessonState>({
-    slides: [
-      {
-        id: crypto.randomUUID(),
-        title: "Slide 1",
-        ...createInitialBoard(),
-      },
-    ],
+  const initialSlide = {
+    id: crypto.randomUUID(),
+    title: "Slide 1",
+    ...createInitialBoard(),
+  };
+  const [state, dispatch] = useReducer(reducer, {
+    slides: [initialSlide],
+    selectedSlideId: initialSlide.id,
+    selectedElementId: null,
+    dropIndicator: null,
   });
-  const [selectedSlideId, setSelectedSlideId] = useState<string | null>(
-    lesson.slides[0].id
+
+  const setSlides = useCallback(
+    (updater: React.SetStateAction<Slide[]>) =>
+      dispatch({ type: "setSlides", updater }),
+    [dispatch]
   );
-  const [selectedElementId, setSelectedElementId] = useState<string | null>(
-    null
+
+  const selectedSlide = useMemo(
+    () => state.slides.find((s) => s.id === state.selectedSlideId) || null,
+    [state.slides, state.selectedSlideId]
   );
-  const [dropIndicator, setDropIndicator] = useState<{
-    columnId: string;
-    index: number;
-  } | null>(null);
 
-  const setSlides = useCallback((updater: React.SetStateAction<Slide[]>) => {
-    setLesson((prev) => ({
-      ...prev,
-      slides:
-        typeof updater === "function"
-          ? (updater as (prev: Slide[]) => Slide[])(prev.slides)
-          : updater,
-    }));
-  }, []);
-
-  const selectedSlide = lesson.slides.find((s) => s.id === selectedSlideId);
-
-  const getSelectedElement = (): SlideElementDnDItemProps | null => {
-    if (!selectedSlide || !selectedElementId) return null;
+  const selectedElement = useMemo(() => {
+    if (!selectedSlide || !state.selectedElementId) return null;
     for (const board of selectedSlide.boards) {
       for (const colId of board.orderedColumnIds) {
         const col = selectedSlide.columnMap[colId];
-        const item = col.items.find((i) => i.id === selectedElementId);
+        const item = col.items.find((i) => i.id === state.selectedElementId);
         if (item) return item;
       }
     }
     return null;
-  };
+  }, [selectedSlide, state.selectedElementId]);
 
-  const updateElement = (updated: SlideElementDnDItemProps) => {
-    if (!selectedSlideId) return;
-    setLesson((prev) => ({
-      ...prev,
-      slides: prev.slides.map((slide) => {
-        if (slide.id !== selectedSlideId) return slide;
-        const newMap = { ...slide.columnMap } as typeof slide.columnMap;
-        for (const board of slide.boards) {
-          for (const colId of board.orderedColumnIds) {
-            const col = newMap[colId];
-            const idx = col.items.findIndex((i) => i.id === updated.id);
-            if (idx !== -1) {
-              newMap[colId] = {
-                ...col,
-                items: [
-                  ...col.items.slice(0, idx),
-                  updated,
-                  ...col.items.slice(idx + 1),
-                ],
-              };
-              break;
-            }
-          }
-        }
-        return {
-          ...slide,
-          columnMap: newMap,
-        };
-      }),
-    }));
-  };
-
-  const handleDropElement = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-
-    const type = e.dataTransfer.getData("text/plain");
-    if (!selectedSlideId) return;
-    if (!type) return;
-
-    const target = document.elementFromPoint(e.clientX, e.clientY);
-    const columnEl = target?.closest("[data-column-id]") as HTMLElement | null;
-    const dropColumnId = columnEl?.dataset.columnId;
-
-    setLesson((prev) => {
-      const slides = prev.slides.map((s) => {
-        if (s.id !== selectedSlideId) return s;
-        const newEl: SlideElementDnDItemProps = {
-          id: crypto.randomUUID(),
-          type,
-          ...(type === "text"
-            ? {
-                text: "Sample Text",
-                styles: { color: "#000000", fontSize: "16px" },
+  const updateElement = useCallback(
+    (updated: SlideElementDnDItemProps) => {
+      if (!state.selectedSlideId) return;
+      dispatch({
+        type: "updateSlide",
+        slideId: state.selectedSlideId,
+        updater: (slide) => {
+          const newMap = { ...slide.columnMap } as typeof slide.columnMap;
+          for (const board of slide.boards) {
+            for (const colId of board.orderedColumnIds) {
+              const col = newMap[colId];
+              const idx = col.items.findIndex((i) => i.id === updated.id);
+              if (idx !== -1) {
+                newMap[colId] = {
+                  ...col,
+                  items: [
+                    ...col.items.slice(0, idx),
+                    updated,
+                    ...col.items.slice(idx + 1),
+                  ],
+                };
+                break;
               }
-            : {}),
-        };
-
-        const firstColumn = s.boards[0].orderedColumnIds[0];
-        const columnId =
-          dropColumnId && s.columnMap[dropColumnId]
-            ? dropColumnId
-            : firstColumn;
-        const column = s.columnMap[columnId];
-
-        let insertIndex = column.items.length;
-        if (columnEl) {
-          const cards = Array.from(
-            columnEl.querySelectorAll("[data-card-id]")
-          ) as HTMLElement[];
-          for (let i = 0; i < cards.length; i++) {
-            const rect = cards[i].getBoundingClientRect();
-            if (e.clientY < rect.top + rect.height / 2) {
-              insertIndex = i;
-              break;
             }
           }
-        }
-
-        const updatedColumn = {
-          ...column,
-          items: [
-            ...column.items.slice(0, insertIndex),
-            newEl,
-            ...column.items.slice(insertIndex),
-          ],
-        };
-
-        return {
-          ...s,
-          columnMap: { ...s.columnMap, [columnId]: updatedColumn },
-        };
+          return { ...slide, columnMap: newMap };
+        },
       });
-      return { ...prev, slides };
-    });
-    setDropIndicator(null);
-  };
+    },
+    [state.selectedSlideId, dispatch]
+  );
 
-  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
-    e.preventDefault();
-    const type = e.dataTransfer.getData("text/plain");
-    if (!selectedSlideId || !type) return;
+  const handleDropElement = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
 
-    const target = document.elementFromPoint(e.clientX, e.clientY);
-    const columnEl = target?.closest("[data-column-id]") as HTMLElement | null;
-    const dropColumnId = columnEl?.dataset.columnId;
+      const type = e.dataTransfer.getData("text/plain");
+      if (!state.selectedSlideId) return;
+      if (!type) return;
+
+      const target = document.elementFromPoint(e.clientX, e.clientY);
+      const columnEl = target?.closest("[data-column-id]") as HTMLElement | null;
+      const dropColumnId = columnEl?.dataset.columnId;
+
+      dispatch({
+        type: "updateSlide",
+        slideId: state.selectedSlideId,
+        updater: (s) => {
+          const newEl: SlideElementDnDItemProps = {
+            id: crypto.randomUUID(),
+            type,
+            ...(type === "text"
+              ? {
+                  text: "Sample Text",
+                  styles: { color: "#000000", fontSize: "16px" },
+                }
+              : {}),
+          };
+
+          const firstColumn = s.boards[0].orderedColumnIds[0];
+          const columnId =
+            dropColumnId && s.columnMap[dropColumnId]
+              ? dropColumnId
+              : firstColumn;
+          const column = s.columnMap[columnId];
+
+          let insertIndex = column.items.length;
+          if (columnEl) {
+            const cards = Array.from(
+              columnEl.querySelectorAll("[data-card-id]")
+            ) as HTMLElement[];
+            for (let i = 0; i < cards.length; i++) {
+              const rect = cards[i].getBoundingClientRect();
+              if (e.clientY < rect.top + rect.height / 2) {
+                insertIndex = i;
+                break;
+              }
+            }
+          }
+
+          const updatedColumn = {
+            ...column,
+            items: [
+              ...column.items.slice(0, insertIndex),
+              newEl,
+              ...column.items.slice(insertIndex),
+            ],
+          };
+
+          return {
+            ...s,
+            columnMap: { ...s.columnMap, [columnId]: updatedColumn },
+          };
+        },
+      });
+      dispatch({ type: "setDropIndicator", indicator: null });
+    },
+    [state.selectedSlideId, dispatch]
+  );
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      const type = e.dataTransfer.getData("text/plain");
+      if (!state.selectedSlideId || !type) return;
+
+      const target = document.elementFromPoint(e.clientX, e.clientY);
+      const columnEl = target?.closest("[data-column-id]") as HTMLElement | null;
+      const dropColumnId = columnEl?.dataset.columnId;
     if (!dropColumnId) {
-      setDropIndicator(null);
+      dispatch({ type: "setDropIndicator", indicator: null });
       return;
     }
 
-    const slide = lesson.slides.find((s) => s.id === selectedSlideId);
-    if (!slide) return;
-    const column = slide.columnMap[dropColumnId];
+      const slide = state.slides.find((s) => s.id === state.selectedSlideId);
+      if (!slide) return;
+      const column = slide.columnMap[dropColumnId];
     if (!column) return;
 
-    let insertIndex = column.items.length;
-    if (columnEl) {
-      const cards = Array.from(
-        columnEl.querySelectorAll("[data-card-id]")
-      ) as HTMLElement[];
-      for (let i = 0; i < cards.length; i++) {
-        const rect = cards[i].getBoundingClientRect();
-        if (e.clientY < rect.top + rect.height / 2) {
-          insertIndex = i;
-          break;
+      let insertIndex = column.items.length;
+      if (columnEl) {
+        const cards = Array.from(
+          columnEl.querySelectorAll("[data-card-id]")
+        ) as HTMLElement[];
+        for (let i = 0; i < cards.length; i++) {
+          const rect = cards[i].getBoundingClientRect();
+          if (e.clientY < rect.top + rect.height / 2) {
+            insertIndex = i;
+            break;
+          }
         }
       }
-    }
 
-    setDropIndicator({ columnId: dropColumnId, index: insertIndex });
-  };
+      dispatch({
+        type: "setDropIndicator",
+        indicator: { columnId: dropColumnId, index: insertIndex },
+      });
+    },
+    [state.selectedSlideId, state.slides, dispatch]
+  );
 
   return (
     <Box>
@@ -216,12 +253,12 @@ export default function LessonEditor() {
 
       <Flex gap={6} alignItems="flex-start">
         <SlideSequencer
-          slides={lesson.slides}
+          slides={state.slides}
           setSlides={setSlides as any}
-          selectedSlideId={selectedSlideId}
-          onSelect={setSelectedSlideId}
+          selectedSlideId={state.selectedSlideId}
+          onSelect={(id) => dispatch({ type: "selectSlide", id })}
         />
-        {selectedSlideId && (
+        {state.selectedSlideId && (
           <Grid gap={4} flex={1} templateColumns="1fr 1fr 200px">
             <Box
               flex="1"
@@ -229,28 +266,27 @@ export default function LessonEditor() {
               borderWidth="1px"
               borderRadius="md"
               onDragOver={handleDragOver}
-              onDragLeave={() => setDropIndicator(null)}
+              onDragLeave={() =>
+                dispatch({ type: "setDropIndicator", indicator: null })
+              }
               onDrop={handleDropElement}
             >
               <Text mb={2}>Slide Elements</Text>
               <SlideElementsContainer
-                columnMap={
-                  lesson.slides.find((s) => s.id === selectedSlideId)!.columnMap
-                }
-                boards={
-                  lesson.slides.find((s) => s.id === selectedSlideId)!.boards
-                }
+                columnMap={selectedSlide!.columnMap}
+                boards={selectedSlide!.boards}
                 onChange={(columnMap, boards) =>
-                  setLesson((prev) => ({
-                    ...prev,
-                    slides: prev.slides.map((s) =>
-                      s.id === selectedSlideId ? { ...s, columnMap, boards } : s
-                    ),
-                  }))
+                  dispatch({
+                    type: "updateSlide",
+                    slideId: state.selectedSlideId!,
+                    updater: (s) => ({ ...s, columnMap, boards }),
+                  })
                 }
-                selectedElementId={selectedElementId}
-                onSelectElement={setSelectedElementId}
-                dropIndicator={dropIndicator}
+                selectedElementId={state.selectedElementId}
+                onSelectElement={(id) =>
+                  dispatch({ type: "selectElement", id })
+                }
+                dropIndicator={state.dropIndicator}
               />
             </Box>
             <Box
@@ -260,21 +296,14 @@ export default function LessonEditor() {
               minW="300px"
               bgColor="white"
             >
-              <SlidePreview
-                columnMap={
-                  lesson.slides.find((s) => s.id === selectedSlideId)!.columnMap
-                }
-                boards={
-                  lesson.slides.find((s) => s.id === selectedSlideId)!.boards
-                }
-              />
+              <SlidePreview columnMap={selectedSlide!.columnMap} boards={selectedSlide!.boards} />
             </Box>
 
             <Box p={4} borderWidth="1px" borderRadius="md" minW="200px">
               <Text mb={2}>Attributes</Text>
-              {getSelectedElement() && (
+              {selectedElement && (
                 <ElementAttributesPane
-                  element={getSelectedElement()!}
+                  element={selectedElement}
                   onChange={updateElement}
                 />
               )}


### PR DESCRIPTION
## Summary
- refactor `LessonEditor` to use a reducer for all slide state
- memoize selected slide and element lookups
- wrap callbacks in `useCallback`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*