### PR TITLE
Fix default element styling in lesson builder

### DIFF
--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -53,7 +53,7 @@ export default function ElementAttributesPane({
     element.wrapperStyles?.borderWidth ?? 0
   );
   const [borderRadius, setBorderRadius] = useState(
-    element.wrapperStyles?.borderRadius || "md"
+    element.wrapperStyles?.borderRadius || "none"
   );
 
   // Reset local state only when a new element is selected
@@ -72,7 +72,7 @@ export default function ElementAttributesPane({
     setMarginY(element.wrapperStyles?.marginY ?? 0);
     setBorderColor(element.wrapperStyles?.borderColor || "#000000");
     setBorderWidth(element.wrapperStyles?.borderWidth ?? 0);
-    setBorderRadius(element.wrapperStyles?.borderRadius || "md");
+    setBorderRadius(element.wrapperStyles?.borderRadius || "none");
   }, [element.id, element.type]);
 
   useEffect(() => {

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -157,14 +157,14 @@ export default function LessonEditor() {
               : {}),
             wrapperStyles: {
               bgColor: "#ffffff",
-              dropShadow: "md",
-              paddingX: 4,
-              paddingY: 4,
+              dropShadow: "none",
+              paddingX: 0,
+              paddingY: 0,
               marginX: 0,
               marginY: 0,
               borderColor: "#000000",
               borderWidth: 0,
-              borderRadius: "md",
+              borderRadius: "none",
             },
           };
 


### PR DESCRIPTION
## Summary
- update new lesson element defaults
- default element radius to none in settings UI

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `insight-fe` *(fails: missing script)*