### PR TITLE
Enable drag reordering of lesson containers

### DIFF
--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -12,6 +12,7 @@ import {
   monitorForElements,
   dropTargetForElements,
 } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { autoScrollWindowForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
 import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
 import { reorder } from "@atlaskit/pragmatic-drag-and-drop/reorder";
 import {
@@ -178,6 +179,14 @@ export default function SlideElementsContainer({
         source.data.type === "board",
       getData: () => ({ columnId: "boards" }),
       getIsSticky: () => true,
+    });
+  }, []);
+
+  useEffect(() => {
+    return autoScrollWindowForElements({
+      canScroll: ({ source }) =>
+        source.data.instanceId === boardInstanceId.current &&
+        source.data.type === "board",
     });
   }, []);
 


### PR DESCRIPTION
## Summary
- allow boards in LessonEditor to be draggable
- support board reorder handling in `SlideElementsContainer`

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` in insight-be *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f1a9381b88326959c3fc3d2841fbd