### PR TITLE
Add background accordion to editor

### DIFF
--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -74,14 +74,14 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
       <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
         <h2>
           <AccordionButton>
-            <Box flex="1" textAlign="left">Wrapper</Box>
+            <Box flex="1" textAlign="left">Background</Box>
             <AccordionIcon />
           </AccordionButton>
         </h2>
         <AccordionPanel pb={2}>
           <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Background</FormLabel>
+              <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
               <Input
                 type="color"
                 value={bgColor}
@@ -91,6 +91,19 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
                 }}
               />
             </FormControl>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">Wrapper</Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
               <FormLabel mb="0" fontSize="sm" w="40%">Shadow</FormLabel>
               <Select size="sm" value={shadow} onChange={(e) => setShadow(e.target.value)}>

--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -75,14 +75,14 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
       <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
         <h2>
           <AccordionButton>
-            <Box flex="1" textAlign="left">Wrapper</Box>
+            <Box flex="1" textAlign="left">Background</Box>
             <AccordionIcon />
           </AccordionButton>
         </h2>
         <AccordionPanel pb={2}>
           <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Background</FormLabel>
+              <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
               <Input
                 type="color"
                 value={bgColor}
@@ -92,6 +92,19 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
                 }}
               />
             </FormControl>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">Wrapper</Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
               <FormLabel mb="0" fontSize="sm" w="40%">Shadow</FormLabel>
               <Select size="sm" value={shadow} onChange={(e) => setShadow(e.target.value)}>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -192,7 +192,7 @@ export default function ElementAttributesPane({
         <h2>
           <AccordionButton>
             <Box flex="1" textAlign="left">
-              Wrapper
+              Background
             </Box>
             <AccordionIcon />
           </AccordionButton>
@@ -200,9 +200,7 @@ export default function ElementAttributesPane({
         <AccordionPanel pb={2}>
           <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">
-                Background
-              </FormLabel>
+              <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
               <Input
                 type="color"
                 value={bgColor}
@@ -212,6 +210,26 @@ export default function ElementAttributesPane({
                 }}
               />
             </FormControl>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem
+        borderWidth="1px"
+        borderColor="blue.300"
+        borderRadius="md"
+        mb={2}
+      >
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">
+              Wrapper
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
               <FormLabel mb="0" fontSize="sm" w="40%">
                 Shadow


### PR DESCRIPTION
## Summary
- add a separate Background accordion in element attributes
- add the same Background accordion in board and column attributes

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: missing script)*
- `npm run lint` in `insight-be` *(fails: cannot find ESLint module)*
- `npm test` in `insight-be` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f389ba988832685e7ab3b7b4b5ca8