### PR TITLE
Add subject dropdown to lesson builder

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -1,7 +1,39 @@
 "use client";
 
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { useState } from "react";
 import LessonEditor from "@/components/lesson/LessonEditor";
+import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
+import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
 
 export const LessonBuilderPageClient = () => {
-  return <LessonEditor />;
+  const [yearGroupId, setYearGroupId] = useState<string | null>(null);
+  const [subjectId, setSubjectId] = useState<string | null>(null);
+
+  return (
+    <Flex direction="column" gap={4}>
+      <Flex gap={8}>
+        <Box>
+          <Text mb={2}>Year Group</Text>
+          <YearGroupDropdown
+            value={yearGroupId}
+            onChange={(id) => {
+              setYearGroupId(id);
+              setSubjectId(null);
+            }}
+          />
+        </Box>
+        <Box>
+          <Text mb={2}>Subject</Text>
+          <SubjectDropdown
+            yearGroupId={yearGroupId}
+            value={subjectId}
+            onChange={setSubjectId}
+          />
+        </Box>
+      </Flex>
+
+      <LessonEditor />
+    </Flex>
+  );
 };

--- a/insight-fe/src/components/dropdowns/SimpleDropdown.tsx
+++ b/insight-fe/src/components/dropdowns/SimpleDropdown.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import React from "react";
+import { Select, useColorModeValue } from "@chakra-ui/react";
+
+export interface SimpleDropdownOption {
+  label: string;
+  value: string;
+}
+
+interface SimpleDropdownProps {
+  options: SimpleDropdownOption[];
+  value: string | number;
+  onChange: (event: React.ChangeEvent<HTMLSelectElement>) => void;
+  isDisabled?: boolean;
+  isLoading?: boolean;
+}
+
+export default function SimpleDropdown({
+  options,
+  value,
+  onChange,
+  isDisabled = false,
+  isLoading = false,
+}: SimpleDropdownProps) {
+  const dedupedOptions = React.useMemo(() => {
+    const seen = new Set<string | number>();
+    return options.filter((o) => {
+      if (o.value === undefined || seen.has(o.value)) return false;
+      seen.add(o.value);
+      return true;
+    });
+  }, [options]);
+
+  return (
+    <Select
+      value={value}
+      onChange={onChange}
+      isDisabled={isDisabled}
+      bg={useColorModeValue("white", "gray.800")}
+      _hover={{ shadow: "sm" }}
+      _focus={{ shadow: "outline" }}
+    >
+      {isLoading && <option value="">Loading...</option>}
+      {!isLoading && (
+        <option key="__empty" value="">
+          ─ select ─
+        </option>
+      )}
+      {dedupedOptions.map((opt) => (
+        <option key={String(opt.value)} value={opt.value}>
+          {opt.label}
+        </option>
+      ))}
+    </Select>
+  );
+}

--- a/insight-fe/src/components/dropdowns/SubjectDropdown.tsx
+++ b/insight-fe/src/components/dropdowns/SubjectDropdown.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ChangeEvent, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+import SimpleDropdown from "./SimpleDropdown";
+
+const GET_SUBJECTS_FOR_YEAR_GROUP = typedGql("query")({
+  getYearGroup: [
+    { data: $("data", "IdInput!") },
+    {
+      id: true,
+      subjects: { id: true, name: true },
+    },
+  ],
+} as const);
+
+interface SubjectDropdownProps {
+  yearGroupId: string | null;
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+export default function SubjectDropdown({ yearGroupId, value, onChange }: SubjectDropdownProps) {
+  const variables = useMemo(
+    () =>
+      yearGroupId !== null
+        ? { data: { id: Number(yearGroupId), relations: ["subjects"] } }
+        : undefined,
+    [yearGroupId]
+  );
+
+  const { data, loading } = useQuery(GET_SUBJECTS_FOR_YEAR_GROUP, {
+    variables,
+    skip: !yearGroupId,
+  });
+
+  const subjects = yearGroupId ? data?.getYearGroup?.subjects ?? [] : [];
+
+  const options = useMemo(
+    () => subjects.map((s) => ({ label: s.name, value: String(s.id) })),
+    [subjects]
+  );
+
+  return (
+    <SimpleDropdown
+      options={options}
+      value={value ?? ""}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+        onChange(e.target.value || null)
+      }
+      isDisabled={yearGroupId === null}
+    />
+  );
+}

--- a/insight-fe/src/components/dropdowns/YearGroupDropdown.tsx
+++ b/insight-fe/src/components/dropdowns/YearGroupDropdown.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ChangeEvent, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+import SimpleDropdown from "./SimpleDropdown";
+
+const GET_ALL_YEAR_GROUPS = typedGql("query")({
+  getAllYearGroup: [
+    { data: $("data", "FindAllInput!") },
+    { id: true, year: true },
+  ],
+} as const);
+
+interface YearGroupDropdownProps {
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+export default function YearGroupDropdown({ value, onChange }: YearGroupDropdownProps) {
+  const { data, loading } = useQuery(GET_ALL_YEAR_GROUPS, {
+    variables: { data: { all: true } },
+  });
+
+  const yearGroups = data?.getAllYearGroup ?? [];
+
+  const options = useMemo(
+    () => yearGroups.map((yg) => ({ label: yg.year, value: String(yg.id) })),
+    [yearGroups]
+  );
+
+  return (
+    <SimpleDropdown
+      options={options}
+      value={value ?? ""}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+        onChange(e.target.value || null)
+      }
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add reusable `SubjectDropdown` component to fetch subjects by year group
- add reusable `YearGroupDropdown` component
- replace crud dropdowns with simple select dropdowns
- update Lesson Builder page to include year group and subject selections

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dcfb1ceb0832696f698e7b854cecd