### PR TITLE
Add video element to lesson builder

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -2,6 +2,7 @@ import ElementWrapper, {
   ElementWrapperStyles,
 } from "@/components/lesson/ElementWrapper";
 import {
+  Box,
   Text,
   Table,
   Thead,
@@ -18,6 +19,10 @@ export interface SlideElementDnDItemProps {
    * Text content for text elements
    */
   text?: string;
+  /**
+   * Video URL for video elements
+   */
+  url?: string;
   styles?: {
     color?: string;
     fontSize?: string;
@@ -76,6 +81,14 @@ export const SlideElementDnDItem = ({
             </Tr>
           </Tbody>
         </Table>
+      </ElementWrapper>
+    );
+  }
+
+  if (item.type === "video") {
+    return (
+      <ElementWrapper styles={wrapperStyles} {...baseProps}>
+        <Box as="video" src={item.url} controls width="100%" />
       </ElementWrapper>
     );
   }

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -31,6 +31,7 @@ export default function ElementAttributesPane({
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
   const [text, setText] = useState(element.text || "");
+  const [url, setUrl] = useState(element.url || "");
   const [bgColor, setBgColor] = useState(
     element.wrapperStyles?.bgColor || "#ffffff"
   );
@@ -62,6 +63,7 @@ export default function ElementAttributesPane({
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
     setText(element.text || "");
+    setUrl(element.url || "");
     setBgColor(element.wrapperStyles?.bgColor || "#ffffff");
     setShadow(element.wrapperStyles?.dropShadow || "none");
     setPaddingX(element.wrapperStyles?.paddingX ?? 0);
@@ -92,11 +94,15 @@ export default function ElementAttributesPane({
       updated.text = text;
       updated.styles = { ...element.styles, color, fontSize };
     }
+    if (element.type === "video") {
+      updated.url = url;
+    }
     onChange(updated);
   }, [
     color,
     fontSize,
     text,
+    url,
     bgColor,
     shadow,
     paddingX,
@@ -324,6 +330,38 @@ export default function ElementAttributesPane({
                   w="60px"
                   value={parseInt(fontSize)}
                   onChange={(e) => setFontSize(e.target.value + "px")}
+                />
+              </FormControl>
+            </Stack>
+          </AccordionPanel>
+        </AccordionItem>
+      )}
+
+      {element.type === "video" && (
+        <AccordionItem
+          borderWidth="1px"
+          borderColor="purple.300"
+          borderRadius="md"
+          mb={2}
+        >
+          <h2>
+            <AccordionButton>
+              <Box flex="1" textAlign="left">
+                Video
+              </Box>
+              <AccordionIcon />
+            </AccordionButton>
+          </h2>
+          <AccordionPanel pb={2}>
+            <Stack spacing={2}>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  URL
+                </FormLabel>
+                <Input
+                  size="sm"
+                  value={url}
+                  onChange={(e) => setUrl(e.target.value)}
                 />
               </FormControl>
             </Stack>

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -55,6 +55,7 @@ function reducer(state: LessonState, action: Action): LessonState {
 const AVAILABLE_ELEMENTS = [
   { type: "text", label: "Text" },
   { type: "table", label: "Table" },
+  { type: "video", label: "Video" },
 ];
 
 export default function LessonEditor() {
@@ -151,6 +152,8 @@ export default function LessonEditor() {
                   text: "Sample Text",
                   styles: { color: "#000000", fontSize: "16px" },
                 }
+              : type === "video"
+              ? { url: "" }
               : {}),
             wrapperStyles: {
               bgColor: "#ffffff",

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -11,6 +11,7 @@ import {
   Td,
 } from "@chakra-ui/react";
 import ElementWrapper from "./ElementWrapper";
+import VideoElement from "./VideoElement";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface SlideElementRendererProps {
@@ -46,6 +47,12 @@ export default function SlideElementRenderer({ item }: SlideElementRendererProps
           </Tbody>
         </Table>
       </ElementWrapper>
+    );
+  }
+
+  if (item.type === "video") {
+    return (
+      <VideoElement url={item.url || ""} wrapperStyles={item.wrapperStyles} />
     );
   }
 

--- a/insight-fe/src/components/lesson/VideoElement.tsx
+++ b/insight-fe/src/components/lesson/VideoElement.tsx
@@ -1,0 +1,15 @@
+import { Box } from "@chakra-ui/react";
+import ElementWrapper, { ElementWrapperStyles } from "./ElementWrapper";
+
+interface VideoElementProps {
+  url: string;
+  wrapperStyles?: ElementWrapperStyles;
+}
+
+export default function VideoElement({ url, wrapperStyles }: VideoElementProps) {
+  return (
+    <ElementWrapper styles={wrapperStyles}>
+      <Box as="video" src={url} controls width="100%" />
+    </ElementWrapper>
+  );
+}


### PR DESCRIPTION
## Summary
- support new `video` element in lesson builder
- update attributes pane with video URL field
- render videos in preview and drag-n-drop cards

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` in `insight-be` *(fails: jest not found)*