### PR TITLE
Add subject relation to lessons

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
@@ -15,6 +15,7 @@ import { AbstractBaseEntity } from 'src/common/base.entity';
 import { EducatorProfileEntity } from '../../user-profiles/educator-profile/educator-profile.entity';
 import { YearGroupEntity } from '../year-group/year-group.entity';
 import { TopicEntity } from '../topic/topic.entity';
+import { SubjectEntity } from '../subject/subject.entity';
 import { EducatorProfileDto } from '../../user-profiles/educator-profile/dto/educator-profile.dto';
 import { MultipleChoiceQuestionEntity } from '../multiple-choice-question/multiple-choice-question.entity';
 import { QuizEntity } from '../quiz/quiz.entity';
@@ -39,6 +40,10 @@ export class LessonEntity extends AbstractBaseEntity {
   @Field(() => TopicEntity, { nullable: false })
   @ManyToOne(() => TopicEntity, (topic) => topic.lessons, { nullable: false })
   topic?: TopicEntity;
+
+  @Field(() => SubjectEntity, { nullable: false })
+  @ManyToOne(() => SubjectEntity, (subject) => subject.lessons, { nullable: false })
+  subject!: SubjectEntity;
 
   @Field(() => [YearGroupEntity], { nullable: true })
   @ManyToMany(() => YearGroupEntity, { nullable: true })

--- a/insight-be/src/modules/timbuktu/administrative/subject/subject.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/subject/subject.entity.ts
@@ -7,6 +7,7 @@ import { ObjectType, Field } from '@nestjs/graphql';
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { YearGroupEntity } from '../year-group/year-group.entity';
 import { TopicEntity } from '../topic/topic.entity';
+import { LessonEntity } from '../lesson/lesson.entity';
 
 @ObjectType()
 @Entity('subjects')
@@ -20,6 +21,10 @@ export class SubjectEntity extends AbstractBaseEntity {
   @Field(() => [TopicEntity], { nullable: true })
   @OneToMany(() => TopicEntity, (topic) => topic.subject)
   topics?: TopicEntity[];
+
+  @Field(() => [LessonEntity], { nullable: true })
+  @OneToMany(() => LessonEntity, (lesson) => lesson.subject)
+  lessons?: LessonEntity[];
 
   @Field(() => [YearGroupEntity], { nullable: true })
   @ManyToMany(() => YearGroupEntity, (yg) => yg.subjects, {


### PR DESCRIPTION
## Summary
- link lessons to subjects so each lesson belongs to one subject
- expose subject relation on SubjectEntity

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683adfc869348326acc3bc2cb4ed2634