### PR TITLE
Add clone button to lesson builder

### DIFF
--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -4,6 +4,7 @@ import {
   Box,
   Stack,
   Text,
+  Button,
   FormControl,
   FormLabel,
   Input,
@@ -22,11 +23,13 @@ import { useEffect, useState } from "react";
 interface ElementAttributesPaneProps {
   element: SlideElementDnDItemProps;
   onChange: (updated: SlideElementDnDItemProps) => void;
+  onClone?: () => void;
 }
 
 export default function ElementAttributesPane({
   element,
   onChange,
+  onClone,
 }: ElementAttributesPaneProps) {
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
@@ -407,5 +410,12 @@ export default function ElementAttributesPane({
         </AccordionItem>
       )}
     </Accordion>
+    {onClone && (
+      <VStack mt={4} spacing={2} align="stretch">
+        <Button size="sm" colorScheme="teal" onClick={onClone} width="100%">
+          Clone
+        </Button>
+      </VStack>
+    )}
   );
 }

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -127,6 +127,37 @@ export default function LessonEditor() {
     [state.selectedSlideId, dispatch]
   );
 
+  const cloneElement = useCallback(() => {
+    if (!state.selectedSlideId || !state.selectedElementId) return;
+    dispatch({
+      type: "updateSlide",
+      slideId: state.selectedSlideId,
+      updater: (slide) => {
+        const newMap = { ...slide.columnMap } as typeof slide.columnMap;
+        for (const board of slide.boards) {
+          for (const colId of board.orderedColumnIds) {
+            const col = newMap[colId];
+            const idx = col.items.findIndex((i) => i.id === state.selectedElementId);
+            if (idx !== -1) {
+              const orig = col.items[idx];
+              const copy = { ...orig, id: crypto.randomUUID() };
+              newMap[colId] = {
+                ...col,
+                items: [
+                  ...col.items.slice(0, idx + 1),
+                  copy,
+                  ...col.items.slice(idx + 1),
+                ],
+              };
+              return { ...slide, columnMap: newMap };
+            }
+          }
+        }
+        return slide;
+      },
+    });
+  }, [state.selectedSlideId, state.selectedElementId, dispatch]);
+
   const handleDropElement = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
       e.preventDefault();
@@ -334,6 +365,7 @@ export default function LessonEditor() {
                 <ElementAttributesPane
                   element={selectedElement}
                   onChange={updateElement}
+                  onClone={cloneElement}
                 />
               )}
             </Box>


### PR DESCRIPTION
## Summary
- add `onClone` prop to `ElementAttributesPane` and show a **Clone** button
- implement clone logic in `LessonEditor` to duplicate selected element

## Testing
- `npm run lint` *(fails: `next` not found)*