### PR TITLE
Add wrapper component to lesson builder

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -1,4 +1,6 @@
-import { ContentCard } from "@/components/layout/Card";
+import ElementWrapper, {
+  ElementWrapperStyles,
+} from "@/components/lesson/ElementWrapper";
 import {
   Text,
   Table,
@@ -20,6 +22,7 @@ export interface SlideElementDnDItemProps {
     color?: string;
     fontSize?: string;
   };
+  wrapperStyles?: ElementWrapperStyles;
 }
 
 interface SlideElementDnDItemComponentProps {
@@ -36,24 +39,29 @@ export const SlideElementDnDItem = ({
   const baseProps = {
     id: item.id,
     cursor: "grab" as const,
-    borderWidth: isSelected ? "2px" : undefined,
-    borderColor: isSelected ? "blue.400" : undefined,
     onClick: onSelect,
+  };
+
+  const wrapperStyles: ElementWrapperStyles = {
+    ...item.wrapperStyles,
+    borderColor: isSelected ? "blue.400" : item.wrapperStyles?.borderColor,
+    borderWidth: isSelected ? 2 : item.wrapperStyles?.borderWidth,
+    borderRadius: item.wrapperStyles?.borderRadius,
   };
 
   if (item.type === "text") {
     return (
-      <ContentCard {...baseProps}>
+      <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
           {item.text || "Sample Text"}
         </Text>
-      </ContentCard>
+      </ElementWrapper>
     );
   }
 
   if (item.type === "table") {
     return (
-      <ContentCard {...baseProps}>
+      <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Table size="sm">
           <Thead>
             <Tr>
@@ -68,15 +76,15 @@ export const SlideElementDnDItem = ({
             </Tr>
           </Tbody>
         </Table>
-      </ContentCard>
+      </ElementWrapper>
     );
   }
 
   return (
-    <ContentCard {...baseProps}>
+    <ElementWrapper styles={wrapperStyles} {...baseProps}>
       <Text fontSize={14} fontWeight="bold">
         {item.type}
       </Text>
-    </ContentCard>
+    </ElementWrapper>
   );
 };

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -1,6 +1,20 @@
 "use client";
 
-import { Box, Stack, Text, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import {
+  Box,
+  Stack,
+  Text,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  HStack,
+} from "@chakra-ui/react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { useEffect, useState } from "react";
 
@@ -13,6 +27,15 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
   const [text, setText] = useState(element.text || "");
+  const [bgColor, setBgColor] = useState(element.wrapperStyles?.bgColor || "#ffffff");
+  const [shadow, setShadow] = useState(element.wrapperStyles?.dropShadow || "none");
+  const [paddingX, setPaddingX] = useState(element.wrapperStyles?.paddingX ?? 0);
+  const [paddingY, setPaddingY] = useState(element.wrapperStyles?.paddingY ?? 0);
+  const [marginX, setMarginX] = useState(element.wrapperStyles?.marginX ?? 0);
+  const [marginY, setMarginY] = useState(element.wrapperStyles?.marginY ?? 0);
+  const [borderColor, setBorderColor] = useState(element.wrapperStyles?.borderColor || "#000000");
+  const [borderWidth, setBorderWidth] = useState(element.wrapperStyles?.borderWidth ?? 0);
+  const [borderRadius, setBorderRadius] = useState(element.wrapperStyles?.borderRadius || "md");
 
   // Reset local state only when a new element is selected
   // using id/type avoids resets when the parent simply updates
@@ -21,44 +44,186 @@ export default function ElementAttributesPane({ element, onChange }: ElementAttr
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
     setText(element.text || "");
+    setBgColor(element.wrapperStyles?.bgColor || "#ffffff");
+    setShadow(element.wrapperStyles?.dropShadow || "none");
+    setPaddingX(element.wrapperStyles?.paddingX ?? 0);
+    setPaddingY(element.wrapperStyles?.paddingY ?? 0);
+    setMarginX(element.wrapperStyles?.marginX ?? 0);
+    setMarginY(element.wrapperStyles?.marginY ?? 0);
+    setBorderColor(element.wrapperStyles?.borderColor || "#000000");
+    setBorderWidth(element.wrapperStyles?.borderWidth ?? 0);
+    setBorderRadius(element.wrapperStyles?.borderRadius || "md");
   }, [element.id, element.type]);
 
   useEffect(() => {
+    const updated: SlideElementDnDItemProps = {
+      ...element,
+      wrapperStyles: {
+        bgColor,
+        dropShadow: shadow,
+        paddingX,
+        paddingY,
+        marginX,
+        marginY,
+        borderColor,
+        borderWidth,
+        borderRadius,
+      },
+    };
     if (element.type === "text") {
-      onChange({
-        ...element,
-        text,
-        styles: { ...element.styles, color, fontSize },
-      });
+      updated.text = text;
+      updated.styles = { ...element.styles, color, fontSize };
     }
-  }, [color, fontSize, text]);
-
-  if (element.type !== "text") {
-    return (
-      <Box>
-        <Text>No editable attributes</Text>
-      </Box>
-    );
-  }
+    onChange(updated);
+  }, [color, fontSize, text, bgColor, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius]);
 
   return (
-    <Stack>
-      <FormControl>
-        <FormLabel>Text</FormLabel>
-        <Input value={text} onChange={(e) => setText(e.target.value)} />
-      </FormControl>
-      <FormControl>
-        <FormLabel>Color</FormLabel>
-        <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
-      </FormControl>
-      <FormControl>
-        <FormLabel>Font Size (px)</FormLabel>
-        <Input
-          type="number"
-          value={parseInt(fontSize)}
-          onChange={(e) => setFontSize(e.target.value + "px")}
-        />
-      </FormControl>
-    </Stack>
+    <Accordion allowMultiple>
+      <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">
+              Wrapper
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Background
+              </FormLabel>
+              <Input type="color" value={bgColor} onChange={(e) => setBgColor(e.target.value)} />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Shadow
+              </FormLabel>
+              <Select size="sm" value={shadow} onChange={(e) => setShadow(e.target.value)}>
+                <option value="none">None</option>
+                <option value="sm">Small</option>
+                <option value="md">Medium</option>
+                <option value="lg">Large</option>
+                <option value="xl">XL</option>
+                <option value="2xl">2XL</option>
+              </Select>
+            </FormControl>
+            <Box>
+              <Text fontSize="sm" mb={1}>
+                Padding
+              </Text>
+              <HStack spacing={2}>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">
+                    Horiz.
+                  </FormLabel>
+                  <Input size="sm" type="number" w="60px" value={paddingX} onChange={(e) => setPaddingX(parseInt(e.target.value))} />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">
+                    Vert.
+                  </FormLabel>
+                  <Input size="sm" type="number" w="60px" value={paddingY} onChange={(e) => setPaddingY(parseInt(e.target.value))} />
+                </FormControl>
+              </HStack>
+            </Box>
+            <Box>
+              <Text fontSize="sm" mb={1}>
+                Margin
+              </Text>
+              <HStack spacing={2}>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">
+                    Horiz.
+                  </FormLabel>
+                  <Input size="sm" type="number" w="60px" value={marginX} onChange={(e) => setMarginX(parseInt(e.target.value))} />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">
+                    Vert.
+                  </FormLabel>
+                  <Input size="sm" type="number" w="60px" value={marginY} onChange={(e) => setMarginY(parseInt(e.target.value))} />
+                </FormControl>
+              </HStack>
+            </Box>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem borderWidth="1px" borderColor="green.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">
+              Borders
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Color
+              </FormLabel>
+              <Input type="color" value={borderColor} onChange={(e) => setBorderColor(e.target.value)} />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Width
+              </FormLabel>
+              <Input size="sm" type="number" w="60px" value={borderWidth} onChange={(e) => setBorderWidth(parseInt(e.target.value))} />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Radius
+              </FormLabel>
+              <Select size="sm" value={borderRadius} onChange={(e) => setBorderRadius(e.target.value)}>
+                <option value="none">None</option>
+                <option value="sm">Small</option>
+                <option value="md">Medium</option>
+                <option value="lg">Large</option>
+                <option value="50%">Circular</option>
+              </Select>
+            </FormControl>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+
+      {element.type === "text" && (
+        <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>
+          <h2>
+            <AccordionButton>
+              <Box flex="1" textAlign="left">
+                Text
+              </Box>
+              <AccordionIcon />
+            </AccordionButton>
+          </h2>
+          <AccordionPanel pb={2}>
+            <Stack spacing={2}>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Content
+                </FormLabel>
+                <Input size="sm" value={text} onChange={(e) => setText(e.target.value)} />
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Color
+                </FormLabel>
+                <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Size
+                </FormLabel>
+                <Input size="sm" type="number" w="60px" value={parseInt(fontSize)} onChange={(e) => setFontSize(e.target.value + "px")} />
+              </FormControl>
+            </Stack>
+          </AccordionPanel>
+        </AccordionItem>
+      )}
+    </Accordion>
   );
 }

--- a/insight-fe/src/components/lesson/ElementWrapper.tsx
+++ b/insight-fe/src/components/lesson/ElementWrapper.tsx
@@ -1,0 +1,39 @@
+import { Box, BoxProps } from "@chakra-ui/react";
+import React from "react";
+
+export interface ElementWrapperStyles {
+  bgColor?: string;
+  dropShadow?: string;
+  paddingX?: number;
+  paddingY?: number;
+  marginX?: number;
+  marginY?: number;
+  borderColor?: string;
+  borderWidth?: number;
+  borderRadius?: string | number;
+}
+
+interface ElementWrapperProps extends BoxProps {
+  styles?: ElementWrapperStyles;
+  children: React.ReactNode;
+}
+
+export default function ElementWrapper({ styles, children, ...props }: ElementWrapperProps) {
+  return (
+    <Box
+      bg={styles?.bgColor || "white"}
+      boxShadow={styles?.dropShadow}
+      px={styles?.paddingX}
+      py={styles?.paddingY}
+      mx={styles?.marginX}
+      my={styles?.marginY}
+      borderColor={styles?.borderColor}
+      borderWidth={styles?.borderWidth}
+      borderRadius={styles?.borderRadius}
+      borderStyle="solid"
+      {...props}
+    >
+      {children}
+    </Box>
+  );
+}

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -147,6 +147,17 @@ export default function LessonEditor() {
                   styles: { color: "#000000", fontSize: "16px" },
                 }
               : {}),
+            wrapperStyles: {
+              bgColor: "#ffffff",
+              dropShadow: "md",
+              paddingX: 4,
+              paddingY: 4,
+              marginX: 0,
+              marginY: 0,
+              borderColor: "#000000",
+              borderWidth: 0,
+              borderRadius: "md",
+            },
           };
 
           const firstColumn = s.boards[0].orderedColumnIds[0];

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -10,6 +10,7 @@ import {
   Th,
   Td,
 } from "@chakra-ui/react";
+import ElementWrapper from "./ElementWrapper";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface SlideElementRendererProps {
@@ -19,36 +20,38 @@ interface SlideElementRendererProps {
 export default function SlideElementRenderer({ item }: SlideElementRendererProps) {
   if (item.type === "text") {
     return (
-      <Text color={item.styles?.color} fontSize={item.styles?.fontSize} data-testid="text-element">
-        {item.text || "Sample Text"}
-      </Text>
+      <ElementWrapper styles={item.wrapperStyles} data-testid="text-element">
+        <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
+          {item.text || "Sample Text"}
+        </Text>
+      </ElementWrapper>
     );
   }
 
   if (item.type === "table") {
     return (
-      <Table size="sm" data-testid="table-element">
-        <Thead>
-          <Tr>
-            <Th>Header 1</Th>
-            <Th>Header 2</Th>
-          </Tr>
-        </Thead>
-        <Tbody>
-          <Tr>
-            <Td>Cell</Td>
-            <Td>Cell</Td>
-          </Tr>
-        </Tbody>
-      </Table>
+      <ElementWrapper styles={item.wrapperStyles} data-testid="table-element">
+        <Table size="sm">
+          <Thead>
+            <Tr>
+              <Th>Header 1</Th>
+              <Th>Header 2</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            <Tr>
+              <Td>Cell</Td>
+              <Td>Cell</Td>
+            </Tr>
+          </Tbody>
+        </Table>
+      </ElementWrapper>
     );
   }
 
   return (
-    <Box data-testid="unknown-element">
-      <Text fontSize={14} fontWeight="bold">
-        {item.type}
-      </Text>
-    </Box>
+    <ElementWrapper styles={item.wrapperStyles} data-testid="unknown-element">
+      <Text fontSize={14} fontWeight="bold">{item.type}</Text>
+    </ElementWrapper>
   );
 }


### PR DESCRIPTION
## Summary
- add `ElementWrapper` component for reusable slide element styling
- show wrapper style controls in `ElementAttributesPane`
- use wrapper in slide element drag cards and preview renderer
- create default wrapper styles when elements are dropped
- color-coded accordion sections with compact inputs and border radius options

## Testing
- `npm run lint` *(fails: next not found)*