### PR TITLE
Add image element to lesson editor

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -18,6 +18,10 @@ export interface SlideElementDnDItemProps {
    * Text content for text elements
    */
   text?: string;
+  /**
+   * Image source for image elements
+   */
+  src?: string;
   styles?: {
     color?: string;
     fontSize?: string;
@@ -76,6 +80,19 @@ export const SlideElementDnDItem = ({
             </Tr>
           </Tbody>
         </Table>
+      </ElementWrapper>
+    );
+  }
+
+  if (item.type === "image") {
+    return (
+      <ElementWrapper styles={wrapperStyles} {...baseProps}>
+        <img
+          src={item.src}
+          alt="lesson image"
+          style={{ maxWidth: "100%" }}
+          draggable={false}
+        />
       </ElementWrapper>
     );
   }

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -31,6 +31,7 @@ export default function ElementAttributesPane({
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
   const [text, setText] = useState(element.text || "");
+  const [src, setSrc] = useState(element.src || "");
   const [bgColor, setBgColor] = useState(
     element.wrapperStyles?.bgColor || "#ffffff"
   );
@@ -62,6 +63,7 @@ export default function ElementAttributesPane({
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
     setText(element.text || "");
+    setSrc(element.src || "");
     setBgColor(element.wrapperStyles?.bgColor || "#ffffff");
     setShadow(element.wrapperStyles?.dropShadow || "none");
     setPaddingX(element.wrapperStyles?.paddingX ?? 0);
@@ -92,11 +94,15 @@ export default function ElementAttributesPane({
       updated.text = text;
       updated.styles = { ...element.styles, color, fontSize };
     }
+    if (element.type === "image") {
+      updated.src = src;
+    }
     onChange(updated);
   }, [
     color,
     fontSize,
     text,
+    src,
     bgColor,
     shadow,
     paddingX,
@@ -324,6 +330,36 @@ export default function ElementAttributesPane({
                   w="60px"
                   value={parseInt(fontSize)}
                   onChange={(e) => setFontSize(e.target.value + "px")}
+                />
+              </FormControl>
+            </Stack>
+          </AccordionPanel>
+        </AccordionItem>
+      )}
+
+      {element.type === "image" && (
+        <AccordionItem
+          borderWidth="1px"
+          borderColor="purple.300"
+          borderRadius="md"
+          mb={2}
+        >
+          <h2>
+            <AccordionButton>
+              <Box flex="1" textAlign="left">Image</Box>
+              <AccordionIcon />
+            </AccordionButton>
+          </h2>
+          <AccordionPanel pb={2}>
+            <Stack spacing={2}>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Source
+                </FormLabel>
+                <Input
+                  size="sm"
+                  value={src}
+                  onChange={(e) => setSrc(e.target.value)}
                 />
               </FormControl>
             </Stack>

--- a/insight-fe/src/components/lesson/ImageElement.tsx
+++ b/insight-fe/src/components/lesson/ImageElement.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { Image } from "@chakra-ui/react";
+import ElementWrapper, { ElementWrapperStyles } from "./ElementWrapper";
+
+interface ImageElementProps {
+  src: string;
+  wrapperStyles?: ElementWrapperStyles;
+}
+
+export default function ImageElement({ src, wrapperStyles }: ImageElementProps) {
+  return (
+    <ElementWrapper styles={wrapperStyles} data-testid="image-element">
+      <Image
+        src={src}
+        alt="lesson image"
+        objectFit="contain"
+        draggable={false}
+      />
+    </ElementWrapper>
+  );
+}

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -55,6 +55,7 @@ function reducer(state: LessonState, action: Action): LessonState {
 const AVAILABLE_ELEMENTS = [
   { type: "text", label: "Text" },
   { type: "table", label: "Table" },
+  { type: "image", label: "Image" },
 ];
 
 export default function LessonEditor() {
@@ -151,7 +152,11 @@ export default function LessonEditor() {
                   text: "Sample Text",
                   styles: { color: "#000000", fontSize: "16px" },
                 }
-              : {}),
+              : type === "image"
+                ? {
+                    src: "https://via.placeholder.com/150",
+                  }
+                : {}),
             wrapperStyles: {
               bgColor: "#ffffff",
               dropShadow: "md",

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -11,6 +11,7 @@ import {
   Td,
 } from "@chakra-ui/react";
 import ElementWrapper from "./ElementWrapper";
+import ImageElement from "./ImageElement";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface SlideElementRendererProps {
@@ -46,6 +47,12 @@ export default function SlideElementRenderer({ item }: SlideElementRendererProps
           </Tbody>
         </Table>
       </ElementWrapper>
+    );
+  }
+
+  if (item.type === "image") {
+    return (
+      <ImageElement src={item.src || ""} wrapperStyles={item.wrapperStyles} />
     );
   }
 


### PR DESCRIPTION
## Summary
- allow images in lesson builder
- support image settings in attributes pane
- render images in slide elements
- disable native image dragging to fix DnD bugs

## Testing
- `npm test --prefix insight-be` *(fails: jest not found)*