### PR TITLE
Add image element to lesson builder

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -7,6 +7,7 @@ import {
   Tr,
   Th,
   Td,
+  Image,
 } from "@chakra-ui/react";
 
 export interface SlideElementDnDItemProps {
@@ -16,9 +17,18 @@ export interface SlideElementDnDItemProps {
    * Text content for text elements
    */
   text?: string;
+  /**
+   * Image source url for image elements
+   */
+  url?: string;
   styles?: {
     color?: string;
     fontSize?: string;
+    marginTop?: string;
+    marginBottom?: string;
+    border?: string;
+    borderRadius?: string;
+    boxShadow?: string;
   };
 }
 
@@ -47,6 +57,23 @@ export const SlideElementDnDItem = ({
         <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
           {item.text || "Sample Text"}
         </Text>
+      </ContentCard>
+    );
+  }
+
+  if (item.type === "image") {
+    return (
+      <ContentCard {...baseProps}>
+        <Image
+          src={item.url || "https://via.placeholder.com/150"}
+          alt="image"
+          width="100%"
+          mt={item.styles?.marginTop}
+          mb={item.styles?.marginBottom}
+          border={item.styles?.border}
+          borderRadius={item.styles?.borderRadius}
+          boxShadow={item.styles?.boxShadow}
+        />
       </ContentCard>
     );
   }

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import { Box, Stack, Text, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import {
+  Box,
+  Stack,
+  Text,
+  FormControl,
+  FormLabel,
+  Input,
+} from "@chakra-ui/react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { useEffect, useState } from "react";
 
@@ -13,6 +20,12 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
   const [text, setText] = useState(element.text || "");
+  const [url, setUrl] = useState(element.url || "");
+  const [border, setBorder] = useState(element.styles?.border || "");
+  const [borderRadius, setBorderRadius] = useState(element.styles?.borderRadius || "");
+  const [boxShadow, setBoxShadow] = useState(element.styles?.boxShadow || "");
+  const [marginTop, setMarginTop] = useState(element.styles?.marginTop || "0px");
+  const [marginBottom, setMarginBottom] = useState(element.styles?.marginBottom || "0px");
 
   // Reset local state only when a new element is selected
   // using id/type avoids resets when the parent simply updates
@@ -21,6 +34,12 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
     setText(element.text || "");
+    setUrl(element.url || "");
+    setBorder(element.styles?.border || "");
+    setBorderRadius(element.styles?.borderRadius || "");
+    setBoxShadow(element.styles?.boxShadow || "");
+    setMarginTop(element.styles?.marginTop || "0px");
+    setMarginBottom(element.styles?.marginBottom || "0px");
   }, [element.id, element.type]);
 
   useEffect(() => {
@@ -30,35 +49,87 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
         text,
         styles: { ...element.styles, color, fontSize },
       });
+    } else if (element.type === "image") {
+      onChange({
+        ...element,
+        url,
+        styles: {
+          ...element.styles,
+          border,
+          borderRadius,
+          boxShadow,
+          marginTop,
+          marginBottom,
+        },
+      });
     }
-  }, [color, fontSize, text]);
+  }, [color, fontSize, text, url, border, borderRadius, boxShadow, marginTop, marginBottom]);
 
-  if (element.type !== "text") {
+  if (element.type === "text") {
     return (
-      <Box>
-        <Text>No editable attributes</Text>
-      </Box>
+      <Stack>
+        <FormControl>
+          <FormLabel>Text</FormLabel>
+          <Input value={text} onChange={(e) => setText(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Color</FormLabel>
+          <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Font Size (px)</FormLabel>
+          <Input
+            type="number"
+            value={parseInt(fontSize)}
+            onChange={(e) => setFontSize(e.target.value + "px")}
+          />
+        </FormControl>
+      </Stack>
+    );
+  }
+
+  if (element.type === "image") {
+    return (
+      <Stack>
+        <FormControl>
+          <FormLabel>Image URL</FormLabel>
+          <Input value={url} onChange={(e) => setUrl(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Border</FormLabel>
+          <Input value={border} onChange={(e) => setBorder(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Border Radius</FormLabel>
+          <Input value={borderRadius} onChange={(e) => setBorderRadius(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Drop Shadow</FormLabel>
+          <Input value={boxShadow} onChange={(e) => setBoxShadow(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Margin Top (px)</FormLabel>
+          <Input
+            type="number"
+            value={parseInt(marginTop)}
+            onChange={(e) => setMarginTop(e.target.value + "px")}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Margin Bottom (px)</FormLabel>
+          <Input
+            type="number"
+            value={parseInt(marginBottom)}
+            onChange={(e) => setMarginBottom(e.target.value + "px")}
+          />
+        </FormControl>
+      </Stack>
     );
   }
 
   return (
-    <Stack>
-      <FormControl>
-        <FormLabel>Text</FormLabel>
-        <Input value={text} onChange={(e) => setText(e.target.value)} />
-      </FormControl>
-      <FormControl>
-        <FormLabel>Color</FormLabel>
-        <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
-      </FormControl>
-      <FormControl>
-        <FormLabel>Font Size (px)</FormLabel>
-        <Input
-          type="number"
-          value={parseInt(fontSize)}
-          onChange={(e) => setFontSize(e.target.value + "px")}
-        />
-      </FormControl>
-    </Stack>
+    <Box>
+      <Text>No editable attributes</Text>
+    </Box>
   );
 }

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -52,6 +52,7 @@ function reducer(state: LessonState, action: Action): LessonState {
 const AVAILABLE_ELEMENTS = [
   { type: "text", label: "Text" },
   { type: "table", label: "Table" },
+  { type: "image", label: "Image" },
 ];
 
 export default function LessonEditor() {
@@ -145,6 +146,18 @@ export default function LessonEditor() {
               ? {
                   text: "Sample Text",
                   styles: { color: "#000000", fontSize: "16px" },
+                }
+              : {}),
+            ...(type === "image"
+              ? {
+                  url: "",
+                  styles: {
+                    border: "",
+                    borderRadius: "",
+                    boxShadow: "",
+                    marginTop: "0px",
+                    marginBottom: "0px",
+                  },
                 }
               : {}),
           };

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -9,6 +9,7 @@ import {
   Tr,
   Th,
   Td,
+  Image,
 } from "@chakra-ui/react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
@@ -22,6 +23,22 @@ export default function SlideElementRenderer({ item }: SlideElementRendererProps
       <Text color={item.styles?.color} fontSize={item.styles?.fontSize} data-testid="text-element">
         {item.text || "Sample Text"}
       </Text>
+    );
+  }
+
+  if (item.type === "image") {
+    return (
+      <Image
+        src={item.url || "https://via.placeholder.com/150"}
+        alt="image"
+        width="100%"
+        mt={item.styles?.marginTop}
+        mb={item.styles?.marginBottom}
+        border={item.styles?.border}
+        borderRadius={item.styles?.borderRadius}
+        boxShadow={item.styles?.boxShadow}
+        data-testid="image-element"
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- add `image` type to `SlideElementDnDItemProps`
- render image elements in slide boards and previews
- update attributes pane to edit image styles and URL
- allow dragging new image elements in lesson editor

## Testing
- `npm run lint` *(fails: `next` not found)*