### PR TITLE
Add year group dropdown in lesson builder

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -1,7 +1,20 @@
 "use client";
 
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { useState } from "react";
 import LessonEditor from "@/components/lesson/LessonEditor";
+import YearGroupDropdown from "./YearGroupDropdown";
 
 export const LessonBuilderPageClient = () => {
-  return <LessonEditor />;
+  const [yearGroupId, setYearGroupId] = useState<string | null>(null);
+
+  return (
+    <Box display="flex" flexDirection="column" gap={4}>
+      <Flex alignItems="center" gap={2}>
+        <Text>Year Group</Text>
+        <YearGroupDropdown value={yearGroupId} onChange={setYearGroupId} />
+      </Flex>
+      <LessonEditor />
+    </Box>
+  );
 };

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/YearGroupDropdown.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/YearGroupDropdown.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import React, { ChangeEvent, useMemo } from "react";
+import { Select } from "@chakra-ui/react";
+import { useQuery } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+
+const GET_ALL_YEAR_GROUPS = typedGql("query")({
+  getAllYearGroup: [
+    { data: $("data", "FindAllInput!") },
+    { id: true, year: true },
+  ],
+} as const);
+
+export interface YearGroupDropdownProps {
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+export default function YearGroupDropdown({ value, onChange }: YearGroupDropdownProps) {
+  const { data, loading } = useQuery(GET_ALL_YEAR_GROUPS, {
+    variables: { data: { all: true } },
+  });
+
+  const options = useMemo(
+    () => (data?.getAllYearGroup ?? []).map((yg) => ({
+      label: yg.year,
+      value: String(yg.id),
+    })),
+    [data]
+  );
+
+  return (
+    <Select
+      placeholder={loading ? "Loading..." : "Select year group"}
+      value={value ?? ""}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) => onChange(e.target.value || null)}
+    >
+      {options.map((opt) => (
+        <option key={opt.value} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </Select>
+  );
+}


### PR DESCRIPTION
## Summary
- add `YearGroupDropdown` component to fetch and display all year groups
- include the dropdown at the top of the Lesson Builder page

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in insight-fe *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683dcb21259083269a112157b622c759