### PR TITLE
Add load style button and modal

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -21,6 +21,7 @@ import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnD
 import { ColumnType } from "@/components/DnD/types";
 import { availableFonts } from "@/theme/fonts";
 import SaveStyleModal from "./SaveStyleModal";
+import LoadStyleModal from "./LoadStyleModal";
 
 const GET_STYLE_COLLECTIONS = gql`
   query GetStyleCollections {
@@ -167,6 +168,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     { id: number; name: string }[]
   >([]);
   const [isSaveStyleOpen, setIsSaveStyleOpen] = useState(false);
+  const [isLoadStyleOpen, setIsLoadStyleOpen] = useState(false);
 
   const { data: collectionsData } = useQuery(GET_STYLE_COLLECTIONS);
 
@@ -569,9 +571,14 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
             <Box p={4} borderWidth="1px" borderRadius="md" minW="200px">
               <HStack justify="space-between" mb={2}>
                 <Text>Attributes</Text>
-                <Button size="xs" onClick={() => setIsSaveStyleOpen(true)}>
-                  Save Style
-                </Button>
+                <HStack>
+                  <Button size="xs" onClick={() => setIsLoadStyleOpen(true)}>
+                    Load Style
+                  </Button>
+                  <Button size="xs" onClick={() => setIsSaveStyleOpen(true)}>
+                    Save Style
+                  </Button>
+                </HStack>
               </HStack>
               {selectedElement && (
                 <ElementAttributesPane
@@ -614,6 +621,16 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         onAddCollection={(collection) =>
           setStyleCollections([...styleCollections, collection])
         }
+      />
+      <LoadStyleModal
+        isOpen={isLoadStyleOpen}
+        onClose={() => setIsLoadStyleOpen(false)}
+        collections={styleCollections}
+        onLoad={(collectionId) => {
+          if (!selectedElement) return;
+          // Placeholder for backend call using style module
+          console.log("load style", { collectionId });
+        }}
       />
     </Box>
   );

--- a/insight-fe/src/components/lesson/LoadStyleModal.tsx
+++ b/insight-fe/src/components/lesson/LoadStyleModal.tsx
@@ -1,0 +1,61 @@
+import { useState } from "react";
+import {
+  Button,
+  FormControl,
+  FormLabel,
+  Select,
+  Stack,
+} from "@chakra-ui/react";
+import { BaseModal } from "../modals/BaseModal";
+
+interface LoadStyleModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Style collections available for loading */
+  collections: { id: number; name: string }[];
+  /** Callback executed when user chooses a collection */
+  onLoad: (collectionId: number) => void;
+}
+
+export default function LoadStyleModal({
+  isOpen,
+  onClose,
+  collections,
+  onLoad,
+}: LoadStyleModalProps) {
+  const [collectionId, setCollectionId] = useState<number | "">("");
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} title="Load Style">
+      <Stack spacing={4}>
+        <FormControl>
+          <FormLabel>Collection</FormLabel>
+          <Select
+            placeholder="Select collection"
+            value={collectionId}
+            onChange={(e) => setCollectionId(parseInt(e.target.value))}
+          >
+            {collections.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </Select>
+        </FormControl>
+        <Button
+          colorScheme="blue"
+          isDisabled={collectionId === ""}
+          onClick={() => {
+            if (collectionId !== "") {
+              onLoad(collectionId);
+              setCollectionId("");
+              onClose();
+            }
+          }}
+        >
+          Load
+        </Button>
+      </Stack>
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- load style dropdown modal
- wire up new LoadStyleModal in LessonEditor next to Save Style button

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f24d96e408326b82b395da11fa84d