### PR TITLE
Improve lesson editor color picker performance

### DIFF
--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -16,6 +16,7 @@ import {
   HStack,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import useDebouncedEffect from "@/hooks/useDebouncedEffect";
 import type { BoardRow } from "./SlideElementsContainer";
 
 interface BoardAttributesPaneProps {
@@ -50,24 +51,28 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
     setSpacing(board.spacing ?? 0);
   }, [board.id]);
 
-  useEffect(() => {
-    onChange({
-      ...board,
-      wrapperStyles: {
-        bgColor,
-        bgOpacity,
-        dropShadow: shadow,
-        paddingX,
-        paddingY,
-        marginX,
-        marginY,
-        borderColor,
-        borderWidth,
-        borderRadius,
-      },
-      spacing,
-    });
-  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
+  useDebouncedEffect(
+    () => {
+      onChange({
+        ...board,
+        wrapperStyles: {
+          bgColor,
+          bgOpacity,
+          dropShadow: shadow,
+          paddingX,
+          paddingY,
+          marginX,
+          marginY,
+          borderColor,
+          borderWidth,
+          borderRadius,
+        },
+        spacing,
+      });
+    },
+    [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing],
+    100
+  );
 
   return (
     <Accordion allowMultiple>

--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -16,6 +16,7 @@ import {
   HStack,
 } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
+import useDebouncedEffect from "@/hooks/useDebouncedEffect";
 import { ColumnType } from "@/components/DnD/types";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
@@ -51,24 +52,28 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
     setSpacing(column.spacing ?? 0);
   }, [column.columnId]);
 
-  useEffect(() => {
-    onChange({
-      ...column,
-      wrapperStyles: {
-        bgColor,
-        bgOpacity,
-        dropShadow: shadow,
-        paddingX,
-        paddingY,
-        marginX,
-        marginY,
-        borderColor,
-        borderWidth,
-        borderRadius,
-      },
-      spacing,
-    });
-  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
+  useDebouncedEffect(
+    () => {
+      onChange({
+        ...column,
+        wrapperStyles: {
+          bgColor,
+          bgOpacity,
+          dropShadow: shadow,
+          paddingX,
+          paddingY,
+          marginX,
+          marginY,
+          borderColor,
+          borderWidth,
+          borderRadius,
+        },
+        spacing,
+      });
+    },
+    [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing],
+    100
+  );
 
   return (
     <Accordion allowMultiple>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -23,6 +23,7 @@ import { Trash2 } from "lucide-react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import EditQuizModal from "./EditQuizModal";
 import { useEffect, useState } from "react";
+import useDebouncedEffect from "@/hooks/useDebouncedEffect";
 
 interface ElementAttributesPaneProps {
   element: SlideElementDnDItemProps;
@@ -115,52 +116,54 @@ export default function ElementAttributesPane({
     setBorderRadius(element.wrapperStyles?.borderRadius || "none");
   }, [element.id, element.type]);
 
-  useEffect(() => {
-    const updated: SlideElementDnDItemProps = {
-      ...element,
-      wrapperStyles: {
-        bgColor,
-        bgOpacity,
-        dropShadow: shadow,
-        paddingX,
-        paddingY,
-        marginX,
-        marginY,
-        borderColor,
-        borderWidth,
-        borderRadius,
-      },
-    };
-    if (element.type === "text") {
-      updated.text = text;
-      updated.styles = {
-        ...element.styles,
-        color,
-        fontSize,
-        fontFamily,
-        fontWeight,
-        lineHeight,
-        textAlign,
+  useDebouncedEffect(
+    () => {
+      const updated: SlideElementDnDItemProps = {
+        ...element,
+        wrapperStyles: {
+          bgColor,
+          bgOpacity,
+          dropShadow: shadow,
+          paddingX,
+          paddingY,
+          marginX,
+          marginY,
+          borderColor,
+          borderWidth,
+          borderRadius,
+        },
       };
-    }
-    if (element.type === "image") {
-      updated.src = src;
-    }
-    if (element.type === "video") {
-      updated.url = url;
-    }
-    if (element.type === "quiz") {
-      updated.title = title;
-      updated.description = description;
-      updated.questions = questions;
-    }
-    onChange(updated);
-  }, [
-    color,
-    fontSize,
-    fontFamily,
-    fontWeight,
-    lineHeight,
+      if (element.type === "text") {
+        updated.text = text;
+        updated.styles = {
+          ...element.styles,
+          color,
+          fontSize,
+          fontFamily,
+          fontWeight,
+          lineHeight,
+          textAlign,
+        };
+      }
+      if (element.type === "image") {
+        updated.src = src;
+      }
+      if (element.type === "video") {
+        updated.url = url;
+      }
+      if (element.type === "quiz") {
+        updated.title = title;
+        updated.description = description;
+        updated.questions = questions;
+      }
+      onChange(updated);
+    },
+    [
+      color,
+      fontSize,
+      fontFamily,
+      fontWeight,
+      lineHeight,
     textAlign,
     text,
     src,
@@ -178,7 +181,9 @@ export default function ElementAttributesPane({
     borderColor,
     borderWidth,
     borderRadius,
-  ]);
+  ],
+    100
+  );
 
   return (
     <>

--- a/insight-fe/src/hooks/useDebouncedEffect.ts
+++ b/insight-fe/src/hooks/useDebouncedEffect.ts
@@ -1,0 +1,18 @@
+"use client";
+import { useEffect, useRef } from "react";
+
+export default function useDebouncedEffect(
+  effect: () => void,
+  deps: React.DependencyList,
+  delay: number
+) {
+  const handler = useRef<NodeJS.Timeout>();
+
+  useEffect(() => {
+    if (handler.current) clearTimeout(handler.current);
+    handler.current = setTimeout(effect, delay);
+    return () => {
+      if (handler.current) clearTimeout(handler.current);
+    };
+  }, [...deps, delay]);
+}


### PR DESCRIPTION
## Summary
- add a reusable `useDebouncedEffect` hook
- debounce attribute updates in lesson editor panels

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f355bc9b88326aad451bff25133e8