### PR TITLE
Add delete button in lesson builder

### DIFF
--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -16,7 +16,9 @@ import {
   AccordionIcon,
   HStack,
   VStack,
+  Icon,
 } from "@chakra-ui/react";
+import { Trash2 } from "lucide-react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { useEffect, useState } from "react";
 
@@ -421,7 +423,13 @@ export default function ElementAttributesPane({
             </Button>
           )}
           {onDelete && (
-            <Button size="sm" colorScheme="red" onClick={onDelete} width="100%">
+            <Button
+              size="sm"
+              colorScheme="red"
+              onClick={onDelete}
+              width="100%"
+              leftIcon={<Icon as={Trash2} boxSize={4} />}
+            >
               Delete
             </Button>
           )}


### PR DESCRIPTION
## Summary
- in lesson editor attributes pane, show a delete button alongside clone
- include a trash icon in the delete action

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*