### PR TITLE
Add lesson preview modal

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -3,6 +3,8 @@
 import { Flex, Button } from "@chakra-ui/react";
 import { useState, useRef } from "react";
 import LessonEditor, { LessonEditorHandle } from "@/components/lesson/LessonEditor";
+import LessonPreviewModal from "@/components/lesson/LessonPreviewModal";
+import { Slide } from "@/components/lesson/SlideSequencer";
 import SaveLessonModal from "@/components/lesson/SaveLessonModal";
 import LoadLessonModal from "@/components/lesson/LoadLessonModal";
 import { useMutation, useLazyQuery } from "@apollo/client";
@@ -12,6 +14,8 @@ import { $ } from "@/zeus";
 export const LessonBuilderPageClient = () => {
   const [isSaveOpen, setIsSaveOpen] = useState(false);
   const [isLoadOpen, setIsLoadOpen] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
+  const [previewSlides, setPreviewSlides] = useState<Slide[]>([]);
   const editorRef = useRef<LessonEditorHandle>(null);
 
   const CREATE_LESSON = typedGql("mutation")({
@@ -30,6 +34,12 @@ export const LessonBuilderPageClient = () => {
   });
 
   const [fetchLesson, { loading: loadingLesson }] = useLazyQuery(GET_LESSON);
+
+  const openPreview = () => {
+    const slides = editorRef.current?.getContent().slides ?? [];
+    setPreviewSlides(slides);
+    setIsPreviewOpen(true);
+  };
 
   const handleSave = async ({
     title,
@@ -74,6 +84,7 @@ export const LessonBuilderPageClient = () => {
   return (
     <Flex direction="column" gap={4}>
       <Flex justifyContent="flex-end" gap={2}>
+        <Button onClick={openPreview}>Show Preview</Button>
         <Button onClick={() => setIsLoadOpen(true)}>Load Lesson</Button>
         <Button onClick={() => setIsSaveOpen(true)} colorScheme="blue">
           Save Lesson
@@ -95,6 +106,13 @@ export const LessonBuilderPageClient = () => {
           onClose={() => setIsLoadOpen(false)}
           onLoad={handleLoad}
           isLoading={loadingLesson}
+        />
+      )}
+      {isPreviewOpen && (
+        <LessonPreviewModal
+          isOpen={isPreviewOpen}
+          onClose={() => setIsPreviewOpen(false)}
+          slides={previewSlides}
         />
       )}
     </Flex>

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -16,7 +16,6 @@ import SlideElementsContainer, { BoardRow } from "./SlideElementsContainer";
 import ElementAttributesPane from "./ElementAttributesPane";
 import ColumnAttributesPane from "./ColumnAttributesPane";
 import BoardAttributesPane from "./BoardAttributesPane";
-import SlidePreview from "./SlidePreview";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnType } from "@/components/DnD/types";
 import { availableFonts } from "@/theme/fonts";
@@ -521,7 +520,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
           onSelect={(id) => dispatch({ type: "selectSlide", id })}
         />
         {state.selectedSlideId && (
-          <Grid gap={4} flex={1} templateColumns="1fr 1fr 300px">
+          <Grid gap={4} flex={1} templateColumns="1fr 300px">
             <Box
               flex="1"
               p={4}
@@ -555,19 +554,6 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
                 onSelectBoard={(id) => dispatch({ type: "selectBoard", id })}
               />
             </Box>
-            <Box
-              p={4}
-              borderWidth="1px"
-              borderRadius="md"
-              minW="300px"
-              bgColor="white"
-            >
-              <SlidePreview
-                columnMap={selectedSlide!.columnMap}
-                boards={selectedSlide!.boards}
-              />
-            </Box>
-
             <Box p={4} borderWidth="1px" borderRadius="md" minW="200px">
               <HStack justify="space-between" mb={2}>
                 <Text>Attributes</Text>

--- a/insight-fe/src/components/lesson/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/LessonPreviewModal.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { Box, Stack, Text } from "@chakra-ui/react";
+import { BaseModal } from "../modals/BaseModal";
+import SlidePreview from "./SlidePreview";
+import { Slide } from "./SlideSequencer";
+
+interface LessonPreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  slides: Slide[];
+}
+
+export default function LessonPreviewModal({
+  isOpen,
+  onClose,
+  slides,
+}: LessonPreviewModalProps) {
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="6xl" title="Lesson Preview">
+      <Stack spacing={6} py={2}>
+        {slides.length === 0 && <Text>No slides available</Text>}
+        {slides.map((slide) => (
+          <Box key={slide.id}>
+            <Text mb={2} fontWeight="bold">
+              {slide.title}
+            </Text>
+            <SlidePreview columnMap={slide.columnMap} boards={slide.boards} />
+          </Box>
+        ))}
+      </Stack>
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- add `LessonPreviewModal` component to display slides
- show preview modal from lesson builder
- remove inline preview from lesson editor

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f34a482388326a41340dd1b884d6c