### PR TITLE
Add OpenAI lesson generator

### DIFF
--- a/insight-be/README.md
+++ b/insight-be/README.md
@@ -57,6 +57,10 @@ $ npm run test:e2e
 $ npm run test:cov
 ```
 
+## OpenAI Lesson Generation
+
+Set the `OPENAI_API_KEY` environment variable before starting the backend to enable lesson generation. A new GraphQL mutation `generateLessonFromPrompt(prompt: String!)` returns AI generated lesson data containing `title`, `description` and `content`.
+
 ## Deployment
 
 When you're ready to deploy your NestJS application to production, there are some key steps you can take to ensure it runs as efficiently as possible. Check out the [deployment documentation](https://docs.nestjs.com/deployment) for more information.

--- a/insight-be/src/modules/openai/openai.module.ts
+++ b/insight-be/src/modules/openai/openai.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { OpenAiService } from './openai.service';
+
+@Module({
+  providers: [OpenAiService],
+  exports: [OpenAiService],
+})
+export class OpenAiModule {}

--- a/insight-be/src/modules/openai/openai.service.spec.ts
+++ b/insight-be/src/modules/openai/openai.service.spec.ts
@@ -1,0 +1,23 @@
+import { OpenAiService } from './openai.service';
+
+describe('OpenAiService', () => {
+  let service: OpenAiService;
+
+  beforeEach(() => {
+    service = new OpenAiService();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [
+          { message: { content: JSON.stringify({ title: 't', description: 'd', content: {} }) } },
+        ],
+      }),
+    }) as any;
+  });
+
+  it('calls fetch and parses response', async () => {
+    const lesson = await service.generateLesson('prompt');
+    expect(fetch).toHaveBeenCalled();
+    expect(lesson.title).toBe('t');
+  });
+});

--- a/insight-be/src/modules/openai/openai.service.ts
+++ b/insight-be/src/modules/openai/openai.service.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@nestjs/common';
+import { GeneratedLesson } from './openai.types';
+
+@Injectable()
+export class OpenAiService {
+  private readonly apiKey = process.env.OPENAI_API_KEY ?? '';
+
+  async generateLesson(prompt: string): Promise<GeneratedLesson> {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${this.apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: prompt }],
+      }),
+    });
+
+    if (!res.ok) {
+      throw new Error(`OpenAI request failed with status ${res.status}`);
+    }
+
+    const data = await res.json();
+    const message = data.choices?.[0]?.message?.content ?? '{}';
+    try {
+      return JSON.parse(message) as GeneratedLesson;
+    } catch {
+      return { title: 'Untitled Lesson', description: message, content: null };
+    }
+  }
+}

--- a/insight-be/src/modules/openai/openai.types.ts
+++ b/insight-be/src/modules/openai/openai.types.ts
@@ -1,0 +1,14 @@
+import { Field, ObjectType } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
+
+@ObjectType()
+export class GeneratedLesson {
+  @Field()
+  title: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  content?: Record<string, any> | null;
+}

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { LessonService } from './lesson.service';
 import { LessonResolver } from './lesson.resolver';
 import { LessonEntity } from './lesson.entity';
+import { OpenAiModule } from '../../../openai/openai.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([LessonEntity])],
+  imports: [TypeOrmModule.forFeature([LessonEntity]), OpenAiModule],
   providers: [LessonService, LessonResolver],
   exports: [LessonService],
 })

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.spec.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.spec.ts
@@ -1,0 +1,31 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LessonResolver } from './lesson.resolver';
+import { LessonService } from './lesson.service';
+import { OpenAiService } from '../../../openai/openai.service';
+
+describe('LessonResolver generateLessonFromPrompt', () => {
+  let resolver: LessonResolver;
+  let openAi: OpenAiService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        LessonResolver,
+        { provide: LessonService, useValue: {} },
+        {
+          provide: OpenAiService,
+          useValue: { generateLesson: jest.fn().mockResolvedValue({ title: 'ai' }) },
+        },
+      ],
+    }).compile();
+
+    resolver = module.get<LessonResolver>(LessonResolver);
+    openAi = module.get<OpenAiService>(OpenAiService);
+  });
+
+  it('returns generated lesson', async () => {
+    const result = await resolver.generateLessonFromPrompt('hi');
+    expect(openAi.generateLesson).toHaveBeenCalledWith('hi');
+    expect(result).toEqual({ title: 'ai' });
+  });
+});

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.ts
@@ -1,8 +1,10 @@
-import { Resolver } from '@nestjs/graphql';
+import { Resolver, Mutation, Args } from '@nestjs/graphql';
 import { createBaseResolver } from 'src/common/base.resolver';
 import { CreateLessonInput, UpdateLessonInput } from './lesson.inputs';
 import { LessonEntity } from './lesson.entity';
 import { LessonService } from './lesson.service';
+import { OpenAiService } from '../../../openai/openai.service';
+import { GeneratedLesson } from '../../../openai/openai.types';
 
 const BaseLessonResolver = createBaseResolver<
   LessonEntity,
@@ -24,7 +26,17 @@ const BaseLessonResolver = createBaseResolver<
 
 @Resolver(() => LessonEntity)
 export class LessonResolver extends BaseLessonResolver {
-  constructor(private readonly lessonService: LessonService) {
+  constructor(
+    private readonly lessonService: LessonService,
+    private readonly openAiService: OpenAiService,
+  ) {
     super(lessonService);
+  }
+
+  @Mutation(() => GeneratedLesson)
+  async generateLessonFromPrompt(
+    @Args('prompt') prompt: string,
+  ): Promise<GeneratedLesson> {
+    return this.openAiService.generateLesson(prompt);
   }
 }

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -1,7 +1,49 @@
 "use client";
 
+import { useState } from "react";
+import { Box, Button, Stack, Textarea } from "@chakra-ui/react";
+import { useMutation } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
 import LessonEditor from "@/components/lesson/LessonEditor";
 
+const GENERATE_LESSON = typedGql("mutation")({
+  generateLessonFromPrompt: [
+    { prompt: $("prompt", "String!") },
+    { title: true, description: true, content: true },
+  ],
+} as const);
+
 export const LessonBuilderPageClient = () => {
-  return <LessonEditor />;
+  const [prompt, setPrompt] = useState("");
+  const [initial, setInitial] = useState<any>(null);
+
+  const [generate, { loading }] = useMutation(GENERATE_LESSON, {
+    onCompleted: (data) => {
+      setInitial(data.generateLessonFromPrompt.content?.slides || null);
+    },
+  });
+
+  if (!initial) {
+    return (
+      <Box p={4} maxW="600px">
+        <Stack spacing={4}>
+          <Textarea
+            placeholder="Describe your lesson"
+            value={prompt}
+            onChange={(e) => setPrompt(e.target.value)}
+          />
+          <Button
+            colorScheme="blue"
+            onClick={() => generate({ variables: { prompt } })}
+            isLoading={loading}
+          >
+            Generate Lesson
+          </Button>
+        </Stack>
+      </Box>
+    );
+  }
+
+  return <LessonEditor initialSlides={initial} />;
 };

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -59,15 +59,20 @@ const AVAILABLE_ELEMENTS = [
   { type: "video", label: "Video" },
 ];
 
-export default function LessonEditor() {
-  const initialSlide = {
+export default function LessonEditor({
+  initialSlides,
+}: {
+  initialSlides?: Slide[] | null;
+}) {
+  const defaultSlide = {
     id: crypto.randomUUID(),
     title: "Slide 1",
     ...createInitialBoard(),
   };
+  const slidesInit = initialSlides && initialSlides.length > 0 ? initialSlides : [defaultSlide];
   const [state, dispatch] = useReducer(reducer, {
-    slides: [initialSlide],
-    selectedSlideId: initialSlide.id,
+    slides: slidesInit,
+    selectedSlideId: slidesInit[0].id,
     selectedElementId: null,
     dropIndicator: null,
   });


### PR DESCRIPTION
## Summary
- add `OpenAiService` and module
- wire lesson module to OpenAI service and expose `generateLessonFromPrompt`
- add tests for service and resolver
- update LessonEditor to accept initial slides
- let Lesson Builder page request AI generated lesson
- document new environment variable

## Testing
- `npm --prefix insight-be test` *(fails: jest not found)*