### PR TITLE
Fix style collection dropdown loading

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -1,7 +1,8 @@
 "use client";
 
 import { Flex, Box, Text, Grid, HStack, Button } from "@chakra-ui/react";
-import { useCallback, useReducer, useMemo, useState } from "react";
+import { useCallback, useReducer, useMemo, useState, useEffect } from "react";
+import { gql, useQuery } from "@apollo/client";
 import SlideSequencer, { Slide, createInitialBoard } from "./SlideSequencer";
 import SlideElementsContainer, { BoardRow } from "./SlideElementsContainer";
 import ElementAttributesPane from "./ElementAttributesPane";
@@ -114,6 +115,15 @@ const AVAILABLE_ELEMENTS = [
   { type: "quiz", label: "Quiz" },
 ];
 
+const GET_STYLE_COLLECTIONS = gql`
+  query GetStyleCollections($data: FindAllInput!) {
+    getAllStyleCollection(data: $data) {
+      id
+      name
+    }
+  }
+`;
+
 export default function LessonEditor() {
   const initialSlide = {
     id: crypto.randomUUID(),
@@ -133,6 +143,17 @@ export default function LessonEditor() {
     { id: number; name: string }[]
   >([]);
   const [isSaveStyleOpen, setIsSaveStyleOpen] = useState(false);
+
+  const { data: styleColData, loading: styleColLoading } = useQuery(
+    GET_STYLE_COLLECTIONS,
+    { variables: { data: { all: true } } }
+  );
+
+  useEffect(() => {
+    if (styleColData?.getAllStyleCollection) {
+      setStyleCollections(styleColData.getAllStyleCollection);
+    }
+  }, [styleColData]);
 
   const setSlides = useCallback(
     (updater: React.SetStateAction<Slide[]>) =>
@@ -537,6 +558,7 @@ export default function LessonEditor() {
         isOpen={isSaveStyleOpen}
         onClose={() => setIsSaveStyleOpen(false)}
         collections={styleCollections}
+        isLoading={styleColLoading}
         element={selectedElement?.type || ""}
         onSave={({ name, collectionId }) => {
           // Placeholder for backend call using style module

--- a/insight-fe/src/components/lesson/SaveStyleModal.tsx
+++ b/insight-fe/src/components/lesson/SaveStyleModal.tsx
@@ -18,6 +18,11 @@ interface SaveStyleModalProps {
    * selected id can be sent to the backend style module.
    */
   collections: { id: number; name: string }[];
+  /**
+   * Whether the collections are still loading from the server.
+   * When true, show a loading indicator in the dropdown.
+   */
+  isLoading?: boolean;
   /** Callback when the user adds a new collection */
   onAddCollection: (name: string) => void;
   /** Type of the element whose style is being saved */
@@ -30,6 +35,7 @@ export default function SaveStyleModal({
   isOpen,
   onClose,
   collections,
+  isLoading = false,
   onAddCollection,
   element,
   onSave,
@@ -53,10 +59,15 @@ export default function SaveStyleModal({
           <FormControl>
             <FormLabel>Collection</FormLabel>
             <Select
-              placeholder="Select collection"
               value={collectionId}
               onChange={(e) => setCollectionId(parseInt(e.target.value))}
             >
+              {isLoading && <option value="">Loading...</option>}
+              {!isLoading && (
+                <option key="__empty" value="">
+                  ─ select ─
+                </option>
+              )}
               {collections.map((c) => (
                 <option key={c.id} value={c.id}>
                   {c.name}


### PR DESCRIPTION
## Summary
- load style collections from GraphQL in `LessonEditor`
- show loading state in `SaveStyleModal`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dd88df1ac8326a07016ffc529d43d