### PR TITLE
Add delete button to lesson builder

### DIFF
--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -24,12 +24,14 @@ interface ElementAttributesPaneProps {
   element: SlideElementDnDItemProps;
   onChange: (updated: SlideElementDnDItemProps) => void;
   onClone?: () => void;
+  onDelete?: () => void;
 }
 
 export default function ElementAttributesPane({
   element,
   onChange,
   onClone,
+  onDelete,
 }: ElementAttributesPaneProps) {
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
@@ -411,12 +413,19 @@ export default function ElementAttributesPane({
         </AccordionItem>
       )}
       </Accordion>
-      {onClone && (
-        <VStack mt={4} spacing={2} align="stretch">
-          <Button size="sm" colorScheme="teal" onClick={onClone} width="100%">
-            Clone
-          </Button>
-        </VStack>
+      {(onClone || onDelete) && (
+        <HStack mt={4} spacing={2} align="stretch">
+          {onClone && (
+            <Button size="sm" colorScheme="teal" onClick={onClone} width="100%">
+              Clone
+            </Button>
+          )}
+          {onDelete && (
+            <Button size="sm" colorScheme="red" onClick={onDelete} width="100%">
+              Delete
+            </Button>
+          )}
+        </HStack>
       )}
     </>
   );

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -158,6 +158,32 @@ export default function LessonEditor() {
     });
   }, [state.selectedSlideId, state.selectedElementId, dispatch]);
 
+  const deleteElement = useCallback(() => {
+    if (!state.selectedSlideId || !state.selectedElementId) return;
+    dispatch({
+      type: "updateSlide",
+      slideId: state.selectedSlideId,
+      updater: (slide) => {
+        const newMap = { ...slide.columnMap } as typeof slide.columnMap;
+        for (const board of slide.boards) {
+          for (const colId of board.orderedColumnIds) {
+            const col = newMap[colId];
+            const idx = col.items.findIndex((i) => i.id === state.selectedElementId);
+            if (idx !== -1) {
+              newMap[colId] = {
+                ...col,
+                items: [...col.items.slice(0, idx), ...col.items.slice(idx + 1)],
+              };
+              return { ...slide, columnMap: newMap };
+            }
+          }
+        }
+        return slide;
+      },
+    });
+    dispatch({ type: "selectElement", id: null });
+  }, [state.selectedSlideId, state.selectedElementId, dispatch]);
+
   const handleDropElement = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
       e.preventDefault();
@@ -366,6 +392,7 @@ export default function LessonEditor() {
                   element={selectedElement}
                   onChange={updateElement}
                   onClone={cloneElement}
+                  onDelete={deleteElement}
                 />
               )}
             </Box>


### PR DESCRIPTION
## Summary
- allow ElementAttributesPane to accept `onDelete`
- add deleteElement callback in LessonEditor
- show Delete button next to Clone in attribute pane

## Testing
- `npm run test` *(fails: jest not found)*