### PR TITLE
Add text styling controls to lesson editor

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -21,6 +21,10 @@ export interface SlideElementDnDItemProps {
   styles?: {
     color?: string;
     fontSize?: string;
+    fontFamily?: string;
+    fontWeight?: string;
+    lineHeight?: string;
+    textAlign?: string;
   };
   wrapperStyles?: ElementWrapperStyles;
 }
@@ -52,7 +56,14 @@ export const SlideElementDnDItem = ({
   if (item.type === "text") {
     return (
       <ElementWrapper styles={wrapperStyles} {...baseProps}>
-        <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
+        <Text
+          color={item.styles?.color}
+          fontSize={item.styles?.fontSize}
+          fontFamily={item.styles?.fontFamily}
+          fontWeight={item.styles?.fontWeight}
+          lineHeight={item.styles?.lineHeight}
+          textAlign={item.styles?.textAlign as any}
+        >
           {item.text || "Sample Text"}
         </Text>
       </ElementWrapper>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -37,6 +37,19 @@ export default function ElementAttributesPane({
 }: ElementAttributesPaneProps) {
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
+  const [fontFamily, setFontFamily] = useState(
+    element.styles?.fontFamily || "Arial"
+  );
+  const [googleFonts, setGoogleFonts] = useState<string[]>([]);
+  const [fontWeight, setFontWeight] = useState(
+    element.styles?.fontWeight || "normal"
+  );
+  const [lineHeight, setLineHeight] = useState(
+    element.styles?.lineHeight || "1.2"
+  );
+  const [textAlign, setTextAlign] = useState(
+    element.styles?.textAlign || "left"
+  );
   const [text, setText] = useState(element.text || "");
   const [src, setSrc] = useState(element.src || "");
   const [url, setUrl] = useState(element.url || "");
@@ -67,12 +80,29 @@ export default function ElementAttributesPane({
     element.wrapperStyles?.borderRadius || "none"
   );
 
+  // Load Google font families once on mount
+  useEffect(() => {
+    fetch("https://google-webfonts-helper.herokuapp.com/api/fonts")
+      .then((res) => res.json())
+      .then((data) => {
+        const families = (data as any[]).map((f) => f.family) as string[];
+        setGoogleFonts(families);
+      })
+      .catch(() => {
+        // Ignore errors, leave list empty
+      });
+  }, []);
+
   // Reset local state only when a new element is selected
   // using id/type avoids resets when the parent simply updates
   // the same element instance with new references
   useEffect(() => {
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
+    setFontFamily(element.styles?.fontFamily || "Arial");
+    setFontWeight(element.styles?.fontWeight || "normal");
+    setLineHeight(element.styles?.lineHeight || "1.2");
+    setTextAlign(element.styles?.textAlign || "left");
     setText(element.text || "");
     setSrc(element.src || "");
     setUrl(element.url || "");
@@ -106,7 +136,15 @@ export default function ElementAttributesPane({
     };
     if (element.type === "text") {
       updated.text = text;
-      updated.styles = { ...element.styles, color, fontSize };
+      updated.styles = {
+        ...element.styles,
+        color,
+        fontSize,
+        fontFamily,
+        fontWeight,
+        lineHeight,
+        textAlign,
+      };
     }
     if (element.type === "image") {
       updated.src = src;
@@ -118,6 +156,10 @@ export default function ElementAttributesPane({
   }, [
     color,
     fontSize,
+    fontFamily,
+    fontWeight,
+    lineHeight,
+    textAlign,
     text,
     src,
     url,
@@ -354,6 +396,78 @@ export default function ElementAttributesPane({
                   value={parseInt(fontSize)}
                   onChange={(e) => setFontSize(e.target.value + "px")}
                 />
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Font
+                </FormLabel>
+                <Select
+                  size="sm"
+                  value={fontFamily}
+                  onChange={(e) => setFontFamily(e.target.value)}
+                >
+                  <option value="Arial">Arial</option>
+                  <option value="Helvetica">Helvetica</option>
+                  <option value="Times New Roman">Times New Roman</option>
+                  <option value="Georgia">Georgia</option>
+                  <option value="Courier New">Courier New</option>
+                  {googleFonts.map((f) => (
+                    <option key={f} value={f}>
+                      {f}
+                    </option>
+                  ))}
+                </Select>
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Weight
+                </FormLabel>
+                <Select
+                  size="sm"
+                  value={fontWeight}
+                  onChange={(e) => setFontWeight(e.target.value)}
+                >
+                  <option value="normal">Normal</option>
+                  <option value="bold">Bold</option>
+                  <option value="bolder">Bolder</option>
+                  <option value="lighter">Lighter</option>
+                  <option value="100">100</option>
+                  <option value="200">200</option>
+                  <option value="300">300</option>
+                  <option value="400">400</option>
+                  <option value="500">500</option>
+                  <option value="600">600</option>
+                  <option value="700">700</option>
+                  <option value="800">800</option>
+                  <option value="900">900</option>
+                </Select>
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Line Height
+                </FormLabel>
+                <Input
+                  size="sm"
+                  type="number"
+                  w="60px"
+                  value={parseFloat(lineHeight)}
+                  onChange={(e) => setLineHeight(e.target.value)}
+                />
+              </FormControl>
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">
+                  Align
+                </FormLabel>
+                <Select
+                  size="sm"
+                  value={textAlign}
+                  onChange={(e) => setTextAlign(e.target.value)}
+                >
+                  <option value="left">Left</option>
+                  <option value="center">Center</option>
+                  <option value="right">Right</option>
+                  <option value="justify">Justify</option>
+                </Select>
               </FormControl>
             </Stack>
           </AccordionPanel>

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -300,7 +300,14 @@ export default function LessonEditor() {
             ...(type === "text"
               ? {
                   text: "Sample Text",
-                  styles: { color: "#000000", fontSize: "16px" },
+                  styles: {
+                    color: "#000000",
+                    fontSize: "16px",
+                    fontFamily: "Arial",
+                    fontWeight: "normal",
+                    lineHeight: "1.2",
+                    textAlign: "left",
+                  },
                 }
               : type === "image"
               ? {

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -16,7 +16,14 @@ export default function SlideElementRenderer({
   if (item.type === "text") {
     return (
       <ElementWrapper styles={item.wrapperStyles} data-testid="text-element">
-        <Text color={item.styles?.color} fontSize={item.styles?.fontSize}>
+        <Text
+          color={item.styles?.color}
+          fontSize={item.styles?.fontSize}
+          fontFamily={item.styles?.fontFamily}
+          fontWeight={item.styles?.fontWeight}
+          lineHeight={item.styles?.lineHeight}
+          textAlign={item.styles?.textAlign as any}
+        >
           {item.text || "Sample Text"}
         </Text>
       </ElementWrapper>


### PR DESCRIPTION
## Summary
- extend `SlideElementDnDItemProps` with font styling fields
- apply font styles when rendering slide elements
- include default font styles when creating new text elements
- update attribute pane to edit font family, weight, line height and alignment
- load font list dynamically from Google Fonts API and populate font dropdown

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683acfa357908326ac5f20a95495d9b9