### PR TITLE
Update SaveStyleModal element handling

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -132,6 +132,14 @@ const AVAILABLE_ELEMENTS = [
   { type: "quiz", label: "Quiz" },
 ];
 
+const ELEMENT_TYPE_TO_ENUM: Record<string, string> = {
+  text: "Text",
+  table: "Table",
+  image: "Image",
+  video: "Video",
+  quiz: "Quiz",
+};
+
 export interface LessonEditorHandle {
   getContent: () => { slides: Slide[] };
   setContent: (slides: Slide[]) => void;
@@ -593,12 +601,13 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         isOpen={isSaveStyleOpen}
         onClose={() => setIsSaveStyleOpen(false)}
         collections={styleCollections}
-        element={selectedElement?.type || ""}
         onSave={({ name, collectionId }) => {
+          if (!selectedElement) return;
           // Placeholder for backend call using style module
           console.log("save style", {
             name,
             collectionId,
+            element: ELEMENT_TYPE_TO_ENUM[selectedElement.type],
             config: selectedElement,
           });
         }}

--- a/insight-fe/src/components/lesson/SaveStyleModal.tsx
+++ b/insight-fe/src/components/lesson/SaveStyleModal.tsx
@@ -30,8 +30,6 @@ interface SaveStyleModalProps {
   collections: { id: number; name: string }[];
   /** Callback when the user adds a new collection */
   onAddCollection: (collection: { id: number; name: string }) => void;
-  /** Type of the element whose style is being saved */
-  element: string;
   /** Callback executed when user submits the form */
   onSave: (data: { name: string; collectionId: number }) => void;
 }
@@ -41,7 +39,6 @@ export default function SaveStyleModal({
   onClose,
   collections,
   onAddCollection,
-  element,
   onSave,
 }: SaveStyleModalProps) {
   const [isAddOpen, setIsAddOpen] = useState(false);
@@ -56,10 +53,6 @@ export default function SaveStyleModal({
           <FormControl>
             <FormLabel>Style Name</FormLabel>
             <Input value={name} onChange={(e) => setName(e.target.value)} />
-          </FormControl>
-          <FormControl>
-            <FormLabel>Element</FormLabel>
-            <Input value={element} isReadOnly />
           </FormControl>
           <FormControl>
             <FormLabel>Collection</FormLabel>


### PR DESCRIPTION
## Summary
- remove the element field from SaveStyleModal
- infer element type in LessonEditor and pass to save action

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f2120fc5c8326809260e9427280e5