### PR TITLE
Update lesson editor column styles

### DIFF
--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -52,6 +52,9 @@ const columnBaseStyles = {
   transition: "background 200ms ease-in-out",
   flex: 1,
   overflowY: "auto",
+  borderWidth: "1px",
+  borderStyle: "dashed",
+  borderColor: "gray.300",
 };
 
 const idleStyles = { cursor: "grab" };
@@ -59,8 +62,8 @@ const cardOverStyles = { bg: "blue.50" };
 const isDraggingStyles = { opacity: 0.4 };
 
 const columnHeaderStyles = {
-  px: 4,
-  py: 3,
+  px: 2,
+  py: 1,
   color: "gray.500",
   userSelect: "none",
 };

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -77,8 +77,8 @@ export default function SlideElementsBoard({
       title: "",
       columnId: id,
       styles: {
-        container: { border: `2px dashed ${color}`, width: "100%" },
-        header: { bg: color, color: "white" },
+        container: { border: "1px dashed gray", width: "100%" },
+        header: { bg: color, color: "white", px: 2, py: 1 },
       },
       wrapperStyles: {
         bgColor: "#ffffff",

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -70,8 +70,8 @@ export default function SlideElementsContainer({
       title: "",
       columnId,
       styles: {
-        container: { border: `2px dashed ${color}`, width: "100%" },
-        header: { bg: color, color: "white" },
+        container: { border: "1px dashed gray", width: "100%" },
+        header: { bg: color, color: "white", px: 2, py: 1 },
       },
       wrapperStyles: {
         bgColor: "#ffffff",

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -45,8 +45,8 @@ export const createInitialBoard = (): {
         title: "",
         columnId,
         styles: {
-          container: { border: "2px dashed red", width: "100%" },
-          header: { bg: "red.300", color: "white" },
+          container: { border: "1px dashed gray", width: "100%" },
+          header: { bg: "red.300", color: "white", px: 2, py: 1 },
         },
         wrapperStyles: {
           bgColor: "#ffffff",


### PR DESCRIPTION
## Summary
- add 1px grey dashed borders to columns
- thin out column headers so they match button size

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in insight-fe *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f0aaac350832686d7519eeaa079b6