### PR TITLE
Add background opacity support

### DIFF
--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -26,6 +26,7 @@ interface ColumnAttributesPaneProps {
 
 export default function ColumnAttributesPane({ column, onChange }: ColumnAttributesPaneProps) {
   const [bgColor, setBgColor] = useState(column.wrapperStyles?.bgColor || "#ffffff");
+  const [bgOpacity, setBgOpacity] = useState(column.wrapperStyles?.bgOpacity ?? 0);
   const [shadow, setShadow] = useState(column.wrapperStyles?.dropShadow || "none");
   const [paddingX, setPaddingX] = useState(column.wrapperStyles?.paddingX ?? 0);
   const [paddingY, setPaddingY] = useState(column.wrapperStyles?.paddingY ?? 0);
@@ -37,6 +38,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
 
   useEffect(() => {
     setBgColor(column.wrapperStyles?.bgColor || "#ffffff");
+    setBgOpacity(column.wrapperStyles?.bgOpacity ?? 0);
     setShadow(column.wrapperStyles?.dropShadow || "none");
     setPaddingX(column.wrapperStyles?.paddingX ?? 0);
     setPaddingY(column.wrapperStyles?.paddingY ?? 0);
@@ -52,6 +54,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
       ...column,
       wrapperStyles: {
         bgColor,
+        bgOpacity,
         dropShadow: shadow,
         paddingX,
         paddingY,
@@ -62,7 +65,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
         borderRadius,
       },
     });
-  }, [bgColor, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius]);
+  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius]);
 
   return (
     <Accordion allowMultiple>
@@ -77,7 +80,14 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
           <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
               <FormLabel mb="0" fontSize="sm" w="40%">Background</FormLabel>
-              <Input type="color" value={bgColor} onChange={(e) => setBgColor(e.target.value)} />
+              <Input
+                type="color"
+                value={bgColor}
+                onChange={(e) => {
+                  setBgColor(e.target.value);
+                  setBgOpacity(1);
+                }}
+              />
             </FormControl>
             <FormControl display="flex" alignItems="center">
               <FormLabel mb="0" fontSize="sm" w="40%">Shadow</FormLabel>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -43,6 +43,9 @@ export default function ElementAttributesPane({
   const [bgColor, setBgColor] = useState(
     element.wrapperStyles?.bgColor || "#ffffff"
   );
+  const [bgOpacity, setBgOpacity] = useState(
+    element.wrapperStyles?.bgOpacity ?? 0
+  );
   const [shadow, setShadow] = useState(
     element.wrapperStyles?.dropShadow || "none"
   );
@@ -74,6 +77,7 @@ export default function ElementAttributesPane({
     setSrc(element.src || "");
     setUrl(element.url || "");
     setBgColor(element.wrapperStyles?.bgColor || "#ffffff");
+    setBgOpacity(element.wrapperStyles?.bgOpacity ?? 0);
     setShadow(element.wrapperStyles?.dropShadow || "none");
     setPaddingX(element.wrapperStyles?.paddingX ?? 0);
     setPaddingY(element.wrapperStyles?.paddingY ?? 0);
@@ -89,6 +93,7 @@ export default function ElementAttributesPane({
       ...element,
       wrapperStyles: {
         bgColor,
+        bgOpacity,
         dropShadow: shadow,
         paddingX,
         paddingY,
@@ -117,6 +122,7 @@ export default function ElementAttributesPane({
     src,
     url,
     bgColor,
+    bgOpacity,
     shadow,
     paddingX,
     paddingY,
@@ -153,7 +159,10 @@ export default function ElementAttributesPane({
               <Input
                 type="color"
                 value={bgColor}
-                onChange={(e) => setBgColor(e.target.value)}
+                onChange={(e) => {
+                  setBgColor(e.target.value);
+                  setBgOpacity(1);
+                }}
               />
             </FormControl>
             <FormControl display="flex" alignItems="center">

--- a/insight-fe/src/components/lesson/ElementWrapper.tsx
+++ b/insight-fe/src/components/lesson/ElementWrapper.tsx
@@ -3,6 +3,8 @@ import React from "react";
 
 export interface ElementWrapperStyles {
   bgColor?: string;
+  /** Opacity value between 0 and 1 */
+  bgOpacity?: number;
   dropShadow?: string;
   paddingX?: number;
   paddingY?: number;
@@ -19,9 +21,22 @@ interface ElementWrapperProps extends BoxProps {
 }
 
 export default function ElementWrapper({ styles, children, ...props }: ElementWrapperProps) {
+  const hexToRgba = (hex: string, opacity: number) => {
+    const sanitized = hex.replace('#', '');
+    const bigint = parseInt(sanitized, 16);
+    const r = (bigint >> 16) & 255;
+    const g = (bigint >> 8) & 255;
+    const b = bigint & 255;
+    return `rgba(${r}, ${g}, ${b}, ${opacity})`;
+  };
+
+  const bgColor = styles?.bgColor
+    ? hexToRgba(styles.bgColor, styles.bgOpacity ?? 0)
+    : undefined;
+
   return (
     <Box
-      bg={styles?.bgColor || "white"}
+      bg={bgColor}
       boxShadow={styles?.dropShadow}
       px={styles?.paddingX}
       py={styles?.paddingY}

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -246,6 +246,7 @@ export default function LessonEditor() {
               : {}),
             wrapperStyles: {
               bgColor: "#ffffff",
+              bgOpacity: 0,
               dropShadow: "none",
               paddingX: 0,
               paddingY: 0,

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -71,6 +71,7 @@ export default function SlideElementsBoard({
       },
       wrapperStyles: {
         bgColor: "#ffffff",
+        bgOpacity: 0,
         dropShadow: "none",
         paddingX: 0,
         paddingY: 0,

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -69,6 +69,7 @@ export default function SlideElementsContainer({
       },
       wrapperStyles: {
         bgColor: "#ffffff",
+        bgOpacity: 0,
         dropShadow: "none",
         paddingX: 0,
         paddingY: 0,

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -48,6 +48,7 @@ export const createInitialBoard = (): {
         },
         wrapperStyles: {
           bgColor: "#ffffff",
+          bgOpacity: 0,
           dropShadow: "none",
           paddingX: 0,
           paddingY: 0,


### PR DESCRIPTION
## Summary
- allow ElementWrapper styles to include `bgOpacity`
- manage new `bgOpacity` state in attribute panes
- default new elements and columns to zero background opacity
- set opacity to 1 when a background color is chosen

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npx tsc --noEmit` *(fails: Cannot find module '@chakra-ui/react')*