### PR TITLE
Remove drag-and-drop card shadows

### DIFF
--- a/insight-fe/src/components/DnD/types.ts
+++ b/insight-fe/src/components/DnD/types.ts
@@ -14,13 +14,11 @@ export const getStateStyle = (state: State["type"]) => {
     case "idle":
       return {
         cursor: "grab",
-        boxShadow: "md",
         opacity: 1,
       };
     case "dragging":
       return {
         opacity: 0.4,
-        boxShadow: "md",
       };
     case "preview":
       return {};


### PR DESCRIPTION
## Summary
- tweak drag-and-drop state styles so elements no longer have drop shadows

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f37f2736c8326b440224a9c5d7bd8