### PR TITLE
Add style modules

### DIFF
--- a/insight-be/src/app.module.ts
+++ b/insight-be/src/app.module.ts
@@ -31,6 +31,8 @@ import { QuizModule } from './modules/timbuktu/administrative/quiz/quiz.module';
 import { SubjectModule } from './modules/timbuktu/administrative/subject/subject.module';
 import { YearGroupModule } from './modules/timbuktu/administrative/year-group/year-group.module';
 import { TopicModule } from './modules/timbuktu/administrative/topic/topic.module';
+import { StyleCollectionModule } from './modules/timbuktu/administrative/style-collection/style-collection.module';
+import { StyleModule } from './modules/timbuktu/administrative/style/style.module';
 import { AssignmentSubmissionModule } from './modules/timbuktu/administrative/assignment-submission/assignment-submission.model';
 import { AssignmentModule } from './modules/timbuktu/administrative/assignment/assignment.module';
 import { AssignmentSubmissionEntity } from './modules/timbuktu/administrative/assignment-submission/assignment-submission.entity';
@@ -44,6 +46,8 @@ import { SubjectEntity } from './modules/timbuktu/administrative/subject/subject
 import { YearGroupEntity } from './modules/timbuktu/administrative/year-group/year-group.entity';
 import { TopicEntity } from './modules/timbuktu/administrative/topic/topic.entity';
 import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-tables/class-lesson/class-lesson.entity';
+import { StyleCollectionEntity } from './modules/timbuktu/administrative/style-collection/style-collection.entity';
+import { StyleEntity } from './modules/timbuktu/administrative/style/style.entity';
 
 @Module({
   imports: [
@@ -83,6 +87,8 @@ import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-table
         AssignmentSubmissionEntity,
         AssignmentEntity,
         ClassLessonEntity,
+        StyleCollectionEntity,
+        StyleEntity,
       ],
       synchronize: true,
     }),
@@ -102,6 +108,8 @@ import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-table
     YearGroupModule,
     SubjectModule,
     TopicModule,
+    StyleCollectionModule,
+    StyleModule,
     ClassModule,
     LessonModule,
     QuizModule,

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
@@ -1,0 +1,16 @@
+import { Column, Entity, OneToMany } from 'typeorm';
+import { Field, ObjectType } from '@nestjs/graphql';
+import { AbstractBaseEntity } from 'src/common/base.entity';
+import { StyleEntity } from '../style/style.entity';
+
+@ObjectType()
+@Entity('style_collections')
+export class StyleCollectionEntity extends AbstractBaseEntity {
+  @Field()
+  @Column()
+  name: string;
+
+  @Field(() => [StyleEntity], { nullable: true })
+  @OneToMany(() => StyleEntity, (style) => style.collection)
+  styles?: StyleEntity[];
+}

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
@@ -1,0 +1,13 @@
+import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
+
+@InputType()
+export class CreateStyleCollectionInput {
+  @Field()
+  name: string;
+}
+
+@InputType()
+export class UpdateStyleCollectionInput extends PartialType(CreateStyleCollectionInput) {
+  @Field(() => ID)
+  id: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StyleCollectionEntity } from './style-collection.entity';
+import { StyleCollectionResolver } from './style-collection.resolver';
+import { StyleCollectionService } from './style-collection.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([StyleCollectionEntity])],
+  providers: [StyleCollectionService, StyleCollectionResolver],
+  exports: [StyleCollectionService],
+})
+export class StyleCollectionModule {}

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.resolver.ts
@@ -1,0 +1,33 @@
+import { Resolver } from '@nestjs/graphql';
+import { createBaseResolver } from 'src/common/base.resolver';
+import { StyleCollectionEntity } from './style-collection.entity';
+import {
+  CreateStyleCollectionInput,
+  UpdateStyleCollectionInput,
+} from './style-collection.inputs';
+import { StyleCollectionService } from './style-collection.service';
+
+const BaseStyleCollectionResolver = createBaseResolver<
+  StyleCollectionEntity,
+  CreateStyleCollectionInput,
+  UpdateStyleCollectionInput
+>(StyleCollectionEntity, CreateStyleCollectionInput, UpdateStyleCollectionInput, {
+  queryName: 'StyleCollection',
+  stableKeyPrefix: 'styleCollection',
+  enabledOperations: [
+    'findAll',
+    'findOne',
+    'findOneBy',
+    'create',
+    'update',
+    'remove',
+    'search',
+  ],
+});
+
+@Resolver(() => StyleCollectionEntity)
+export class StyleCollectionResolver extends BaseStyleCollectionResolver {
+  constructor(private readonly collectionService: StyleCollectionService) {
+    super(collectionService);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.service.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BaseService } from 'src/common/base.service';
+import { StyleCollectionEntity } from './style-collection.entity';
+import { CreateStyleCollectionInput, UpdateStyleCollectionInput } from './style-collection.inputs';
+
+@Injectable()
+export class StyleCollectionService extends BaseService<
+  StyleCollectionEntity,
+  CreateStyleCollectionInput,
+  UpdateStyleCollectionInput
+> {
+  constructor(
+    @InjectRepository(StyleCollectionEntity)
+    collectionRepository: Repository<StyleCollectionEntity>,
+    @InjectDataSource() dataSource: DataSource,
+  ) {
+    super(collectionRepository, dataSource);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/style/style.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.entity.ts
@@ -1,0 +1,31 @@
+import { Column, Entity, ManyToOne, RelationId } from 'typeorm';
+import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
+import { AbstractBaseEntity } from 'src/common/base.entity';
+import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
+
+@ObjectType()
+@Entity('styles')
+export class StyleEntity extends AbstractBaseEntity {
+  @Field()
+  @Column()
+  name: string;
+
+  @Field()
+  @Column()
+  element: string;
+
+  @Field(() => GraphQLJSONObject)
+  @Column({ type: 'jsonb' })
+  config: Record<string, any>;
+
+  @Field(() => StyleCollectionEntity)
+  @ManyToOne(() => StyleCollectionEntity, (collection) => collection.styles, {
+    nullable: false,
+  })
+  collection!: StyleCollectionEntity;
+
+  @Field(() => ID)
+  @RelationId((style: StyleEntity) => style.collection)
+  collectionId!: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/style/style.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.inputs.ts
@@ -1,0 +1,24 @@
+import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
+import { HasRelationsInput } from 'src/common/base.inputs';
+
+@InputType()
+export class CreateStyleInput extends HasRelationsInput {
+  @Field()
+  name: string;
+
+  @Field()
+  element: string;
+
+  @Field(() => GraphQLJSONObject)
+  config: Record<string, any>;
+
+  @Field(() => ID)
+  collectionId: number;
+}
+
+@InputType()
+export class UpdateStyleInput extends PartialType(CreateStyleInput) {
+  @Field(() => ID)
+  id: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/style/style.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StyleEntity } from './style.entity';
+import { StyleResolver } from './style.resolver';
+import { StyleService } from './style.service';
+import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([StyleEntity, StyleCollectionEntity])],
+  providers: [StyleService, StyleResolver],
+  exports: [StyleService],
+})
+export class StyleModule {}

--- a/insight-be/src/modules/timbuktu/administrative/style/style.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.resolver.ts
@@ -1,0 +1,30 @@
+import { Resolver } from '@nestjs/graphql';
+import { createBaseResolver } from 'src/common/base.resolver';
+import { StyleEntity } from './style.entity';
+import { CreateStyleInput, UpdateStyleInput } from './style.inputs';
+import { StyleService } from './style.service';
+
+const BaseStyleResolver = createBaseResolver<
+  StyleEntity,
+  CreateStyleInput,
+  UpdateStyleInput
+>(StyleEntity, CreateStyleInput, UpdateStyleInput, {
+  queryName: 'Style',
+  stableKeyPrefix: 'style',
+  enabledOperations: [
+    'findAll',
+    'findOne',
+    'findOneBy',
+    'create',
+    'update',
+    'remove',
+    'search',
+  ],
+});
+
+@Resolver(() => StyleEntity)
+export class StyleResolver extends BaseStyleResolver {
+  constructor(private readonly styleService: StyleService) {
+    super(styleService);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/style/style.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BaseService } from 'src/common/base.service';
+import { StyleEntity } from './style.entity';
+import { CreateStyleInput, UpdateStyleInput } from './style.inputs';
+
+@Injectable()
+export class StyleService extends BaseService<
+  StyleEntity,
+  CreateStyleInput,
+  UpdateStyleInput
+> {
+  constructor(
+    @InjectRepository(StyleEntity) styleRepository: Repository<StyleEntity>,
+    @InjectDataSource() dataSource: DataSource,
+  ) {
+    super(styleRepository, dataSource);
+  }
+}


### PR DESCRIPTION
## Summary
- add `Style` and `StyleCollection` modules for saving lesson builder attribute configs
- wire up new modules and entities in `AppModule`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dcc15d690832680801e577be8575c