### PR TITLE
Add configurable spacing for lesson editor

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -89,6 +89,8 @@ export interface DnDBoardMainProps<TCard extends BaseCardDnD> {
   externalDropIndicator?: { columnId: string; index: number } | null;
   selectedColumnId?: string | null;
   onSelectColumn?: (columnId: string) => void;
+  /** Gap between columns */
+  columnSpacing?: number;
   /** Optional shared instance id for cross-board drag */
   instanceId?: symbol;
   /** Optional shared registry for cross-board drag */
@@ -119,6 +121,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   onSelectColumn,
   instanceId: instanceIdProp,
   registry: registryProp,
+  columnSpacing = 2,
   controlled = false,
 }: DnDBoardMainProps<TCard>) => {
   /* -----------------------------------------------------------------------
@@ -600,7 +603,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
         flex={1}
         justifyContent="space-between"
       >
-        <Board>
+        <Board spacing={columnSpacing}>
           {renderedBoard.orderedColumnIds.map((columnId) => (
             <Column
               key={columnId}

--- a/insight-fe/src/components/DnD/board.tsx
+++ b/insight-fe/src/components/DnD/board.tsx
@@ -5,10 +5,12 @@ import { useBoardContext } from "./BoardContext";
 
 type BoardProps = {
   children: ReactNode;
+  /** Gap between columns */
+  spacing?: number;
 };
 
 const Board = forwardRef<HTMLDivElement, BoardProps>(
-  ({ children }: BoardProps, ref) => {
+  ({ children, spacing = 2 }: BoardProps, ref) => {
     const { instanceId } = useBoardContext();
 
     useEffect(() => {
@@ -23,7 +25,7 @@ const Board = forwardRef<HTMLDivElement, BoardProps>(
         justifyContent="center"
         flexDirection="row"
         ref={ref}
-        gap={2}
+        gap={spacing}
         flex={1}
       >
         {children}

--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -359,6 +359,7 @@ function ColumnBase<TCard extends BaseCardDnD>({
               <Stack
                 flexGrow={1}
                 sx={{ ...cardListStyles, ...(column.styles?.cardList ?? {}) }}
+                spacing={column.spacing ?? 2}
               >
                 {isLoading ? (
                   <LoadingSpinnerCard />

--- a/insight-fe/src/components/DnD/types.ts
+++ b/insight-fe/src/components/DnD/types.ts
@@ -39,6 +39,8 @@ export type ColumnType<TCard extends BaseCardDnD> = {
   items: TCard[];
   styles?: ColumnStyles;
   wrapperStyles?: ElementWrapperStyles;
+  /** Gap between elements in this column */
+  spacing?: number;
   sortBy?: (item: TCard) => string;
   sortDirection?: "asc" | "desc" | "none";
 };

--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -35,6 +35,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
   const [borderColor, setBorderColor] = useState(column.wrapperStyles?.borderColor || "#000000");
   const [borderWidth, setBorderWidth] = useState(column.wrapperStyles?.borderWidth ?? 0);
   const [borderRadius, setBorderRadius] = useState(column.wrapperStyles?.borderRadius || "none");
+  const [spacing, setSpacing] = useState(column.spacing ?? 2);
 
   useEffect(() => {
     setBgColor(column.wrapperStyles?.bgColor || "#ffffff");
@@ -47,6 +48,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
     setBorderColor(column.wrapperStyles?.borderColor || "#000000");
     setBorderWidth(column.wrapperStyles?.borderWidth ?? 0);
     setBorderRadius(column.wrapperStyles?.borderRadius || "none");
+    setSpacing(column.spacing ?? 2);
   }, [column.columnId]);
 
   useEffect(() => {
@@ -64,8 +66,9 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
         borderWidth,
         borderRadius,
       },
+      spacing,
     });
-  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius]);
+  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
 
   return (
     <Accordion allowMultiple>
@@ -126,6 +129,10 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
                 </FormControl>
               </HStack>
             </Box>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Spacing</FormLabel>
+              <Input size="sm" type="number" w="60px" value={spacing} onChange={(e) => setSpacing(parseInt(e.target.value))} />
+            </FormControl>
           </Stack>
         </AccordionPanel>
       </AccordionItem>

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Button, HStack, Text } from "@chakra-ui/react";
+import { Box, Button, HStack, Input } from "@chakra-ui/react";
 import { useState } from "react";
 import { DnDBoardMain } from "@/components/DnD/DnDBoardMain";
 import {
@@ -22,12 +22,14 @@ interface SlideElementsBoardProps {
   ) => void;
   registry: ReturnType<typeof createRegistry>;
   instanceId: symbol;
+  spacing?: number;
   selectedElementId?: string | null;
   onSelectElement?: (id: string) => void;
   dropIndicator?: { columnId: string; index: number } | null;
   onRemoveBoard?: () => void;
   selectedColumnId?: string | null;
   onSelectColumn?: (id: string) => void;
+  onSpacingChange?: (value: number) => void;
 }
 
 const COLUMN_COLORS = [
@@ -45,12 +47,14 @@ export default function SlideElementsBoard({
   onChange,
   registry,
   instanceId,
+  spacing = 2,
   selectedElementId,
   onSelectElement,
   dropIndicator,
   onRemoveBoard,
   selectedColumnId,
   onSelectColumn,
+  onSpacingChange,
 }: SlideElementsBoardProps) {
   /* ------------------------------------------------------------------ */
   /*  Column helpers                                                     */
@@ -148,9 +152,20 @@ export default function SlideElementsBoard({
             Delete Container
           </Button>
         )}
-        <Button size="sm" colorScheme="teal" onClick={addColumn}>
-          Add Column
-        </Button>
+        <HStack>
+          <Button size="sm" colorScheme="teal" onClick={addColumn}>
+            Add Column
+          </Button>
+          {onSpacingChange && (
+            <Input
+              size="xs"
+              type="number"
+              width="60px"
+              value={spacing}
+              onChange={(e) => onSpacingChange(parseInt(e.target.value))}
+            />
+          )}
+        </HStack>
       </HStack>
 
       <ContentCard height={700}>
@@ -159,6 +174,7 @@ export default function SlideElementsBoard({
           columnMap={columnMap}
           orderedColumnIds={orderedColumnIds}
           CardComponent={CardWrapper}
+          columnSpacing={spacing}
           onChange={(b) => onChange(b.columnMap, b.orderedColumnIds)}
           onRemoveColumn={removeColumn}
           externalDropIndicator={dropIndicator}

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -15,6 +15,8 @@ import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/types";
 export interface BoardRow {
   id: string;
   orderedColumnIds: string[];
+  /** Gap between columns in this container */
+  spacing?: number;
 }
 
 interface SlideElementsContainerProps {
@@ -84,19 +86,20 @@ export default function SlideElementsContainer({
 
     onChange({ ...columnMap, [columnId]: newColumn }, [
       ...boards,
-      { id: boardId, orderedColumnIds: [columnId] },
+      { id: boardId, orderedColumnIds: [columnId], spacing: 2 },
     ]);
   };
 
   const updateBoard = (
     boardId: string,
     map: ColumnMap<SlideElementDnDItemProps>,
-    ids: string[]
+    ids: string[],
+    spacing?: number
   ) => {
     onChange(
       map,
       boards.map((b) =>
-        b.id === boardId ? { ...b, orderedColumnIds: ids } : b
+        b.id === boardId ? { ...b, orderedColumnIds: ids, spacing } : b
       )
     );
   };
@@ -208,15 +211,17 @@ export default function SlideElementsContainer({
           <SlideElementsBoard
             columnMap={columnMap}
             orderedColumnIds={b.orderedColumnIds}
-            onChange={(map, ids) => updateBoard(b.id, map, ids)}
+            onChange={(map, ids) => updateBoard(b.id, map, ids, b.spacing)}
             registry={registry.current}
             instanceId={instanceId.current}
+            spacing={b.spacing}
             selectedElementId={selectedElementId}
             onSelectElement={onSelectElement}
             dropIndicator={dropIndicator}
             onRemoveBoard={() => removeBoard(b.id)}
             selectedColumnId={selectedColumnId}
             onSelectColumn={onSelectColumn}
+            onSpacingChange={(val) => updateBoard(b.id, columnMap, b.orderedColumnIds, val)}
           />
         </ContentCard>
       ))}

--- a/insight-fe/src/components/lesson/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/SlidePreview.tsx
@@ -20,14 +20,14 @@ export default function SlidePreview({ columnMap, boards }: SlidePreviewProps) {
           key={board.id}
           display="grid"
           gridTemplateColumns={`repeat(${board.orderedColumnIds.length}, 1fr)`}
-          gap={4}
+          gap={board.spacing ?? 4}
         >
           {board.orderedColumnIds.map((colId) => {
             const column = columnMap[colId];
             if (!column) return null;
             return (
               <ElementWrapper key={colId} styles={column.wrapperStyles} data-column-id={colId}>
-                <Stack gap={2}>
+                <Stack gap={column.spacing ?? 2}>
                   {column.items.map((item) => (
                     <Box key={item.id} mb={2} data-card-id={item.id}>
                       <SlideElementRenderer item={item} />

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -58,10 +58,11 @@ export const createInitialBoard = (): {
           borderWidth: 0,
           borderRadius: "none",
         },
+        spacing: 2,
         items: [],
       },
     },
-    boards: [{ id: boardId, orderedColumnIds: [columnId] }],
+    boards: [{ id: boardId, orderedColumnIds: [columnId], spacing: 2 }],
   };
 };
 


### PR DESCRIPTION
## Summary
- allow specifying spacing on columns and containers
- add UI inputs for spacing
- use spacing properties in board and column layouts

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683acce107a8832685e6534d96664a77