### PR TITLE
Add extra border radius presets

### DIFF
--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -172,6 +172,10 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
                 <option value="sm">Small</option>
                 <option value="md">Medium</option>
                 <option value="lg">Large</option>
+                <option value="xl">Extra Large</option>
+                <option value="2xl">2x Large</option>
+                <option value="3xl">3x Large</option>
+                <option value="full">Fully Rounded</option>
                 <option value="50%">Circular</option>
               </Select>
             </FormControl>

--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -173,6 +173,10 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
                 <option value="sm">Small</option>
                 <option value="md">Medium</option>
                 <option value="lg">Large</option>
+                <option value="xl">Extra Large</option>
+                <option value="2xl">2x Large</option>
+                <option value="3xl">3x Large</option>
+                <option value="full">Fully Rounded</option>
                 <option value="50%">Circular</option>
               </Select>
             </FormControl>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -364,6 +364,10 @@ export default function ElementAttributesPane({
                 <option value="sm">Small</option>
                 <option value="md">Medium</option>
                 <option value="lg">Large</option>
+                <option value="xl">Extra Large</option>
+                <option value="2xl">2x Large</option>
+                <option value="3xl">3x Large</option>
+                <option value="full">Fully Rounded</option>
                 <option value="50%">Circular</option>
               </Select>
             </FormControl>


### PR DESCRIPTION
## Summary
- expand border radius options in each attributes panel

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3f2839248326a22a492e2ebbeee6