### PR TITLE
Add wrapper component to lesson builder

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -1,4 +1,6 @@
-import { ContentCard } from "@/components/layout/Card";
+import ElementWrapper, {
+  ElementWrapperStyles,
+} from "@/components/lesson/ElementWrapper";
 import {
   Text,
   Table,
@@ -20,6 +22,7 @@ export interface SlideElementDnDItemProps {
     color?: string;
     fontSize?: string;
   };
+  wrapperStyles?: ElementWrapperStyles;
 }
 
 interface SlideElementDnDItemComponentProps {
@@ -36,24 +39,28 @@ export const SlideElementDnDItem = ({
   const baseProps = {
     id: item.id,
     cursor: "grab" as const,
-    borderWidth: isSelected ? "2px" : undefined,
-    borderColor: isSelected ? "blue.400" : undefined,
     onClick: onSelect,
+  };
+
+  const wrapperStyles: ElementWrapperStyles = {
+    ...item.wrapperStyles,
+    borderColor: isSelected ? "blue.400" : item.wrapperStyles?.borderColor,
+    borderWidth: isSelected ? 2 : item.wrapperStyles?.borderWidth,
   };
 
   if (item.type === "text") {
     return (
-      <ContentCard {...baseProps}>
+      <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
           {item.text || "Sample Text"}
         </Text>
-      </ContentCard>
+      </ElementWrapper>
     );
   }
 
   if (item.type === "table") {
     return (
-      <ContentCard {...baseProps}>
+      <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Table size="sm">
           <Thead>
             <Tr>
@@ -68,15 +75,15 @@ export const SlideElementDnDItem = ({
             </Tr>
           </Tbody>
         </Table>
-      </ContentCard>
+      </ElementWrapper>
     );
   }
 
   return (
-    <ContentCard {...baseProps}>
+    <ElementWrapper styles={wrapperStyles} {...baseProps}>
       <Text fontSize={14} fontWeight="bold">
         {item.type}
       </Text>
-    </ContentCard>
+    </ElementWrapper>
   );
 };

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -1,6 +1,14 @@
 "use client";
 
-import { Box, Stack, Text, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import {
+  Box,
+  Stack,
+  Text,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+} from "@chakra-ui/react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { useEffect, useState } from "react";
 
@@ -13,6 +21,14 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
   const [text, setText] = useState(element.text || "");
+  const [bgColor, setBgColor] = useState(element.wrapperStyles?.bgColor || "#ffffff");
+  const [shadow, setShadow] = useState(element.wrapperStyles?.dropShadow || "none");
+  const [paddingX, setPaddingX] = useState(element.wrapperStyles?.paddingX ?? 0);
+  const [paddingY, setPaddingY] = useState(element.wrapperStyles?.paddingY ?? 0);
+  const [marginX, setMarginX] = useState(element.wrapperStyles?.marginX ?? 0);
+  const [marginY, setMarginY] = useState(element.wrapperStyles?.marginY ?? 0);
+  const [borderColor, setBorderColor] = useState(element.wrapperStyles?.borderColor || "#000000");
+  const [borderWidth, setBorderWidth] = useState(element.wrapperStyles?.borderWidth ?? 0);
 
   // Reset local state only when a new element is selected
   // using id/type avoids resets when the parent simply updates
@@ -21,44 +37,94 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
     setText(element.text || "");
+    setBgColor(element.wrapperStyles?.bgColor || "#ffffff");
+    setShadow(element.wrapperStyles?.dropShadow || "none");
+    setPaddingX(element.wrapperStyles?.paddingX ?? 0);
+    setPaddingY(element.wrapperStyles?.paddingY ?? 0);
+    setMarginX(element.wrapperStyles?.marginX ?? 0);
+    setMarginY(element.wrapperStyles?.marginY ?? 0);
+    setBorderColor(element.wrapperStyles?.borderColor || "#000000");
+    setBorderWidth(element.wrapperStyles?.borderWidth ?? 0);
   }, [element.id, element.type]);
 
   useEffect(() => {
+    const updated: SlideElementDnDItemProps = {
+      ...element,
+      wrapperStyles: {
+        bgColor,
+        dropShadow: shadow,
+        paddingX,
+        paddingY,
+        marginX,
+        marginY,
+        borderColor,
+        borderWidth,
+      },
+    };
     if (element.type === "text") {
-      onChange({
-        ...element,
-        text,
-        styles: { ...element.styles, color, fontSize },
-      });
+      updated.text = text;
+      updated.styles = { ...element.styles, color, fontSize };
     }
-  }, [color, fontSize, text]);
-
-  if (element.type !== "text") {
-    return (
-      <Box>
-        <Text>No editable attributes</Text>
-      </Box>
-    );
-  }
+    onChange(updated);
+  }, [color, fontSize, text, bgColor, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth]);
 
   return (
     <Stack>
       <FormControl>
-        <FormLabel>Text</FormLabel>
-        <Input value={text} onChange={(e) => setText(e.target.value)} />
+        <FormLabel>Background Color</FormLabel>
+        <Input type="color" value={bgColor} onChange={(e) => setBgColor(e.target.value)} />
       </FormControl>
       <FormControl>
-        <FormLabel>Color</FormLabel>
-        <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+        <FormLabel>Shadow</FormLabel>
+        <Select value={shadow} onChange={(e) => setShadow(e.target.value)}>
+          <option value="none">None</option>
+          <option value="sm">Small</option>
+          <option value="md">Medium</option>
+          <option value="lg">Large</option>
+          <option value="xl">XL</option>
+          <option value="2xl">2XL</option>
+        </Select>
       </FormControl>
       <FormControl>
-        <FormLabel>Font Size (px)</FormLabel>
-        <Input
-          type="number"
-          value={parseInt(fontSize)}
-          onChange={(e) => setFontSize(e.target.value + "px")}
-        />
+        <FormLabel>Padding X (px)</FormLabel>
+        <Input type="number" value={paddingX} onChange={(e) => setPaddingX(parseInt(e.target.value))} />
       </FormControl>
+      <FormControl>
+        <FormLabel>Padding Y (px)</FormLabel>
+        <Input type="number" value={paddingY} onChange={(e) => setPaddingY(parseInt(e.target.value))} />
+      </FormControl>
+      <FormControl>
+        <FormLabel>Margin X (px)</FormLabel>
+        <Input type="number" value={marginX} onChange={(e) => setMarginX(parseInt(e.target.value))} />
+      </FormControl>
+      <FormControl>
+        <FormLabel>Margin Y (px)</FormLabel>
+        <Input type="number" value={marginY} onChange={(e) => setMarginY(parseInt(e.target.value))} />
+      </FormControl>
+      <FormControl>
+        <FormLabel>Border Color</FormLabel>
+        <Input type="color" value={borderColor} onChange={(e) => setBorderColor(e.target.value)} />
+      </FormControl>
+      <FormControl>
+        <FormLabel>Border Width (px)</FormLabel>
+        <Input type="number" value={borderWidth} onChange={(e) => setBorderWidth(parseInt(e.target.value))} />
+      </FormControl>
+      {element.type === "text" && (
+        <>
+          <FormControl>
+            <FormLabel>Text</FormLabel>
+            <Input value={text} onChange={(e) => setText(e.target.value)} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Color</FormLabel>
+            <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Font Size (px)</FormLabel>
+            <Input type="number" value={parseInt(fontSize)} onChange={(e) => setFontSize(e.target.value + "px")} />
+          </FormControl>
+        </>
+      )}
     </Stack>
   );
 }

--- a/insight-fe/src/components/lesson/ElementWrapper.tsx
+++ b/insight-fe/src/components/lesson/ElementWrapper.tsx
@@ -1,0 +1,37 @@
+import { Box, BoxProps } from "@chakra-ui/react";
+import React from "react";
+
+export interface ElementWrapperStyles {
+  bgColor?: string;
+  dropShadow?: string;
+  paddingX?: number;
+  paddingY?: number;
+  marginX?: number;
+  marginY?: number;
+  borderColor?: string;
+  borderWidth?: number;
+}
+
+interface ElementWrapperProps extends BoxProps {
+  styles?: ElementWrapperStyles;
+  children: React.ReactNode;
+}
+
+export default function ElementWrapper({ styles, children, ...props }: ElementWrapperProps) {
+  return (
+    <Box
+      bg={styles?.bgColor || "white"}
+      boxShadow={styles?.dropShadow}
+      px={styles?.paddingX}
+      py={styles?.paddingY}
+      mx={styles?.marginX}
+      my={styles?.marginY}
+      borderColor={styles?.borderColor}
+      borderWidth={styles?.borderWidth}
+      borderStyle="solid"
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -147,6 +147,16 @@ export default function LessonEditor() {
                   styles: { color: "#000000", fontSize: "16px" },
                 }
               : {}),
+            wrapperStyles: {
+              bgColor: "#ffffff",
+              dropShadow: "md",
+              paddingX: 4,
+              paddingY: 4,
+              marginX: 0,
+              marginY: 0,
+              borderColor: "#000000",
+              borderWidth: 0,
+            },
           };
 
           const firstColumn = s.boards[0].orderedColumnIds[0];

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -10,6 +10,7 @@ import {
   Th,
   Td,
 } from "@chakra-ui/react";
+import ElementWrapper from "./ElementWrapper";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface SlideElementRendererProps {
@@ -19,36 +20,38 @@ interface SlideElementRendererProps {
 export default function SlideElementRenderer({ item }: SlideElementRendererProps) {
   if (item.type === "text") {
     return (
-      <Text color={item.styles?.color} fontSize={item.styles?.fontSize} data-testid="text-element">
-        {item.text || "Sample Text"}
-      </Text>
+      <ElementWrapper styles={item.wrapperStyles} data-testid="text-element">
+        <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
+          {item.text || "Sample Text"}
+        </Text>
+      </ElementWrapper>
     );
   }
 
   if (item.type === "table") {
     return (
-      <Table size="sm" data-testid="table-element">
-        <Thead>
-          <Tr>
-            <Th>Header 1</Th>
-            <Th>Header 2</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          <Tr>
-            <Td>Cell</Td>
-            <Td>Cell</Td>
-          </Tr>
-        </Tbody>
-      </Table>
+      <ElementWrapper styles={item.wrapperStyles} data-testid="table-element">
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Header 1</Th>
+              <Th>Header 2</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Cell</Td>
+              <Td>Cell</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </ElementWrapper>
     );
   }
 
   return (
-    <Box data-testid="unknown-element">
-      <Text fontSize={14} fontWeight="bold">
-        {item.type}
-      </Text>
-    </Box>
+    <ElementWrapper styles={item.wrapperStyles} data-testid="unknown-element">
+      <Text fontSize={14} fontWeight="bold">{item.type}</Text>
+    </ElementWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- add `ElementWrapper` component for reusable slide element styling
- show wrapper style controls in `ElementAttributesPane`
- use wrapper in slide element drag cards and preview renderer
- create default wrapper styles when elements are dropped

## Testing
- `npm run lint` *(fails: next not found)*