### PR TITLE
Add gradient background controls

### DIFF
--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -298,12 +298,20 @@ function ColumnBase<TCard extends BaseCardDnD>({
     ...columnBaseStyles,
     ...(column.wrapperStyles
       ? {
-          bg: column.wrapperStyles.bgColor
-            ? hexToRgba(
-                column.wrapperStyles.bgColor,
-                column.wrapperStyles.bgOpacity ?? 0,
-              )
-            : undefined,
+          bg:
+            column.wrapperStyles.gradientFrom &&
+            column.wrapperStyles.gradientTo
+              ? `linear-gradient(${
+                  column.wrapperStyles.gradientDirection ?? 0
+                }deg, ${column.wrapperStyles.gradientFrom}, ${
+                  column.wrapperStyles.gradientTo
+                })`
+              : column.wrapperStyles.bgColor
+              ? hexToRgba(
+                  column.wrapperStyles.bgColor,
+                  column.wrapperStyles.bgOpacity ?? 0,
+                )
+              : undefined,
           boxShadow: column.wrapperStyles.dropShadow,
           px: column.wrapperStyles.paddingX,
           py: column.wrapperStyles.paddingY,

--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -26,6 +26,11 @@ interface BoardAttributesPaneProps {
 export default function BoardAttributesPane({ board, onChange }: BoardAttributesPaneProps) {
   const [bgColor, setBgColor] = useState(board.wrapperStyles?.bgColor || "#ffffff");
   const [bgOpacity, setBgOpacity] = useState(board.wrapperStyles?.bgOpacity ?? 1);
+  const [gradientFrom, setGradientFrom] = useState(board.wrapperStyles?.gradientFrom || "");
+  const [gradientTo, setGradientTo] = useState(board.wrapperStyles?.gradientTo || "");
+  const [gradientDirection, setGradientDirection] = useState(
+    board.wrapperStyles?.gradientDirection ?? 0
+  );
   const [shadow, setShadow] = useState(board.wrapperStyles?.dropShadow || "none");
   const [paddingX, setPaddingX] = useState(board.wrapperStyles?.paddingX ?? 0);
   const [paddingY, setPaddingY] = useState(board.wrapperStyles?.paddingY ?? 0);
@@ -39,6 +44,9 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
   useEffect(() => {
     setBgColor(board.wrapperStyles?.bgColor || "#ffffff");
     setBgOpacity(board.wrapperStyles?.bgOpacity ?? 1);
+    setGradientFrom(board.wrapperStyles?.gradientFrom || "");
+    setGradientTo(board.wrapperStyles?.gradientTo || "");
+    setGradientDirection(board.wrapperStyles?.gradientDirection ?? 0);
     setShadow(board.wrapperStyles?.dropShadow || "none");
     setPaddingX(board.wrapperStyles?.paddingX ?? 0);
     setPaddingY(board.wrapperStyles?.paddingY ?? 0);
@@ -56,6 +64,9 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
       wrapperStyles: {
         bgColor,
         bgOpacity,
+        gradientFrom,
+        gradientTo,
+        gradientDirection,
         dropShadow: shadow,
         paddingX,
         paddingY,
@@ -67,7 +78,7 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
       },
       spacing,
     });
-  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
+  }, [bgColor, bgOpacity, gradientFrom, gradientTo, gradientDirection, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
 
   return (
     <Accordion allowMultiple>
@@ -89,6 +100,32 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
                   setBgColor(e.target.value);
                   setBgOpacity(1);
                 }}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
+              <Input
+                type="color"
+                value={gradientFrom}
+                onChange={(e) => setGradientFrom(e.target.value)}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
+              <Input
+                type="color"
+                value={gradientTo}
+                onChange={(e) => setGradientTo(e.target.value)}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
+              <Input
+                size="sm"
+                type="number"
+                w="60px"
+                value={gradientDirection}
+                onChange={(e) => setGradientDirection(parseInt(e.target.value))}
               />
             </FormControl>
           </Stack>

--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -27,6 +27,11 @@ interface ColumnAttributesPaneProps {
 export default function ColumnAttributesPane({ column, onChange }: ColumnAttributesPaneProps) {
   const [bgColor, setBgColor] = useState(column.wrapperStyles?.bgColor || "#ffffff");
   const [bgOpacity, setBgOpacity] = useState(column.wrapperStyles?.bgOpacity ?? 0);
+  const [gradientFrom, setGradientFrom] = useState(column.wrapperStyles?.gradientFrom || "");
+  const [gradientTo, setGradientTo] = useState(column.wrapperStyles?.gradientTo || "");
+  const [gradientDirection, setGradientDirection] = useState(
+    column.wrapperStyles?.gradientDirection ?? 0
+  );
   const [shadow, setShadow] = useState(column.wrapperStyles?.dropShadow || "none");
   const [paddingX, setPaddingX] = useState(column.wrapperStyles?.paddingX ?? 0);
   const [paddingY, setPaddingY] = useState(column.wrapperStyles?.paddingY ?? 0);
@@ -40,6 +45,9 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
   useEffect(() => {
     setBgColor(column.wrapperStyles?.bgColor || "#ffffff");
     setBgOpacity(column.wrapperStyles?.bgOpacity ?? 0);
+    setGradientFrom(column.wrapperStyles?.gradientFrom || "");
+    setGradientTo(column.wrapperStyles?.gradientTo || "");
+    setGradientDirection(column.wrapperStyles?.gradientDirection ?? 0);
     setShadow(column.wrapperStyles?.dropShadow || "none");
     setPaddingX(column.wrapperStyles?.paddingX ?? 0);
     setPaddingY(column.wrapperStyles?.paddingY ?? 0);
@@ -57,6 +65,9 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
       wrapperStyles: {
         bgColor,
         bgOpacity,
+        gradientFrom,
+        gradientTo,
+        gradientDirection,
         dropShadow: shadow,
         paddingX,
         paddingY,
@@ -68,7 +79,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
       },
       spacing,
     });
-  }, [bgColor, bgOpacity, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
+  }, [bgColor, bgOpacity, gradientFrom, gradientTo, gradientDirection, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
 
   return (
     <Accordion allowMultiple>
@@ -90,6 +101,32 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
                   setBgColor(e.target.value);
                   setBgOpacity(1);
                 }}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
+              <Input
+                type="color"
+                value={gradientFrom}
+                onChange={(e) => setGradientFrom(e.target.value)}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
+              <Input
+                type="color"
+                value={gradientTo}
+                onChange={(e) => setGradientTo(e.target.value)}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
+              <Input
+                size="sm"
+                type="number"
+                w="60px"
+                value={gradientDirection}
+                onChange={(e) => setGradientDirection(parseInt(e.target.value))}
               />
             </FormControl>
           </Stack>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -66,6 +66,15 @@ export default function ElementAttributesPane({
   const [bgOpacity, setBgOpacity] = useState(
     element.wrapperStyles?.bgOpacity ?? 0
   );
+  const [gradientFrom, setGradientFrom] = useState(
+    element.wrapperStyles?.gradientFrom || ""
+  );
+  const [gradientTo, setGradientTo] = useState(
+    element.wrapperStyles?.gradientTo || ""
+  );
+  const [gradientDirection, setGradientDirection] = useState(
+    element.wrapperStyles?.gradientDirection ?? 0
+  );
   const [shadow, setShadow] = useState(
     element.wrapperStyles?.dropShadow || "none"
   );
@@ -105,6 +114,9 @@ export default function ElementAttributesPane({
     setQuestions(element.questions || []);
     setBgColor(element.wrapperStyles?.bgColor || "#ffffff");
     setBgOpacity(element.wrapperStyles?.bgOpacity ?? 0);
+    setGradientFrom(element.wrapperStyles?.gradientFrom || "");
+    setGradientTo(element.wrapperStyles?.gradientTo || "");
+    setGradientDirection(element.wrapperStyles?.gradientDirection ?? 0);
     setShadow(element.wrapperStyles?.dropShadow || "none");
     setPaddingX(element.wrapperStyles?.paddingX ?? 0);
     setPaddingY(element.wrapperStyles?.paddingY ?? 0);
@@ -121,6 +133,9 @@ export default function ElementAttributesPane({
       wrapperStyles: {
         bgColor,
         bgOpacity,
+        gradientFrom,
+        gradientTo,
+        gradientDirection,
         dropShadow: shadow,
         paddingX,
         paddingY,
@@ -170,6 +185,9 @@ export default function ElementAttributesPane({
     questions,
     bgColor,
     bgOpacity,
+    gradientFrom,
+    gradientTo,
+    gradientDirection,
     shadow,
     paddingX,
     paddingY,
@@ -208,6 +226,32 @@ export default function ElementAttributesPane({
                   setBgColor(e.target.value);
                   setBgOpacity(1);
                 }}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
+              <Input
+                type="color"
+                value={gradientFrom}
+                onChange={(e) => setGradientFrom(e.target.value)}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
+              <Input
+                type="color"
+                value={gradientTo}
+                onChange={(e) => setGradientTo(e.target.value)}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
+              <Input
+                size="sm"
+                type="number"
+                w="60px"
+                value={gradientDirection}
+                onChange={(e) => setGradientDirection(parseInt(e.target.value))}
               />
             </FormControl>
           </Stack>

--- a/insight-fe/src/components/lesson/ElementWrapper.tsx
+++ b/insight-fe/src/components/lesson/ElementWrapper.tsx
@@ -5,6 +5,9 @@ export interface ElementWrapperStyles {
   bgColor?: string;
   /** Opacity value between 0 and 1 */
   bgOpacity?: number;
+  gradientFrom?: string;
+  gradientTo?: string;
+  gradientDirection?: number;
   dropShadow?: string;
   paddingX?: number;
   paddingY?: number;
@@ -30,13 +33,15 @@ export default function ElementWrapper({ styles, children, ...props }: ElementWr
     return `rgba(${r}, ${g}, ${b}, ${opacity})`;
   };
 
-  const bgColor = styles?.bgColor
+  const background = styles?.gradientFrom && styles?.gradientTo
+    ? `linear-gradient(${styles.gradientDirection ?? 0}deg, ${styles.gradientFrom}, ${styles.gradientTo})`
+    : styles?.bgColor
     ? hexToRgba(styles.bgColor, styles.bgOpacity ?? 0)
     : undefined;
 
   return (
     <Box
-      bg={bgColor}
+      bg={background}
       boxShadow={styles?.dropShadow}
       px={styles?.paddingX}
       py={styles?.paddingY}

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -397,6 +397,9 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
             wrapperStyles: {
               bgColor: "#ffffff",
               bgOpacity: 0,
+              gradientFrom: "",
+              gradientTo: "",
+              gradientDirection: 0,
               dropShadow: "none",
               paddingX: 0,
               paddingY: 0,

--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -133,6 +133,9 @@ export default function SlideElementsBoard({
       wrapperStyles: {
         bgColor: "#ffffff",
         bgOpacity: 0,
+        gradientFrom: "",
+        gradientTo: "",
+        gradientDirection: 0,
         dropShadow: "none",
         paddingX: 0,
         paddingY: 0,

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -88,6 +88,9 @@ export default function SlideElementsContainer({
       wrapperStyles: {
         bgColor: "#ffffff",
         bgOpacity: 0,
+        gradientFrom: "",
+        gradientTo: "",
+        gradientDirection: 0,
         dropShadow: "none",
         paddingX: 0,
         paddingY: 0,
@@ -106,10 +109,13 @@ export default function SlideElementsContainer({
       {
         id: boardId,
         orderedColumnIds: [columnId],
-        wrapperStyles: {
-          bgColor: "#ffffff",
-          bgOpacity: 1,
-          dropShadow: "none",
+      wrapperStyles: {
+        bgColor: "#ffffff",
+        bgOpacity: 1,
+        gradientFrom: "",
+        gradientTo: "",
+        gradientDirection: 0,
+        dropShadow: "none",
           paddingX: 0,
           paddingY: 0,
           marginX: 0,

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -51,6 +51,9 @@ export const createInitialBoard = (): {
         wrapperStyles: {
           bgColor: "#ffffff",
           bgOpacity: 0,
+          gradientFrom: "",
+          gradientTo: "",
+          gradientDirection: 0,
           dropShadow: "none",
           paddingX: 0,
           paddingY: 0,
@@ -70,6 +73,9 @@ export const createInitialBoard = (): {
         wrapperStyles: {
           bgColor: "#ffffff",
           bgOpacity: 1,
+          gradientFrom: "",
+          gradientTo: "",
+          gradientDirection: 0,
           dropShadow: "none",
           paddingX: 0,
           paddingY: 0,


### PR DESCRIPTION
## Summary
- expand `ElementWrapperStyles` with gradient fields
- compute gradient CSS in wrapper components and column styles
- add gradient defaults for new boards, columns, and elements
- support gradient controls in board, column and element attribute panes

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3e6293708326ad3b1a5ec51e0e44