### PR TITLE
Enable dragable column reordering

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -362,6 +362,12 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
             const startIndex = board.orderedColumnIds.findIndex(
               (id) => id === source.data.columnId
             );
+
+            // If the column does not belong to this board, ignore here.
+            if (startIndex === -1) {
+              return;
+            }
+
             const target = location.current.dropTargets[0];
             const indexOfTarget = board.orderedColumnIds.findIndex(
               (id) => id === target.data.columnId

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -117,7 +117,6 @@ export default function SlideElementsBoard({
           columnMap={columnMap}
           orderedColumnIds={orderedColumnIds}
           CardComponent={CardWrapper}
-          enableColumnReorder={false}
           onChange={(b) => onChange(b.columnMap, b.orderedColumnIds)}
           onRemoveColumn={removeColumn}
           externalDropIndicator={dropIndicator}

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import { Button, Stack } from "@chakra-ui/react";
-import { useRef } from "react";
+import { useRef, useEffect } from "react";
 import SlideElementsBoard from "./SlideElementsBoard";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap, ColumnType } from "@/components/DnD/types";
 import { createRegistry } from "@/components/DnD/registry";
 import { ContentCard } from "../layout/Card";
+import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/types";
 
 export interface BoardRow {
   id: string;
@@ -79,6 +82,64 @@ export default function SlideElementsContainer({
       )
     );
   };
+
+  // Handle moving columns between boards
+  useEffect(() => {
+    return monitorForElements({
+      canMonitor: ({ source }) => source.data.instanceId === instanceId.current,
+      onDrop: ({ source, location }) => {
+        if (source.data.type !== "column") return;
+        if (!location.current.dropTargets.length) return;
+
+        const columnId = source.data.columnId as string;
+
+        const startBoardIdx = boards.findIndex((b) =>
+          b.orderedColumnIds.includes(columnId)
+        );
+        if (startBoardIdx === -1) return;
+
+        const target = location.current.dropTargets[0];
+        const targetColumnId = target.data.columnId as string;
+        const destBoardIdx = boards.findIndex((b) =>
+          b.orderedColumnIds.includes(targetColumnId)
+        );
+        if (destBoardIdx === -1) return;
+
+        if (startBoardIdx === destBoardIdx) {
+          // same board - internal logic already handles
+          return;
+        }
+
+        const indexOfTarget = boards[destBoardIdx].orderedColumnIds.findIndex(
+          (id) => id === targetColumnId
+        );
+        const closestEdge: Edge | null = extractClosestEdge(target.data);
+        const insertIndex =
+          closestEdge === "right" ? indexOfTarget + 1 : indexOfTarget;
+
+        const updatedBoards = boards.map((b, idx) => {
+          if (idx === startBoardIdx) {
+            return {
+              ...b,
+              orderedColumnIds: b.orderedColumnIds.filter((id) => id !== columnId),
+            };
+          }
+          if (idx === destBoardIdx) {
+            const ids = Array.from(b.orderedColumnIds);
+            ids.splice(insertIndex, 0, columnId);
+            return { ...b, orderedColumnIds: ids };
+          }
+          return b;
+        });
+
+        const cleanedBoards = updatedBoards.filter(
+          (b) => b.orderedColumnIds.length > 0
+        );
+
+        onChange(columnMap, cleanedBoards);
+      },
+    });
+  }, [boards, columnMap, onChange]);
 
   return (
     <Stack gap={4}>


### PR DESCRIPTION
## Summary
- allow reordering columns in SlideElementsBoard
- handle dropping columns across boards in SlideElementsContainer
- skip column reordering for external drags in DnDBoardMain
- remove empty boards after moving the last column out

## Testing
- `npm -C insight-fe run lint` *(fails: `next` not found)*
- `npm -C insight-fe run build` *(fails: `next` not found)*