### PR TITLE
Add configurable quiz element to lesson editor

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -18,6 +18,23 @@ export interface SlideElementDnDItemProps {
    * Image source for image elements
    */
   src?: string;
+  /**
+   * Quiz title when type is "quiz"
+   */
+  title?: string;
+  /**
+   * Quiz description when type is "quiz"
+   */
+  description?: string;
+  /**
+   * Quiz questions when type is "quiz"
+   */
+  questions?: {
+    id: string;
+    text: string;
+    options: string[];
+    correctAnswer: string;
+  }[];
   styles?: {
     color?: string;
     fontSize?: string;
@@ -97,6 +114,14 @@ export const SlideElementDnDItem = ({
           style={{ maxWidth: "100%" }}
           draggable={false}
         />
+      </ElementWrapper>
+    );
+  }
+
+  if (item.type === "quiz") {
+    return (
+      <ElementWrapper styles={wrapperStyles} {...baseProps}>
+        <Text fontWeight="bold">{item.title || "Quiz"}</Text>
       </ElementWrapper>
     );
   }

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -40,6 +40,11 @@ export default function ElementAttributesPane({
   const [text, setText] = useState(element.text || "");
   const [src, setSrc] = useState(element.src || "");
   const [url, setUrl] = useState(element.url || "");
+  const [title, setTitle] = useState(element.title || "");
+  const [description, setDescription] = useState(element.description || "");
+  const [questions, setQuestions] = useState(
+    element.questions || ([] as SlideElementDnDItemProps["questions"])
+  );
   const [bgColor, setBgColor] = useState(
     element.wrapperStyles?.bgColor || "#ffffff"
   );
@@ -76,6 +81,9 @@ export default function ElementAttributesPane({
     setText(element.text || "");
     setSrc(element.src || "");
     setUrl(element.url || "");
+    setTitle(element.title || "");
+    setDescription(element.description || "");
+    setQuestions(element.questions || []);
     setBgColor(element.wrapperStyles?.bgColor || "#ffffff");
     setBgOpacity(element.wrapperStyles?.bgOpacity ?? 0);
     setShadow(element.wrapperStyles?.dropShadow || "none");
@@ -114,6 +122,11 @@ export default function ElementAttributesPane({
     if (element.type === "video") {
       updated.url = url;
     }
+    if (element.type === "quiz") {
+      updated.title = title;
+      updated.description = description;
+      updated.questions = questions;
+    }
     onChange(updated);
   }, [
     color,
@@ -121,6 +134,9 @@ export default function ElementAttributesPane({
     text,
     src,
     url,
+    title,
+    description,
+    questions,
     bgColor,
     bgOpacity,
     shadow,
@@ -419,6 +435,158 @@ export default function ElementAttributesPane({
                   onChange={(e) => setUrl(e.target.value)}
                 />
               </FormControl>
+            </Stack>
+          </AccordionPanel>
+        </AccordionItem>
+      )}
+
+      {element.type === "quiz" && (
+        <AccordionItem
+          borderWidth="1px"
+          borderColor="purple.300"
+          borderRadius="md"
+          mb={2}
+        >
+          <h2>
+            <AccordionButton>
+              <Box flex="1" textAlign="left">Quiz</Box>
+              <AccordionIcon />
+            </AccordionButton>
+          </h2>
+          <AccordionPanel pb={2}>
+            <Stack spacing={3}>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Title
+                </FormLabel>
+                <Input
+                  size="sm"
+                  value={title}
+                  onChange={(e) => setTitle(e.target.value)}
+                />
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Description
+                </FormLabel>
+                <Input
+                  size="sm"
+                  value={description}
+                  onChange={(e) => setDescription(e.target.value)}
+                />
+              </FormControl>
+              <Box>
+                <Text fontSize="sm" mb={2} fontWeight="bold">
+                  Questions
+                </Text>
+                <Stack spacing={3}>
+                  {questions.map((q, qIdx) => (
+                    <Box key={q.id} p={2} borderWidth="1px" borderRadius="md">
+                      <FormControl mb={2}>
+                        <FormLabel fontSize="sm">Question</FormLabel>
+                        <Input
+                          size="sm"
+                          value={q.text}
+                          onChange={(e) => {
+                            const updated = [...questions];
+                            updated[qIdx] = { ...q, text: e.target.value };
+                            setQuestions(updated);
+                          }}
+                        />
+                      </FormControl>
+                      <Stack spacing={2} mb={2} pl={2}>
+                        {q.options.map((opt, oIdx) => (
+                          <HStack key={oIdx} align="center">
+                            <Text w="20px">{String.fromCharCode(65 + oIdx)}</Text>
+                            <Input
+                              size="sm"
+                              value={opt}
+                              onChange={(e) => {
+                                const updated = [...questions];
+                                const opts = [...updated[qIdx].options];
+                                opts[oIdx] = e.target.value;
+                                updated[qIdx] = { ...updated[qIdx], options: opts };
+                                setQuestions(updated);
+                              }}
+                            />
+                            <Button
+                              size="xs"
+                              colorScheme="red"
+                              onClick={() => {
+                                const updated = [...questions];
+                                updated[qIdx] = {
+                                  ...updated[qIdx],
+                                  options: updated[qIdx].options.filter((_, i) => i !== oIdx),
+                                };
+                                setQuestions(updated);
+                              }}
+                            >
+                              X
+                            </Button>
+                          </HStack>
+                        ))}
+                        <Button
+                          size="xs"
+                          onClick={() => {
+                            const updated = [...questions];
+                            updated[qIdx] = {
+                              ...updated[qIdx],
+                              options: [...updated[qIdx].options, ""],
+                            };
+                            setQuestions(updated);
+                          }}
+                        >
+                          Add Option
+                        </Button>
+                      </Stack>
+                      <FormControl>
+                        <FormLabel fontSize="sm">Correct Answer</FormLabel>
+                        <Select
+                          size="sm"
+                          value={q.correctAnswer}
+                          onChange={(e) => {
+                            const updated = [...questions];
+                            updated[qIdx] = { ...q, correctAnswer: e.target.value };
+                            setQuestions(updated);
+                          }}
+                        >
+                          {q.options.map((_, oIdx) => (
+                            <option key={oIdx} value={String.fromCharCode(97 + oIdx)}>
+                              {String.fromCharCode(65 + oIdx)}
+                            </option>
+                          ))}
+                        </Select>
+                      </FormControl>
+                      <Button
+                        mt={2}
+                        size="xs"
+                        colorScheme="red"
+                        onClick={() => {
+                          setQuestions(questions.filter((_, i) => i !== qIdx));
+                        }}
+                      >
+                        Delete Question
+                      </Button>
+                    </Box>
+                  ))}
+                  <Button
+                    size="sm"
+                    onClick={() =>
+                      setQuestions([
+                        ...questions,
+                        {
+                          id: crypto.randomUUID(),
+                          text: "",
+                          options: ["", ""],
+                          correctAnswer: "a",
+                        },
+                      ])
+                    }
+                  >
+                    Add Question
+                  </Button>
+                </Stack>
+              </Box>
             </Stack>
           </AccordionPanel>
         </AccordionItem>

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -63,6 +63,7 @@ const AVAILABLE_ELEMENTS = [
   { type: "table", label: "Table" },
   { type: "image", label: "Image" },
   { type: "video", label: "Video" },
+  { type: "quiz", label: "Quiz" },
 ];
 
 export default function LessonEditor() {
@@ -243,6 +244,12 @@ export default function LessonEditor() {
                 }
               : type === "video"
               ? { url: "" }
+              : type === "quiz"
+              ? {
+                  title: "Untitled Quiz",
+                  description: "",
+                  questions: [],
+                }
               : {}),
             wrapperStyles: {
               bgColor: "#ffffff",

--- a/insight-fe/src/components/lesson/QuizElement.tsx
+++ b/insight-fe/src/components/lesson/QuizElement.tsx
@@ -1,0 +1,105 @@
+import { Box, Text, Stack, RadioGroup, Radio, Button } from "@chakra-ui/react";
+import { useState } from "react";
+import ElementWrapper, { ElementWrapperStyles } from "./ElementWrapper";
+
+export interface MultipleChoiceQuestion {
+  id: string;
+  text: string;
+  options: string[];
+  correctAnswer: string;
+}
+
+interface QuizElementProps {
+  title: string;
+  description?: string;
+  questions: MultipleChoiceQuestion[];
+  wrapperStyles?: ElementWrapperStyles;
+}
+
+export default function QuizElement({
+  title,
+  description,
+  questions,
+  wrapperStyles,
+}: QuizElementProps) {
+  const [current, setCurrent] = useState(0);
+  const [choice, setChoice] = useState("");
+  const [results, setResults] = useState<{ id: string; correct: boolean }[]>([]);
+  const [showFeedback, setShowFeedback] = useState<null | boolean>(null);
+
+  const currentQuestion = questions[current];
+
+  const submitAnswer = () => {
+    if (!currentQuestion) return;
+    const correct = choice === currentQuestion.correctAnswer;
+    setResults([...results, { id: currentQuestion.id, correct }]);
+    setShowFeedback(correct);
+  };
+
+  const nextQuestion = () => {
+    setShowFeedback(null);
+    setChoice("");
+    if (current + 1 < questions.length) {
+      setCurrent(current + 1);
+    }
+  };
+
+  const finished = results.length === questions.length;
+
+  return (
+    <ElementWrapper styles={wrapperStyles} data-testid="quiz-element">
+      <Stack spacing={4}>
+        <Box>
+          <Text fontWeight="bold">{title}</Text>
+          {description && (
+            <Text fontSize="sm" color="gray.600">
+              {description}
+            </Text>
+          )}
+        </Box>
+        {!finished && currentQuestion && (
+          <Box>
+            <Text mb={2}>{currentQuestion.text}</Text>
+            <RadioGroup onChange={setChoice} value={choice}>
+              <Stack spacing={1} pl={4}>
+                {currentQuestion.options.map((opt, idx) => (
+                  <Radio key={idx} value={String.fromCharCode(97 + idx)}>
+                    {opt}
+                  </Radio>
+                ))}
+              </Stack>
+            </RadioGroup>
+            {showFeedback === null ? (
+              <Button mt={2} size="sm" onClick={submitAnswer} isDisabled={!choice}>
+                Submit
+              </Button>
+            ) : (
+              <Box mt={2}>
+                <Text color={showFeedback ? "green.600" : "red.600"} mb={1}>
+                  {showFeedback ? "Correct!" : "Incorrect"}
+                </Text>
+                <Button size="sm" onClick={nextQuestion}>
+                  {current + 1 < questions.length ? "Next" : "Finish"}
+                </Button>
+              </Box>
+            )}
+          </Box>
+        )}
+        {finished && (
+          <Box>
+            <Text fontWeight="bold" mb={2}>
+              Results
+            </Text>
+            <Stack pl={4} spacing={1}>
+              {results.map((r, idx) => (
+                <Text key={r.id} color={r.correct ? "green.600" : "red.600"}>
+                  Question {idx + 1}: {r.correct ? "Correct" : "Incorrect"}
+                </Text>
+              ))}
+            </Stack>
+          </Box>
+        )}
+      </Stack>
+    </ElementWrapper>
+  );
+}

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -4,6 +4,7 @@ import { Box, Text, Table, Thead, Tbody, Tr, Th, Td } from "@chakra-ui/react";
 import ElementWrapper from "./ElementWrapper";
 import ImageElement from "./ImageElement";
 import VideoElement from "./VideoElement";
+import QuizElement from "./QuizElement";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface SlideElementRendererProps {
@@ -53,6 +54,17 @@ export default function SlideElementRenderer({
   if (item.type === "video") {
     return (
       <VideoElement url={item.url || ""} wrapperStyles={item.wrapperStyles} />
+    );
+  }
+
+  if (item.type === "quiz") {
+    return (
+      <QuizElement
+        title={item.title || "Untitled Quiz"}
+        description={item.description}
+        questions={item.questions || []}
+        wrapperStyles={item.wrapperStyles}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- allow drag/drop of quizzes in lesson editor
- show quiz placeholder in slide elements
- render quizzes with title, description and questions
- expose quiz attributes for editing
- show dropdown to select correct answer and evaluate quiz sequentially

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in insight-fe *(fails: missing script)*
- `npm run lint` in insight-fe *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683acaabad48832689dba4b31476b29d