### PR TITLE
Add Google fonts

### DIFF
--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -18,6 +18,7 @@ import {
   VStack,
   Icon,
 } from "@chakra-ui/react";
+import { availableFonts } from "@/theme/fonts";
 import { Trash2 } from "lucide-react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { useEffect, useState } from "react";
@@ -38,7 +39,7 @@ export default function ElementAttributesPane({
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
   const [fontFamily, setFontFamily] = useState(
-    element.styles?.fontFamily || "Arial"
+    element.styles?.fontFamily || availableFonts[0].fontFamily
   );
   const [fontWeight, setFontWeight] = useState(
     element.styles?.fontWeight || "normal"
@@ -90,7 +91,7 @@ export default function ElementAttributesPane({
   useEffect(() => {
     setColor(element.styles?.color || "#000000");
     setFontSize(element.styles?.fontSize || "16px");
-    setFontFamily(element.styles?.fontFamily || "Arial");
+    setFontFamily(element.styles?.fontFamily || availableFonts[0].fontFamily);
     setFontWeight(element.styles?.fontWeight || "normal");
     setLineHeight(element.styles?.lineHeight || "1.2");
     setTextAlign(element.styles?.textAlign || "left");
@@ -408,11 +409,11 @@ export default function ElementAttributesPane({
                   value={fontFamily}
                   onChange={(e) => setFontFamily(e.target.value)}
                 >
-                  <option value="Arial">Arial</option>
-                  <option value="Helvetica">Helvetica</option>
-                  <option value="Times New Roman">Times New Roman</option>
-                  <option value="Georgia">Georgia</option>
-                  <option value="Courier New">Courier New</option>
+                  {availableFonts.map((f) => (
+                    <option key={f.fontFamily} value={f.fontFamily}>
+                      {f.label}
+                    </option>
+                  ))}
                 </Select>
               </FormControl>
               <FormControl display="flex" alignItems="center">

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -10,6 +10,7 @@ import BoardAttributesPane from "./BoardAttributesPane";
 import SlidePreview from "./SlidePreview";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnType } from "@/components/DnD/types";
+import { availableFonts } from "@/theme/fonts";
 
 interface LessonState {
   slides: Slide[];
@@ -304,7 +305,7 @@ export default function LessonEditor() {
                   styles: {
                     color: "#000000",
                     fontSize: "16px",
-                    fontFamily: "Arial",
+                    fontFamily: availableFonts[0].fontFamily,
                     fontWeight: "normal",
                     lineHeight: "1.2",
                     textAlign: "left",

--- a/insight-fe/src/theme/fonts.ts
+++ b/insight-fe/src/theme/fonts.ts
@@ -1,0 +1,18 @@
+import { Roboto, Lato, Montserrat, Open_Sans } from 'next/font/google'
+
+const roboto = Roboto({ subsets: ['latin'] })
+const lato = Lato({ subsets: ['latin'] })
+const montserrat = Montserrat({ subsets: ['latin'] })
+const openSans = Open_Sans({ subsets: ['latin'] })
+
+export const availableFonts = [
+  { label: 'Roboto', fontFamily: roboto.style.fontFamily },
+  { label: 'Lato', fontFamily: lato.style.fontFamily },
+  { label: 'Montserrat', fontFamily: montserrat.style.fontFamily },
+  { label: 'Open Sans', fontFamily: openSans.style.fontFamily },
+]
+
+export const chakraFonts = {
+  heading: roboto.style.fontFamily,
+  body: roboto.style.fontFamily,
+}

--- a/insight-fe/src/theme/theme.ts
+++ b/insight-fe/src/theme/theme.ts
@@ -1,7 +1,8 @@
 import { extendTheme } from "@chakra-ui/react";
+import { chakraFonts } from "./fonts";
 
 const theme = extendTheme({
-  // Add custom theme configurations here
+  fonts: chakraFonts,
 });
 
 export default theme;


### PR DESCRIPTION
## Summary
- add fonts from `next/font/google`
- expose font list for dropdown
- configure Chakra theme with new fonts
- use new fonts when creating slide text elements
- populate font selection using available fonts

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad6352ce08326b0afb0a97b17d9fd