### PR TITLE
Add quiz support

### DIFF
--- a/insight-be/src/app.module.ts
+++ b/insight-be/src/app.module.ts
@@ -27,6 +27,7 @@ import { ClassModule } from './modules/timbuktu/administrative/class/class.modul
 import { KeyStageModule } from './modules/timbuktu/administrative/key-stage/key-stage.module';
 import { LessonModule } from './modules/timbuktu/administrative/lesson/lesson.module';
 import { MultipleChoiceQuestionModule } from './modules/timbuktu/administrative/multiple-choice-question/multiple-choice-question.module';
+import { QuizModule } from './modules/timbuktu/administrative/quiz/quiz.module';
 import { SubjectModule } from './modules/timbuktu/administrative/subject/subject.module';
 import { YearGroupModule } from './modules/timbuktu/administrative/year-group/year-group.module';
 import { TopicModule } from './modules/timbuktu/administrative/topic/topic.module';
@@ -38,6 +39,7 @@ import { ClassEntity } from './modules/timbuktu/administrative/class/class.entit
 import { KeyStageEntity } from './modules/timbuktu/administrative/key-stage/key-stage.entity';
 import { LessonEntity } from './modules/timbuktu/administrative/lesson/lesson.entity';
 import { MultipleChoiceQuestionEntity } from './modules/timbuktu/administrative/multiple-choice-question/multiple-choice-question.entity';
+import { QuizEntity } from './modules/timbuktu/administrative/quiz/quiz.entity';
 import { SubjectEntity } from './modules/timbuktu/administrative/subject/subject.entity';
 import { YearGroupEntity } from './modules/timbuktu/administrative/year-group/year-group.entity';
 import { TopicEntity } from './modules/timbuktu/administrative/topic/topic.entity';
@@ -75,6 +77,7 @@ import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-table
         YearGroupEntity,
         SubjectEntity,
         LessonEntity,
+        QuizEntity,
         MultipleChoiceQuestionEntity,
         TopicEntity,
         AssignmentSubmissionEntity,
@@ -101,6 +104,7 @@ import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-table
     TopicModule,
     ClassModule,
     LessonModule,
+    QuizModule,
     MultipleChoiceQuestionModule,
     AssignmentModule,
     AssignmentSubmissionModule,

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
@@ -17,6 +17,7 @@ import { YearGroupEntity } from '../year-group/year-group.entity';
 import { TopicEntity } from '../topic/topic.entity';
 import { EducatorProfileDto } from '../../user-profiles/educator-profile/dto/educator-profile.dto';
 import { MultipleChoiceQuestionEntity } from '../multiple-choice-question/multiple-choice-question.entity';
+import { QuizEntity } from '../quiz/quiz.entity';
 
 @ObjectType()
 @Entity('lessons')
@@ -61,4 +62,8 @@ export class LessonEntity extends AbstractBaseEntity {
   @Field(() => [MultipleChoiceQuestionEntity], { nullable: true })
   @OneToMany(() => MultipleChoiceQuestionEntity, (q) => q.lesson)
   multipleChoiceQuestions?: MultipleChoiceQuestionEntity[];
+
+  @Field(() => [QuizEntity], { nullable: true })
+  @OneToMany(() => QuizEntity, (quiz) => quiz.lesson)
+  quizzes?: QuizEntity[];
 }

--- a/insight-be/src/modules/timbuktu/administrative/multiple-choice-question/multiple-choice-question.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/multiple-choice-question/multiple-choice-question.entity.ts
@@ -2,6 +2,7 @@ import { Entity, Column, ManyToOne } from 'typeorm';
 import { ObjectType, Field } from '@nestjs/graphql';
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { LessonEntity } from '../lesson/lesson.entity';
+import { QuizEntity } from '../quiz/quiz.entity';
 
 @ObjectType()
 @Entity('multiple_choice_questions')
@@ -24,4 +25,11 @@ export class MultipleChoiceQuestionEntity extends AbstractBaseEntity {
     onDelete: 'CASCADE',
   })
   lesson: LessonEntity;
+
+  @Field(() => QuizEntity, { nullable: true })
+  @ManyToOne(() => QuizEntity, (quiz) => quiz.multipleChoiceQuestions, {
+    nullable: true,
+    onDelete: 'SET NULL',
+  })
+  quiz?: QuizEntity;
 }

--- a/insight-be/src/modules/timbuktu/administrative/multiple-choice-question/multiple-choice-question.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/multiple-choice-question/multiple-choice-question.inputs.ts
@@ -14,6 +14,9 @@ export class CreateMultipleChoiceQuestionInput extends HasRelationsInput {
 
   @Field(() => ID)
   lessonId: number;
+
+  @Field(() => ID, { nullable: true })
+  quizId?: number;
 }
 
 @InputType()

--- a/insight-be/src/modules/timbuktu/administrative/quiz/quiz.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/quiz/quiz.entity.ts
@@ -1,0 +1,31 @@
+import { Entity, Column, ManyToOne, OneToMany } from 'typeorm';
+import { ObjectType, Field } from '@nestjs/graphql';
+
+import { AbstractBaseEntity } from 'src/common/base.entity';
+import { LessonEntity } from '../lesson/lesson.entity';
+import { MultipleChoiceQuestionEntity } from '../multiple-choice-question/multiple-choice-question.entity';
+
+@ObjectType()
+@Entity('quizzes')
+export class QuizEntity extends AbstractBaseEntity {
+  @Field()
+  @Column()
+  title: string;
+
+  @Field({ nullable: true })
+  @Column({ type: 'text', nullable: true })
+  description?: string;
+
+  /* ---------- relationships ---------- */
+
+  @Field(() => LessonEntity)
+  @ManyToOne(() => LessonEntity, (lesson) => lesson.quizzes, {
+    nullable: false,
+    onDelete: 'CASCADE',
+  })
+  lesson: LessonEntity;
+
+  @Field(() => [MultipleChoiceQuestionEntity], { nullable: true })
+  @OneToMany(() => MultipleChoiceQuestionEntity, (mcq) => mcq.quiz)
+  multipleChoiceQuestions?: MultipleChoiceQuestionEntity[];
+}

--- a/insight-be/src/modules/timbuktu/administrative/quiz/quiz.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/quiz/quiz.inputs.ts
@@ -1,0 +1,20 @@
+import { InputType, Field, ID, PartialType } from '@nestjs/graphql';
+import { HasRelationsInput } from 'src/common/base.inputs';
+
+@InputType()
+export class CreateQuizInput extends HasRelationsInput {
+  @Field()
+  title: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field(() => ID)
+  lessonId: number;
+}
+
+@InputType()
+export class UpdateQuizInput extends PartialType(CreateQuizInput) {
+  @Field(() => ID)
+  id: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/quiz/quiz.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/quiz/quiz.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { QuizEntity } from './quiz.entity';
+import { QuizService } from './quiz.service';
+import { QuizResolver } from './quiz.resolver';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([QuizEntity])],
+  providers: [QuizService, QuizResolver],
+  exports: [QuizService],
+})
+export class QuizModule {}

--- a/insight-be/src/modules/timbuktu/administrative/quiz/quiz.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/quiz/quiz.resolver.ts
@@ -1,0 +1,30 @@
+import { Resolver } from '@nestjs/graphql';
+import { createBaseResolver } from 'src/common/base.resolver';
+import { QuizEntity } from './quiz.entity';
+import { QuizService } from './quiz.service';
+import { CreateQuizInput, UpdateQuizInput } from './quiz.inputs';
+
+const BaseQuizResolver = createBaseResolver<
+  QuizEntity,
+  CreateQuizInput,
+  UpdateQuizInput
+>(QuizEntity, CreateQuizInput, UpdateQuizInput, {
+  queryName: 'Quiz',
+  stableKeyPrefix: 'quiz',
+  enabledOperations: [
+    'findAll',
+    'findOne',
+    'findOneBy',
+    'create',
+    'update',
+    'remove',
+    'search',
+  ],
+});
+
+@Resolver(() => QuizEntity)
+export class QuizResolver extends BaseQuizResolver {
+  constructor(private readonly quizService: QuizService) {
+    super(quizService);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/quiz/quiz.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/quiz/quiz.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+
+import { BaseService } from 'src/common/base.service';
+import { QuizEntity } from './quiz.entity';
+import { CreateQuizInput, UpdateQuizInput } from './quiz.inputs';
+
+@Injectable()
+export class QuizService extends BaseService<
+  QuizEntity,
+  CreateQuizInput,
+  UpdateQuizInput
+> {
+  constructor(
+    @InjectRepository(QuizEntity) quizRepository: Repository<QuizEntity>,
+    @InjectDataSource() dataSource: DataSource,
+  ) {
+    super(quizRepository, dataSource);
+  }
+}


### PR DESCRIPTION
## Summary
- introduce quiz module and entity
- link quizzes to lessons and multiple-choice questions
- extend multiple choice question DTOs with quiz reference
- register quiz module and entity in the app

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module '@nestjs/graphql', etc.)*
