### PR TITLE
Fix image cropping in lesson builder

### DIFF
--- a/insight-fe/src/components/lesson/ElementWrapper.tsx
+++ b/insight-fe/src/components/lesson/ElementWrapper.tsx
@@ -30,6 +30,7 @@ export default function ElementWrapper({ styles, children, ...props }: ElementWr
       borderColor={styles?.borderColor}
       borderWidth={styles?.borderWidth}
       borderRadius={styles?.borderRadius}
+      overflow="hidden"
       borderStyle="solid"
       {...props}
     >


### PR DESCRIPTION
## Summary
- ensure lesson content wrappers crop to their borders

## Testing
- `npm run lint` in `insight-fe` *(fails: next not found)*
- `npm run lint` in `insight-be` *(fails: cannot find @eslint/js)*
