### PR TITLE
Add lesson loading modal

### DIFF
--- a/insight-fe/src/components/dropdowns/LessonDropdown.tsx
+++ b/insight-fe/src/components/dropdowns/LessonDropdown.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import { ChangeEvent, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+import { typedGql } from "@/zeus/typedDocumentNode";
+import { $ } from "@/zeus";
+import SimpleDropdown from "./SimpleDropdown";
+
+const GET_LESSONS_FOR_TOPIC = typedGql("query")({
+  getTopic: [
+    { data: $("data", "IdInput!") },
+    {
+      id: true,
+      lessons: { id: true, title: true },
+    },
+  ],
+} as const);
+
+interface LessonDropdownProps {
+  topicId: string | null;
+  value: string | null;
+  onChange: (id: string | null) => void;
+}
+
+export default function LessonDropdown({ topicId, value, onChange }: LessonDropdownProps) {
+  const variables = useMemo(
+    () =>
+      topicId !== null
+        ? { data: { id: Number(topicId), relations: ["lessons"] } }
+        : undefined,
+    [topicId]
+  );
+
+  const { data, loading } = useQuery(GET_LESSONS_FOR_TOPIC, {
+    variables,
+    skip: topicId === null,
+  });
+
+  const lessons = topicId !== null ? data?.getTopic?.lessons ?? [] : [];
+
+  const options = useMemo(
+    () => lessons.map((l: any) => ({ label: l.title, value: String(l.id) })),
+    [lessons]
+  );
+
+  return (
+    <SimpleDropdown
+      options={options}
+      value={value ?? ""}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+        onChange(e.target.value || null)
+      }
+      isDisabled={topicId === null}
+    />
+  );
+}

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -134,6 +134,7 @@ const AVAILABLE_ELEMENTS = [
 
 export interface LessonEditorHandle {
   getContent: () => { slides: Slide[] };
+  setContent: (slides: Slide[]) => void;
 }
 
 const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
@@ -171,8 +172,12 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     ref,
     () => ({
       getContent: () => ({ slides: state.slides }),
+      setContent: (slides: Slide[]) => {
+        dispatch({ type: "setSlides", updater: slides });
+        dispatch({ type: "selectSlide", id: slides[0]?.id ?? null });
+      },
     }),
-    [state.slides]
+    [state.slides, dispatch]
   );
 
   const setSlides = useCallback(

--- a/insight-fe/src/components/lesson/LoadLessonModal.tsx
+++ b/insight-fe/src/components/lesson/LoadLessonModal.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { BaseModal } from "../modals/BaseModal";
+import { Button, FormControl, FormLabel, HStack, Stack } from "@chakra-ui/react";
+import { useState } from "react";
+import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
+import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
+import TopicDropdown from "@/components/dropdowns/TopicDropdown";
+import LessonDropdown from "@/components/dropdowns/LessonDropdown";
+
+interface LoadLessonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onLoad: (lessonId: string) => Promise<void>;
+  isLoading?: boolean;
+}
+
+export default function LoadLessonModal({
+  isOpen,
+  onClose,
+  onLoad,
+  isLoading = false,
+}: LoadLessonModalProps) {
+  const [yearGroupId, setYearGroupId] = useState<string | null>(null);
+  const [subjectId, setSubjectId] = useState<string | null>(null);
+  const [topicId, setTopicId] = useState<string | null>(null);
+  const [lessonId, setLessonId] = useState<string | null>(null);
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Load Lesson"
+      footer={
+        <HStack>
+          <Button
+            colorScheme="blue"
+            onClick={() => lessonId && onLoad(lessonId)}
+            isDisabled={!lessonId}
+            isLoading={isLoading}
+          >
+            Load Lesson
+          </Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </HStack>
+      }
+    >
+      <Stack spacing={4}>
+        <FormControl isRequired>
+          <FormLabel>Year Group</FormLabel>
+          <YearGroupDropdown
+            value={yearGroupId}
+            onChange={(id) => {
+              setYearGroupId(id);
+              setSubjectId(null);
+              setTopicId(null);
+              setLessonId(null);
+            }}
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Subject</FormLabel>
+          <SubjectDropdown
+            yearGroupId={yearGroupId}
+            value={subjectId}
+            onChange={(id) => {
+              setSubjectId(id);
+              setTopicId(null);
+              setLessonId(null);
+            }}
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Topic</FormLabel>
+          <TopicDropdown
+            yearGroupId={yearGroupId}
+            subjectId={subjectId}
+            value={topicId}
+            onChange={(id) => {
+              setTopicId(id);
+              setLessonId(null);
+            }}
+          />
+        </FormControl>
+        <FormControl isRequired>
+          <FormLabel>Lesson</FormLabel>
+          <LessonDropdown
+            topicId={topicId}
+            value={lessonId}
+            onChange={(id) => setLessonId(id)}
+          />
+        </FormControl>
+      </Stack>
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- add `LessonDropdown` component to select lessons
- add `LoadLessonModal` with sequential dropdowns
- enable setting content via `LessonEditor` ref
- hook up Load Lesson button in `LessonBuilderPageClient`

## Testing
- `npm --prefix insight-fe run lint` *(fails: `next` not found)*
- `npm --prefix insight-be run lint` *(fails: cannot find `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_683f0961c3f88326b59cee1f9e0f1c13