### PR TITLE
Add style save form in lesson editor

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -129,7 +129,9 @@ export default function LessonEditor() {
     dropIndicator: null,
   });
 
-  const [styleCollections, setStyleCollections] = useState<string[]>([]);
+  const [styleCollections, setStyleCollections] = useState<
+    { id: number; name: string }[]
+  >([]);
   const [isSaveStyleOpen, setIsSaveStyleOpen] = useState(false);
 
   const setSlides = useCallback(
@@ -535,8 +537,16 @@ export default function LessonEditor() {
         isOpen={isSaveStyleOpen}
         onClose={() => setIsSaveStyleOpen(false)}
         collections={styleCollections}
+        element={selectedElement?.type || ""}
+        onSave={({ name, collectionId }) => {
+          // Placeholder for backend call using style module
+          console.log("save style", { name, collectionId, config: selectedElement });
+        }}
         onAddCollection={(name) =>
-          setStyleCollections([...styleCollections, name])
+          setStyleCollections([
+            ...styleCollections,
+            { id: Date.now(), name },
+          ])
         }
       />
     </Box>

--- a/insight-fe/src/components/lesson/SaveStyleModal.tsx
+++ b/insight-fe/src/components/lesson/SaveStyleModal.tsx
@@ -1,13 +1,29 @@
 import { useState } from "react";
-import { Button, Select, Stack } from "@chakra-ui/react";
+import {
+  Button,
+  Select,
+  Stack,
+  FormControl,
+  FormLabel,
+  Input,
+} from "@chakra-ui/react";
 import { BaseModal } from "../modals/BaseModal";
 import AddStyleCollectionModal from "./AddStyleCollectionModal";
 
 interface SaveStyleModalProps {
   isOpen: boolean;
   onClose: () => void;
-  collections: string[];
+  /**
+   * Available style collections. Each entry contains an id and name so that the
+   * selected id can be sent to the backend style module.
+   */
+  collections: { id: number; name: string }[];
+  /** Callback when the user adds a new collection */
   onAddCollection: (name: string) => void;
+  /** Type of the element whose style is being saved */
+  element: string;
+  /** Callback executed when user submits the form */
+  onSave: (data: { name: string; collectionId: number }) => void;
 }
 
 export default function SaveStyleModal({
@@ -15,21 +31,54 @@ export default function SaveStyleModal({
   onClose,
   collections,
   onAddCollection,
+  element,
+  onSave,
 }: SaveStyleModalProps) {
   const [isAddOpen, setIsAddOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [collectionId, setCollectionId] = useState<number | "">("");
 
   return (
     <>
       <BaseModal isOpen={isOpen} onClose={onClose} title="Save Style">
         <Stack spacing={4}>
-          <Select placeholder="Select collection">
-            {collections.map((c) => (
-              <option key={c} value={c}>
-                {c}
-              </option>
-            ))}
-          </Select>
+          <FormControl>
+            <FormLabel>Style Name</FormLabel>
+            <Input value={name} onChange={(e) => setName(e.target.value)} />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Element</FormLabel>
+            <Input value={element} isReadOnly />
+          </FormControl>
+          <FormControl>
+            <FormLabel>Collection</FormLabel>
+            <Select
+              placeholder="Select collection"
+              value={collectionId}
+              onChange={(e) => setCollectionId(parseInt(e.target.value))}
+            >
+              {collections.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </Select>
+          </FormControl>
           <Button onClick={() => setIsAddOpen(true)}>Add Collection</Button>
+          <Button
+            colorScheme="blue"
+            isDisabled={!name || collectionId === ""}
+            onClick={() => {
+              if (collectionId !== "") {
+                onSave({ name, collectionId });
+                setName("");
+                setCollectionId("");
+                onClose();
+              }
+            }}
+          >
+            Save
+          </Button>
         </Stack>
       </BaseModal>
       <AddStyleCollectionModal


### PR DESCRIPTION
## Summary
- expand SaveStyleModal with fields for name and collection
- wire modal up to selected element in LessonEditor

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683dd2f2044483268cdac9f636cb45b3