### PR TITLE
Remove text from lesson builder column headers

### DIFF
--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -53,7 +53,7 @@ export default function SlideElementsBoard({
     const id = `col-${crypto.randomUUID()}` as const;
 
     const newColumn: ColumnType<SlideElementDnDItemProps> = {
-      title: `Column ${idx + 1}`,
+      title: "",
       columnId: id,
       styles: {
         container: { border: `2px dashed ${color}`, width: "100%" },

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -55,7 +55,7 @@ export default function SlideElementsContainer({
     const boardId = crypto.randomUUID();
 
     const newColumn: ColumnType<SlideElementDnDItemProps> = {
-      title: `Column 1`,
+      title: "",
       columnId,
       styles: {
         container: { border: `2px dashed ${color}`, width: "100%" },

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -40,7 +40,7 @@ export const createInitialBoard = (): {
   return {
     columnMap: {
       [columnId]: {
-        title: "Column 1",
+        title: "",
         columnId,
         styles: {
           container: { border: "2px dashed red", width: "100%" },


### PR DESCRIPTION
## Summary
- clear default column titles in Lesson Builder components

## Testing
- `npm run lint` *(fails: next not found)*