### PR TITLE
Add spacing controls to lesson editor

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -93,6 +93,8 @@ export interface DnDBoardMainProps<TCard extends BaseCardDnD> {
   instanceId?: symbol;
   /** Optional shared registry for cross-board drag */
   registry?: ReturnType<typeof createRegistry>;
+  /** Spacing between columns */
+  spacing?: number;
   /**
    * When `true` this component is *controlled*:
    *  - It never stores its own copy of the board.
@@ -119,6 +121,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   onSelectColumn,
   instanceId: instanceIdProp,
   registry: registryProp,
+  spacing = 0,
   controlled = false,
 }: DnDBoardMainProps<TCard>) => {
   /* -----------------------------------------------------------------------
@@ -600,7 +603,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
         flex={1}
         justifyContent="space-between"
       >
-        <Board>
+        <Board spacing={spacing}>
           {renderedBoard.orderedColumnIds.map((columnId) => (
             <Column
               key={columnId}

--- a/insight-fe/src/components/DnD/board.tsx
+++ b/insight-fe/src/components/DnD/board.tsx
@@ -5,10 +5,11 @@ import { useBoardContext } from "./BoardContext";
 
 type BoardProps = {
   children: ReactNode;
+  spacing?: number;
 };
 
 const Board = forwardRef<HTMLDivElement, BoardProps>(
-  ({ children }: BoardProps, ref) => {
+  ({ children, spacing = 0 }: BoardProps, ref) => {
     const { instanceId } = useBoardContext();
 
     useEffect(() => {
@@ -23,7 +24,7 @@ const Board = forwardRef<HTMLDivElement, BoardProps>(
         justifyContent="center"
         flexDirection="row"
         ref={ref}
-        gap={2}
+        gap={spacing}
         flex={1}
       >
         {children}

--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -374,6 +374,7 @@ function ColumnBase<TCard extends BaseCardDnD>({
               <Stack
                 flexGrow={1}
                 sx={{ ...cardListStyles, ...(column.styles?.cardList ?? {}) }}
+                spacing={column.spacing ?? 2}
               >
                 {isLoading ? (
                   <LoadingSpinnerCard />

--- a/insight-fe/src/components/DnD/types.ts
+++ b/insight-fe/src/components/DnD/types.ts
@@ -39,6 +39,7 @@ export type ColumnType<TCard extends BaseCardDnD> = {
   items: TCard[];
   styles?: ColumnStyles;
   wrapperStyles?: ElementWrapperStyles;
+  spacing?: number;
   sortBy?: (item: TCard) => string;
   sortDirection?: "asc" | "desc" | "none";
 };

--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -34,6 +34,7 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
   const [borderColor, setBorderColor] = useState(board.wrapperStyles?.borderColor || "#000000");
   const [borderWidth, setBorderWidth] = useState(board.wrapperStyles?.borderWidth ?? 0);
   const [borderRadius, setBorderRadius] = useState(board.wrapperStyles?.borderRadius || "none");
+  const [spacing, setSpacing] = useState(board.spacing ?? 0);
 
   useEffect(() => {
     setBgColor(board.wrapperStyles?.bgColor || "#ffffff");
@@ -46,6 +47,7 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
     setBorderColor(board.wrapperStyles?.borderColor || "#000000");
     setBorderWidth(board.wrapperStyles?.borderWidth ?? 0);
     setBorderRadius(board.wrapperStyles?.borderRadius || "none");
+    setSpacing(board.spacing ?? 0);
   }, [board.id]);
 
   useEffect(() => {
@@ -63,8 +65,9 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
         borderWidth,
         borderRadius,
       },
+      spacing,
     });
-  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius]);
+  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
 
   return (
     <Accordion allowMultiple>
@@ -125,6 +128,10 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
                 </FormControl>
               </HStack>
             </Box>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Spacing</FormLabel>
+              <Input size="sm" type="number" w="60px" value={spacing} onChange={(e) => setSpacing(parseInt(e.target.value))} />
+            </FormControl>
           </Stack>
         </AccordionPanel>
       </AccordionItem>

--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -35,6 +35,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
   const [borderColor, setBorderColor] = useState(column.wrapperStyles?.borderColor || "#000000");
   const [borderWidth, setBorderWidth] = useState(column.wrapperStyles?.borderWidth ?? 0);
   const [borderRadius, setBorderRadius] = useState(column.wrapperStyles?.borderRadius || "none");
+  const [spacing, setSpacing] = useState(column.spacing ?? 0);
 
   useEffect(() => {
     setBgColor(column.wrapperStyles?.bgColor || "#ffffff");
@@ -47,6 +48,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
     setBorderColor(column.wrapperStyles?.borderColor || "#000000");
     setBorderWidth(column.wrapperStyles?.borderWidth ?? 0);
     setBorderRadius(column.wrapperStyles?.borderRadius || "none");
+    setSpacing(column.spacing ?? 0);
   }, [column.columnId]);
 
   useEffect(() => {
@@ -64,8 +66,9 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
         borderWidth,
         borderRadius,
       },
+      spacing,
     });
-  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius]);
+  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
 
   return (
     <Accordion allowMultiple>
@@ -126,6 +129,10 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
                 </FormControl>
               </HStack>
             </Box>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Spacing</FormLabel>
+              <Input size="sm" type="number" w="60px" value={spacing} onChange={(e) => setSpacing(parseInt(e.target.value))} />
+            </FormControl>
           </Stack>
         </AccordionPanel>
       </AccordionItem>

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -25,6 +25,7 @@ interface SlideElementsBoardProps {
   ) => void;
   registry: ReturnType<typeof createRegistry>;
   instanceId: symbol;
+  spacing?: number;
   selectedElementId?: string | null;
   onSelectElement?: (id: string) => void;
   dropIndicator?: { columnId: string; index: number } | null;
@@ -52,6 +53,7 @@ export default function SlideElementsBoard({
   onChange,
   registry,
   instanceId,
+  spacing = 0,
   selectedElementId,
   onSelectElement,
   dropIndicator,
@@ -91,6 +93,7 @@ export default function SlideElementsBoard({
         borderRadius: "none",
       },
       items: [],
+      spacing: 0,
     };
 
     onChange(
@@ -181,11 +184,12 @@ export default function SlideElementsBoard({
             onChange={(b) => onChange(b.columnMap, b.orderedColumnIds)}
             onRemoveColumn={removeColumn}
             externalDropIndicator={dropIndicator}
-            selectedColumnId={selectedColumnId}
-            onSelectColumn={onSelectColumn}
-            instanceId={instanceId}
-            registry={registry}
-          />
+          selectedColumnId={selectedColumnId}
+          onSelectColumn={onSelectColumn}
+          instanceId={instanceId}
+          registry={registry}
+          spacing={spacing}
+        />
         </ContentCard>
       </ElementWrapper>
       <ConfirmationModal

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -16,6 +16,7 @@ export interface BoardRow {
   id: string;
   orderedColumnIds: string[];
   wrapperStyles?: ElementWrapperStyles;
+  spacing?: number;
 }
 
 interface SlideElementsContainerProps {
@@ -85,6 +86,7 @@ export default function SlideElementsContainer({
         borderRadius: "none",
       },
       items: [],
+      spacing: 0,
     };
 
     onChange({ ...columnMap, [columnId]: newColumn }, [
@@ -104,6 +106,7 @@ export default function SlideElementsContainer({
           borderWidth: 0,
           borderRadius: "none",
         },
+        spacing: 0,
       },
     ]);
   };
@@ -228,6 +231,7 @@ export default function SlideElementsContainer({
           key={b.id}
           boardId={b.id}
           wrapperStyles={b.wrapperStyles}
+          spacing={b.spacing}
           columnMap={columnMap}
           orderedColumnIds={b.orderedColumnIds}
           onChange={(map, ids) => updateBoard(b.id, map, ids)}

--- a/insight-fe/src/components/lesson/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/SlidePreview.tsx
@@ -20,14 +20,14 @@ export default function SlidePreview({ columnMap, boards }: SlidePreviewProps) {
           <Box
             display="grid"
             gridTemplateColumns={`repeat(${board.orderedColumnIds.length}, 1fr)`}
-            gap={4}
+            gap={board.spacing ?? 0}
           >
             {board.orderedColumnIds.map((colId) => {
               const column = columnMap[colId];
               if (!column) return null;
               return (
                 <ElementWrapper key={colId} styles={column.wrapperStyles} data-column-id={colId}>
-                  <Stack gap={2}>
+                  <Stack gap={column.spacing ?? 2}>
                     {column.items.map((item) => (
                       <Box key={item.id} mb={2} data-card-id={item.id}>
                         <SlideElementRenderer item={item} />


### PR DESCRIPTION
## Summary
- remove hard-coded column gap in Board component
- allow boards and columns to define `spacing`
- expose spacing option in board/column attribute panels
- apply spacing in slide preview and editor components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ad600aefc83268f646e30bd4d0d47