### PR TITLE
Enable board wrapper customization

### DIFF
--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -1,0 +1,163 @@
+"use client";
+
+import {
+  Box,
+  Stack,
+  Text,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Accordion,
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  HStack,
+} from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import type { BoardRow } from "./SlideElementsContainer";
+
+interface BoardAttributesPaneProps {
+  board: BoardRow;
+  onChange: (updated: BoardRow) => void;
+}
+
+export default function BoardAttributesPane({ board, onChange }: BoardAttributesPaneProps) {
+  const [bgColor, setBgColor] = useState(board.wrapperStyles?.bgColor || "#ffffff");
+  const [bgOpacity, setBgOpacity] = useState(board.wrapperStyles?.bgOpacity ?? 0);
+  const [shadow, setShadow] = useState(board.wrapperStyles?.dropShadow || "none");
+  const [paddingX, setPaddingX] = useState(board.wrapperStyles?.paddingX ?? 0);
+  const [paddingY, setPaddingY] = useState(board.wrapperStyles?.paddingY ?? 0);
+  const [marginX, setMarginX] = useState(board.wrapperStyles?.marginX ?? 0);
+  const [marginY, setMarginY] = useState(board.wrapperStyles?.marginY ?? 0);
+  const [borderColor, setBorderColor] = useState(board.wrapperStyles?.borderColor || "#000000");
+  const [borderWidth, setBorderWidth] = useState(board.wrapperStyles?.borderWidth ?? 0);
+  const [borderRadius, setBorderRadius] = useState(board.wrapperStyles?.borderRadius || "none");
+
+  useEffect(() => {
+    setBgColor(board.wrapperStyles?.bgColor || "#ffffff");
+    setBgOpacity(board.wrapperStyles?.bgOpacity ?? 0);
+    setShadow(board.wrapperStyles?.dropShadow || "none");
+    setPaddingX(board.wrapperStyles?.paddingX ?? 0);
+    setPaddingY(board.wrapperStyles?.paddingY ?? 0);
+    setMarginX(board.wrapperStyles?.marginX ?? 0);
+    setMarginY(board.wrapperStyles?.marginY ?? 0);
+    setBorderColor(board.wrapperStyles?.borderColor || "#000000");
+    setBorderWidth(board.wrapperStyles?.borderWidth ?? 0);
+    setBorderRadius(board.wrapperStyles?.borderRadius || "none");
+  }, [board.id]);
+
+  useEffect(() => {
+    onChange({
+      ...board,
+      wrapperStyles: {
+        bgColor,
+        bgOpacity,
+        dropShadow: shadow,
+        paddingX,
+        paddingY,
+        marginX,
+        marginY,
+        borderColor,
+        borderWidth,
+        borderRadius,
+      },
+    });
+  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius]);
+
+  return (
+    <Accordion allowMultiple>
+      <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">Wrapper</Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Background</FormLabel>
+              <Input
+                type="color"
+                value={bgColor}
+                onChange={(e) => {
+                  setBgColor(e.target.value);
+                  setBgOpacity(1);
+                }}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Shadow</FormLabel>
+              <Select size="sm" value={shadow} onChange={(e) => setShadow(e.target.value)}>
+                <option value="none">None</option>
+                <option value="sm">Small</option>
+                <option value="md">Medium</option>
+                <option value="lg">Large</option>
+                <option value="xl">XL</option>
+                <option value="2xl">2XL</option>
+              </Select>
+            </FormControl>
+            <Box>
+              <Text fontSize="sm" mb={1}>Padding</Text>
+              <HStack spacing={2}>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">Horiz.</FormLabel>
+                  <Input size="sm" type="number" w="60px" value={paddingX} onChange={(e) => setPaddingX(parseInt(e.target.value))} />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">Vert.</FormLabel>
+                  <Input size="sm" type="number" w="60px" value={paddingY} onChange={(e) => setPaddingY(parseInt(e.target.value))} />
+                </FormControl>
+              </HStack>
+            </Box>
+            <Box>
+              <Text fontSize="sm" mb={1}>Margin</Text>
+              <HStack spacing={2}>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">Horiz.</FormLabel>
+                  <Input size="sm" type="number" w="60px" value={marginX} onChange={(e) => setMarginX(parseInt(e.target.value))} />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">Vert.</FormLabel>
+                  <Input size="sm" type="number" w="60px" value={marginY} onChange={(e) => setMarginY(parseInt(e.target.value))} />
+                </FormControl>
+              </HStack>
+            </Box>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+      <AccordionItem borderWidth="1px" borderColor="green.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">Borders</Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
+              <Input type="color" value={borderColor} onChange={(e) => setBorderColor(e.target.value)} />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Width</FormLabel>
+              <Input size="sm" type="number" w="60px" value={borderWidth} onChange={(e) => setBorderWidth(parseInt(e.target.value))} />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Radius</FormLabel>
+              <Select size="sm" value={borderRadius} onChange={(e) => setBorderRadius(e.target.value)}>
+                <option value="none">None</option>
+                <option value="sm">Small</option>
+                <option value="md">Medium</option>
+                <option value="lg">Large</option>
+                <option value="50%">Circular</option>
+              </Select>
+            </FormControl>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+    </Accordion>
+  );
+}

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Button, HStack, Text } from "@chakra-ui/react";
+import { Button, HStack } from "@chakra-ui/react";
 import { useState } from "react";
 import { DnDBoardMain } from "@/components/DnD/DnDBoardMain";
 import {
@@ -10,10 +10,13 @@ import {
 import { ColumnType, ColumnMap } from "@/components/DnD/types";
 import { createRegistry } from "@/components/DnD/registry";
 import { ContentCard } from "../layout/Card";
+import ElementWrapper, { ElementWrapperStyles } from "./ElementWrapper";
 import { useCallback } from "react";
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 
 interface SlideElementsBoardProps {
+  boardId: string;
+  wrapperStyles?: ElementWrapperStyles;
   columnMap: ColumnMap<SlideElementDnDItemProps>;
   orderedColumnIds: string[];
   onChange: (
@@ -28,6 +31,8 @@ interface SlideElementsBoardProps {
   onRemoveBoard?: () => void;
   selectedColumnId?: string | null;
   onSelectColumn?: (id: string) => void;
+  isSelected?: boolean;
+  onSelectBoard?: () => void;
 }
 
 const COLUMN_COLORS = [
@@ -40,6 +45,8 @@ const COLUMN_COLORS = [
 ];
 
 export default function SlideElementsBoard({
+  boardId,
+  wrapperStyles,
   columnMap,
   orderedColumnIds,
   onChange,
@@ -51,6 +58,8 @@ export default function SlideElementsBoard({
   onRemoveBoard,
   selectedColumnId,
   onSelectColumn,
+  isSelected,
+  onSelectBoard,
 }: SlideElementsBoardProps) {
   /* ------------------------------------------------------------------ */
   /*  Column helpers                                                     */
@@ -148,26 +157,37 @@ export default function SlideElementsBoard({
             Delete Container
           </Button>
         )}
+        {onSelectBoard && (
+          <Button size="sm" onClick={onSelectBoard}>
+            Edit Container
+          </Button>
+        )}
         <Button size="sm" colorScheme="teal" onClick={addColumn}>
           Add Column
         </Button>
       </HStack>
-
-      <ContentCard height={700}>
-        <DnDBoardMain<SlideElementDnDItemProps>
-          controlled
-          columnMap={columnMap}
-          orderedColumnIds={orderedColumnIds}
-          CardComponent={CardWrapper}
-          onChange={(b) => onChange(b.columnMap, b.orderedColumnIds)}
-          onRemoveColumn={removeColumn}
-          externalDropIndicator={dropIndicator}
-          selectedColumnId={selectedColumnId}
-          onSelectColumn={onSelectColumn}
-          instanceId={instanceId}
-          registry={registry}
-        />
-      </ContentCard>
+      <ElementWrapper
+        styles={wrapperStyles}
+        borderColor={isSelected ? "blue.300" : undefined}
+        borderWidth={isSelected ? 2 : undefined}
+        data-board-id={boardId}
+      >
+        <ContentCard height={700}>
+          <DnDBoardMain<SlideElementDnDItemProps>
+            controlled
+            columnMap={columnMap}
+            orderedColumnIds={orderedColumnIds}
+            CardComponent={CardWrapper}
+            onChange={(b) => onChange(b.columnMap, b.orderedColumnIds)}
+            onRemoveColumn={removeColumn}
+            externalDropIndicator={dropIndicator}
+            selectedColumnId={selectedColumnId}
+            onSelectColumn={onSelectColumn}
+            instanceId={instanceId}
+            registry={registry}
+          />
+        </ContentCard>
+      </ElementWrapper>
       <ConfirmationModal
         isOpen={columnIdToDelete !== null}
         onClose={() => setColumnIdToDelete(null)}

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -6,7 +6,7 @@ import SlideElementsBoard from "./SlideElementsBoard";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap, ColumnType } from "@/components/DnD/types";
 import { createRegistry } from "@/components/DnD/registry";
-import { ContentCard } from "../layout/Card";
+import type { ElementWrapperStyles } from "./ElementWrapper";
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
 import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
@@ -15,6 +15,7 @@ import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/types";
 export interface BoardRow {
   id: string;
   orderedColumnIds: string[];
+  wrapperStyles?: ElementWrapperStyles;
 }
 
 interface SlideElementsContainerProps {
@@ -29,6 +30,8 @@ interface SlideElementsContainerProps {
   dropIndicator?: { columnId: string; index: number } | null;
   selectedColumnId?: string | null;
   onSelectColumn?: (id: string) => void;
+  selectedBoardId?: string | null;
+  onSelectBoard?: (id: string) => void;
 }
 
 const COLUMN_COLORS = [
@@ -49,6 +52,8 @@ export default function SlideElementsContainer({
   dropIndicator,
   selectedColumnId,
   onSelectColumn,
+  selectedBoardId,
+  onSelectBoard,
 }: SlideElementsContainerProps) {
   const instanceId = useRef(Symbol("slide-container"));
   const registry = useRef(createRegistry());
@@ -84,7 +89,22 @@ export default function SlideElementsContainer({
 
     onChange({ ...columnMap, [columnId]: newColumn }, [
       ...boards,
-      { id: boardId, orderedColumnIds: [columnId] },
+      {
+        id: boardId,
+        orderedColumnIds: [columnId],
+        wrapperStyles: {
+          bgColor: "#ffffff",
+          bgOpacity: 0,
+          dropShadow: "none",
+          paddingX: 0,
+          paddingY: 0,
+          marginX: 0,
+          marginY: 0,
+          borderColor: "#000000",
+          borderWidth: 0,
+          borderRadius: "none",
+        },
+      },
     ]);
   };
 
@@ -204,21 +224,24 @@ export default function SlideElementsContainer({
         Add Container
       </Button>
       {boards.map((b) => (
-        <ContentCard minHeight={400} key={b.id}>
-          <SlideElementsBoard
-            columnMap={columnMap}
-            orderedColumnIds={b.orderedColumnIds}
-            onChange={(map, ids) => updateBoard(b.id, map, ids)}
-            registry={registry.current}
-            instanceId={instanceId.current}
-            selectedElementId={selectedElementId}
-            onSelectElement={onSelectElement}
-            dropIndicator={dropIndicator}
-            onRemoveBoard={() => removeBoard(b.id)}
-            selectedColumnId={selectedColumnId}
-            onSelectColumn={onSelectColumn}
-          />
-        </ContentCard>
+        <SlideElementsBoard
+          key={b.id}
+          boardId={b.id}
+          wrapperStyles={b.wrapperStyles}
+          columnMap={columnMap}
+          orderedColumnIds={b.orderedColumnIds}
+          onChange={(map, ids) => updateBoard(b.id, map, ids)}
+          registry={registry.current}
+          instanceId={instanceId.current}
+          selectedElementId={selectedElementId}
+          onSelectElement={onSelectElement}
+          dropIndicator={dropIndicator}
+          onRemoveBoard={() => removeBoard(b.id)}
+          selectedColumnId={selectedColumnId}
+          onSelectColumn={onSelectColumn}
+          isSelected={selectedBoardId === b.id}
+          onSelectBoard={() => onSelectBoard?.(b.id)}
+        />
       ))}
       <ConfirmationModal
         isOpen={boardIdToDelete !== null}

--- a/insight-fe/src/components/lesson/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/SlidePreview.tsx
@@ -16,28 +16,29 @@ export default function SlidePreview({ columnMap, boards }: SlidePreviewProps) {
   return (
     <Stack gap={4}>
       {boards.map((board) => (
-        <Box
-          key={board.id}
-          display="grid"
-          gridTemplateColumns={`repeat(${board.orderedColumnIds.length}, 1fr)`}
-          gap={4}
-        >
-          {board.orderedColumnIds.map((colId) => {
-            const column = columnMap[colId];
-            if (!column) return null;
-            return (
-              <ElementWrapper key={colId} styles={column.wrapperStyles} data-column-id={colId}>
-                <Stack gap={2}>
-                  {column.items.map((item) => (
-                    <Box key={item.id} mb={2} data-card-id={item.id}>
-                      <SlideElementRenderer item={item} />
-                    </Box>
-                  ))}
-                </Stack>
-              </ElementWrapper>
-            );
-          })}
-        </Box>
+        <ElementWrapper key={board.id} styles={board.wrapperStyles} data-board-id={board.id}>
+          <Box
+            display="grid"
+            gridTemplateColumns={`repeat(${board.orderedColumnIds.length}, 1fr)`}
+            gap={4}
+          >
+            {board.orderedColumnIds.map((colId) => {
+              const column = columnMap[colId];
+              if (!column) return null;
+              return (
+                <ElementWrapper key={colId} styles={column.wrapperStyles} data-column-id={colId}>
+                  <Stack gap={2}>
+                    {column.items.map((item) => (
+                      <Box key={item.id} mb={2} data-card-id={item.id}>
+                        <SlideElementRenderer item={item} />
+                      </Box>
+                    ))}
+                  </Stack>
+                </ElementWrapper>
+              );
+            })}
+          </Box>
+        </ElementWrapper>
       ))}
     </Stack>
   );

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Box, Button, Stack } from "@chakra-ui/react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap } from "@/components/DnD/types";
+import type { ElementWrapperStyles } from "./ElementWrapper";
 import { DropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box";
 import {
   draggable,
@@ -22,6 +23,7 @@ import { getReorderDestinationIndex } from "@atlaskit/pragmatic-drag-and-drop-hi
 export interface SlideBoard {
   id: string;
   orderedColumnIds: string[];
+  wrapperStyles?: ElementWrapperStyles;
 }
 
 export interface Slide {
@@ -61,7 +63,24 @@ export const createInitialBoard = (): {
         items: [],
       },
     },
-    boards: [{ id: boardId, orderedColumnIds: [columnId] }],
+    boards: [
+      {
+        id: boardId,
+        orderedColumnIds: [columnId],
+        wrapperStyles: {
+          bgColor: "#ffffff",
+          bgOpacity: 0,
+          dropShadow: "none",
+          paddingX: 0,
+          paddingY: 0,
+          marginX: 0,
+          marginY: 0,
+          borderColor: "#000000",
+          borderWidth: 0,
+          borderRadius: "none",
+        },
+      },
+    ],
   };
 };
 


### PR DESCRIPTION
## Summary
- add wrapper styles to SlideBoard and BoardRow structures
- support editing board attributes through a new panel
- highlight and select boards in Lesson Editor
- render board wrappers in preview and editor

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68381ac6718083268ee07d30f0146774