### PR TITLE
Fix default container backgrounds

### DIFF
--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -25,7 +25,7 @@ interface BoardAttributesPaneProps {
 
 export default function BoardAttributesPane({ board, onChange }: BoardAttributesPaneProps) {
   const [bgColor, setBgColor] = useState(board.wrapperStyles?.bgColor || "#ffffff");
-  const [bgOpacity, setBgOpacity] = useState(board.wrapperStyles?.bgOpacity ?? 0);
+  const [bgOpacity, setBgOpacity] = useState(board.wrapperStyles?.bgOpacity ?? 1);
   const [shadow, setShadow] = useState(board.wrapperStyles?.dropShadow || "none");
   const [paddingX, setPaddingX] = useState(board.wrapperStyles?.paddingX ?? 0);
   const [paddingY, setPaddingY] = useState(board.wrapperStyles?.paddingY ?? 0);
@@ -38,7 +38,7 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
 
   useEffect(() => {
     setBgColor(board.wrapperStyles?.bgColor || "#ffffff");
-    setBgOpacity(board.wrapperStyles?.bgOpacity ?? 0);
+    setBgOpacity(board.wrapperStyles?.bgOpacity ?? 1);
     setShadow(board.wrapperStyles?.dropShadow || "none");
     setPaddingX(board.wrapperStyles?.paddingX ?? 0);
     setPaddingY(board.wrapperStyles?.paddingY ?? 0);

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -108,7 +108,7 @@ export default function SlideElementsContainer({
         orderedColumnIds: [columnId],
         wrapperStyles: {
           bgColor: "#ffffff",
-          bgOpacity: 0,
+          bgOpacity: 1,
           dropShadow: "none",
           paddingX: 0,
           paddingY: 0,

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -69,7 +69,7 @@ export const createInitialBoard = (): {
         orderedColumnIds: [columnId],
         wrapperStyles: {
           bgColor: "#ffffff",
-          bgOpacity: 0,
+          bgOpacity: 1,
           dropShadow: "none",
           paddingX: 0,
           paddingY: 0,


### PR DESCRIPTION
## Summary
- set container background opacity to `1` when creating boards
- adjust BoardAttributesPane default opacity

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `insight-fe` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f310f52c48326a40ef4b1442365e3