### PR TITLE
Add Save Lesson modal

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -1,18 +1,50 @@
 "use client";
 
-import { Box, Flex, Text } from "@chakra-ui/react";
-import { useState } from "react";
-import LessonEditor from "@/components/lesson/LessonEditor";
+import { Box, Flex, Text, Button } from "@chakra-ui/react";
+import { useState, useRef } from "react";
+import LessonEditor, { LessonEditorHandle } from "@/components/lesson/LessonEditor";
 import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
 import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
+import SaveLessonModal from "@/components/lesson/SaveLessonModal";
+import { useMutation } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
 
 export const LessonBuilderPageClient = () => {
   const [yearGroupId, setYearGroupId] = useState<string | null>(null);
   const [subjectId, setSubjectId] = useState<string | null>(null);
+  const [isSaveOpen, setIsSaveOpen] = useState(false);
+  const editorRef = useRef<LessonEditorHandle>(null);
+
+  const CREATE_LESSON = typedGql("mutation")({
+    createLesson: [{ data: $("data", "CreateLessonInput!") }, { id: true }],
+  } as const);
+
+  const [createLesson, { loading: saving }] = useMutation(CREATE_LESSON, {
+    onCompleted: () => setIsSaveOpen(false),
+  });
+
+  const handleSave = async ({ title, description }: { title: string; description: string }) => {
+    if (!yearGroupId || !subjectId) return;
+    const content = editorRef.current?.getContent() ?? { slides: [] };
+    await createLesson({
+      variables: {
+        data: {
+          title,
+          description: description.length > 0 ? description : null,
+          content,
+          relationIds: [
+            { relation: "recommendedYearGroups", ids: [Number(yearGroupId)] },
+            { relation: "subject", ids: [Number(subjectId)] },
+          ],
+        },
+      },
+    });
+  };
 
   return (
     <Flex direction="column" gap={4}>
-      <Flex gap={8}>
+      <Flex gap={8} alignItems="flex-end">
         <Box>
           <Text mb={2}>Year Group</Text>
           <YearGroupDropdown
@@ -31,9 +63,22 @@ export const LessonBuilderPageClient = () => {
             onChange={setSubjectId}
           />
         </Box>
+        <Button
+          onClick={() => setIsSaveOpen(true)}
+          colorScheme="blue"
+          isDisabled={!yearGroupId || !subjectId}
+        >
+          Save Lesson
+        </Button>
       </Flex>
 
-      <LessonEditor />
+      <LessonEditor ref={editorRef} />
+      <SaveLessonModal
+        isOpen={isSaveOpen}
+        onClose={() => setIsSaveOpen(false)}
+        onSave={handleSave}
+        isSaving={saving}
+      />
     </Flex>
   );
 };

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Flex, Box, Text, Grid, HStack, Button } from "@chakra-ui/react";
-import { useCallback, useReducer, useMemo, useState } from "react";
+import { useCallback, useReducer, useMemo, useState, forwardRef, useImperativeHandle } from "react";
 import SlideSequencer, { Slide, createInitialBoard } from "./SlideSequencer";
 import SlideElementsContainer, { BoardRow } from "./SlideElementsContainer";
 import ElementAttributesPane from "./ElementAttributesPane";
@@ -114,7 +114,11 @@ const AVAILABLE_ELEMENTS = [
   { type: "quiz", label: "Quiz" },
 ];
 
-export default function LessonEditor() {
+export interface LessonEditorHandle {
+  getContent: () => { slides: Slide[] };
+}
+
+const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(_, ref) {
   const initialSlide = {
     id: crypto.randomUUID(),
     title: "Slide 1",
@@ -131,6 +135,10 @@ export default function LessonEditor() {
 
   const [styleCollections, setStyleCollections] = useState<string[]>([]);
   const [isSaveStyleOpen, setIsSaveStyleOpen] = useState(false);
+
+  useImperativeHandle(ref, () => ({
+    getContent: () => ({ slides: state.slides }),
+  }), [state.slides]);
 
   const setSlides = useCallback(
     (updater: React.SetStateAction<Slide[]>) =>
@@ -542,3 +550,5 @@ export default function LessonEditor() {
     </Box>
   );
 }
+
+export default LessonEditor;

--- a/insight-fe/src/components/lesson/SaveLessonModal.tsx
+++ b/insight-fe/src/components/lesson/SaveLessonModal.tsx
@@ -1,0 +1,58 @@
+import { BaseModal } from "../modals/BaseModal";
+import { useForm, SubmitHandler } from "react-hook-form";
+import { Button, FormControl, FormLabel, Input, FormErrorMessage, HStack, Stack, Textarea } from "@chakra-ui/react";
+
+interface FormValues {
+  title: string;
+  description: string;
+}
+
+interface SaveLessonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: FormValues) => Promise<void>;
+  isSaving?: boolean;
+}
+
+export default function SaveLessonModal({ isOpen, onClose, onSave, isSaving = false }: SaveLessonModalProps) {
+  const { register, handleSubmit, formState: { errors }, reset } = useForm<FormValues>({
+    defaultValues: { title: "", description: "" },
+    mode: "onChange",
+  });
+
+  const onSubmit: SubmitHandler<FormValues> = async (values) => {
+    await onSave({
+      title: values.title.trim(),
+      description: values.description.trim(),
+    });
+    reset();
+  };
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Save Lesson"
+      footer={
+        <HStack>
+          <Button colorScheme="blue" type="submit" form="save-lesson-form" isLoading={isSaving}>
+            Save Lesson
+          </Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </HStack>
+      }
+    >
+      <Stack as="form" id="save-lesson-form" onSubmit={handleSubmit(onSubmit)} spacing={4}>
+        <FormControl isInvalid={!!errors.title} isRequired>
+          <FormLabel>Lesson name</FormLabel>
+          <Input {...register("title", { required: "Lesson name is required" })} />
+          <FormErrorMessage>{errors.title?.message}</FormErrorMessage>
+        </FormControl>
+        <FormControl>
+          <FormLabel>Description</FormLabel>
+          <Textarea {...register("description")} />
+        </FormControl>
+      </Stack>
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- add ability to expose lesson data from LessonEditor using a forwardRef
- create `SaveLessonModal` to capture title & description
- wire up modal in lesson builder page with createLesson mutation

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dd58cf98c8326805d8c95c58dff50