### PR TITLE
Hide board controls until hovered

### DIFF
--- a/insight-fe/src/components/DnD/DnDBoardMain.tsx
+++ b/insight-fe/src/components/DnD/DnDBoardMain.tsx
@@ -95,6 +95,8 @@ export interface DnDBoardMainProps<TCard extends BaseCardDnD> {
   registry?: ReturnType<typeof createRegistry>;
   /** Spacing between columns */
   spacing?: number;
+  /** Whether column headers should be visible */
+  showControls?: boolean;
   /**
    * When `true` this component is *controlled*:
    *  - It never stores its own copy of the board.
@@ -122,6 +124,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
   instanceId: instanceIdProp,
   registry: registryProp,
   spacing = 0,
+  showControls = true,
   controlled = false,
 }: DnDBoardMainProps<TCard>) => {
   /* -----------------------------------------------------------------------
@@ -614,6 +617,7 @@ export const DnDBoardMain = <TCard extends BaseCardDnD>({
               onRemoveColumn={onRemoveColumn}
               onSelectColumn={onSelectColumn}
               isSelected={selectedColumnId === columnId}
+              showControls={showControls}
               externalDropIndex={
                 externalDropIndicator &&
                 externalDropIndicator.columnId === columnId

--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -110,6 +110,7 @@ interface ColumnProps<TCard extends BaseCardDnD> {
   externalDropIndex?: number | null;
   onSelectColumn?: (columnId: string) => void;
   isSelected?: boolean;
+  showControls?: boolean;
 }
 
 function ColumnBase<TCard extends BaseCardDnD>({
@@ -121,6 +122,7 @@ function ColumnBase<TCard extends BaseCardDnD>({
   externalDropIndex = null,
   onSelectColumn,
   isSelected = false,
+  showControls = true,
 }: ColumnProps<TCard>) {
   const columnId = column.columnId;
   const columnRef = useRef<HTMLDivElement | null>(null);
@@ -347,6 +349,9 @@ function ColumnBase<TCard extends BaseCardDnD>({
               align="center"
               sx={{ ...columnHeaderStyles, ...(column.styles?.header ?? {}) }}
               data-testid={`column-header-${columnId}`}
+              transform={showControls ? "translateY(0)" : "translateY(100%)"}
+              transition="transform 0.2s"
+              pointerEvents={showControls ? "auto" : "none"}
             >
               <Heading as="span" size="xs">
                 {column.title}

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -211,6 +211,7 @@ export default function SlideElementsBoard({
     <Box
       ref={boardRef}
       position="relative"
+      overflow="hidden"
       onMouseMove={handleMouseMove}
       onMouseLeave={handleMouseLeave}
     >
@@ -227,11 +228,11 @@ export default function SlideElementsBoard({
         top={0}
         right={0}
         left={0}
-        zIndex={1}
-        transform={showControls ? "translateY(0)" : "translateY(-100%)"}
+        zIndex={showControls ? 1 : 0}
+        transform={showControls ? "translateY(0)" : "translateY(100%)"}
         transition="transform 0.2s"
         pointerEvents={showControls ? "auto" : "none"}
-      >
+        >
         {onRemoveBoard && (
           <IconButton
             aria-label="Delete container"
@@ -280,6 +281,7 @@ export default function SlideElementsBoard({
             instanceId={instanceId}
             registry={registry}
             spacing={spacing}
+            showControls={showControls}
           />
         </ContentCard>
       </ElementWrapper>


### PR DESCRIPTION
## Summary
- adjust board header controls to be hidden until hovering near the top
- add slide-in transition for board header

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f25a15ea4832683e2e68ec5554131