### PR TITLE
Move dropdowns into Save Lesson modal

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -1,24 +1,14 @@
 "use client";
 
-import { Box, Flex, Text, Button } from "@chakra-ui/react";
+import { Flex, Button } from "@chakra-ui/react";
 import { useState, useRef } from "react";
-import LessonEditor, {
-  LessonEditorHandle,
-} from "@/components/lesson/LessonEditor";
-import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
-import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
-import TopicDropdown from "@/components/dropdowns/TopicDropdown";
+import LessonEditor, { LessonEditorHandle } from "@/components/lesson/LessonEditor";
 import SaveLessonModal from "@/components/lesson/SaveLessonModal";
 import { useMutation } from "@apollo/client";
 import { typedGql } from "@/zeus/typedDocumentNode";
 import { $ } from "@/zeus";
 
 export const LessonBuilderPageClient = () => {
-  const [{ yearGroupId, subjectId, topicId }, setDropdownIds] = useState<{
-    yearGroupId: string | null;
-    subjectId: string | null;
-    topicId: string | null;
-  }>({ yearGroupId: null, subjectId: null, topicId: null });
   const [isSaveOpen, setIsSaveOpen] = useState(false);
   const editorRef = useRef<LessonEditorHandle>(null);
 
@@ -33,9 +23,15 @@ export const LessonBuilderPageClient = () => {
   const handleSave = async ({
     title,
     description,
+    yearGroupId,
+    subjectId,
+    topicId,
   }: {
     title: string;
     description: string;
+    yearGroupId: string | null;
+    subjectId: string | null;
+    topicId: string | null;
   }) => {
     if (!yearGroupId || !subjectId || !topicId) return;
     const content = editorRef.current?.getContent() ?? { slides: [] };
@@ -57,46 +53,8 @@ export const LessonBuilderPageClient = () => {
 
   return (
     <Flex direction="column" gap={4}>
-      <Flex gap={8} alignItems="flex-end">
-        <Box>
-          <Text mb={2}>Year Group</Text>
-          <YearGroupDropdown
-            value={yearGroupId}
-            onChange={(id) =>
-              setDropdownIds({ yearGroupId: id, subjectId: null, topicId: null })
-            }
-          />
-        </Box>
-        <Box>
-          <Text mb={2}>Subject</Text>
-          <SubjectDropdown
-            yearGroupId={yearGroupId}
-            value={subjectId}
-            onChange={(id) =>
-              setDropdownIds({
-                yearGroupId,
-                subjectId: id,
-                topicId: null,
-              })
-            }
-          />
-        </Box>
-        <Box>
-          <Text mb={2}>Topic</Text>
-          <TopicDropdown
-            yearGroupId={yearGroupId}
-            subjectId={subjectId}
-            value={topicId}
-            onChange={(id) =>
-              setDropdownIds({ yearGroupId, subjectId, topicId: id })
-            }
-          />
-        </Box>
-        <Button
-          onClick={() => setIsSaveOpen(true)}
-          colorScheme="blue"
-          isDisabled={!yearGroupId || !subjectId || !topicId}
-        >
+      <Flex justifyContent="flex-end">
+        <Button onClick={() => setIsSaveOpen(true)} colorScheme="blue">
           Save Lesson
         </Button>
       </Flex>

--- a/insight-fe/src/components/lesson/SaveLessonModal.tsx
+++ b/insight-fe/src/components/lesson/SaveLessonModal.tsx
@@ -1,10 +1,26 @@
 import { BaseModal } from "../modals/BaseModal";
 import { useForm, SubmitHandler } from "react-hook-form";
-import { Button, FormControl, FormLabel, Input, FormErrorMessage, HStack, Stack, Textarea } from "@chakra-ui/react";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Input,
+  FormErrorMessage,
+  HStack,
+  Stack,
+  Textarea,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
+import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
+import TopicDropdown from "@/components/dropdowns/TopicDropdown";
 
 interface FormValues {
   title: string;
   description: string;
+  yearGroupId: string | null;
+  subjectId: string | null;
+  topicId: string | null;
 }
 
 interface SaveLessonModalProps {
@@ -15,17 +31,32 @@ interface SaveLessonModalProps {
 }
 
 export default function SaveLessonModal({ isOpen, onClose, onSave, isSaving = false }: SaveLessonModalProps) {
-  const { register, handleSubmit, formState: { errors }, reset } = useForm<FormValues>({
-    defaultValues: { title: "", description: "" },
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    reset,
+  } = useForm<FormValues>({
+    defaultValues: { title: "", description: "", yearGroupId: null, subjectId: null, topicId: null },
     mode: "onChange",
   });
+
+  const [yearGroupId, setYearGroupId] = useState<string | null>(null);
+  const [subjectId, setSubjectId] = useState<string | null>(null);
+  const [topicId, setTopicId] = useState<string | null>(null);
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     await onSave({
       title: values.title.trim(),
       description: values.description.trim(),
+      yearGroupId,
+      subjectId,
+      topicId,
     });
     reset();
+    setYearGroupId(null);
+    setSubjectId(null);
+    setTopicId(null);
   };
 
   return (
@@ -35,7 +66,13 @@ export default function SaveLessonModal({ isOpen, onClose, onSave, isSaving = fa
       title="Save Lesson"
       footer={
         <HStack>
-          <Button colorScheme="blue" type="submit" form="save-lesson-form" isLoading={isSaving}>
+          <Button
+            colorScheme="blue"
+            type="submit"
+            form="save-lesson-form"
+            isLoading={isSaving}
+            isDisabled={!yearGroupId || !subjectId || !topicId}
+          >
             Save Lesson
           </Button>
           <Button onClick={onClose}>Cancel</Button>
@@ -43,6 +80,37 @@ export default function SaveLessonModal({ isOpen, onClose, onSave, isSaving = fa
       }
     >
       <Stack as="form" id="save-lesson-form" onSubmit={handleSubmit(onSubmit)} spacing={4}>
+        <FormControl isRequired>
+          <FormLabel>Year Group</FormLabel>
+          <YearGroupDropdown
+            value={yearGroupId}
+            onChange={(id) => {
+              setYearGroupId(id);
+              setSubjectId(null);
+              setTopicId(null);
+            }}
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Subject</FormLabel>
+          <SubjectDropdown
+            yearGroupId={yearGroupId}
+            value={subjectId}
+            onChange={(id) => {
+              setSubjectId(id);
+              setTopicId(null);
+            }}
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Topic</FormLabel>
+          <TopicDropdown
+            yearGroupId={yearGroupId}
+            subjectId={subjectId}
+            value={topicId}
+            onChange={(id) => setTopicId(id)}
+          />
+        </FormControl>
         <FormControl isInvalid={!!errors.title} isRequired>
           <FormLabel>Lesson name</FormLabel>
           <Input {...register("title", { required: "Lesson name is required" })} />


### PR DESCRIPTION
## Summary
- shift Year, Subject and Topic dropdowns into `SaveLessonModal`
- simplify lesson builder page UI to open the modal directly

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683efb3d77e483268fefe6893e086ee2