### PR TITLE
Add element animation controls

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -2,6 +2,13 @@ import ElementWrapper, {
   ElementWrapperStyles,
 } from "@/components/lesson/ElementWrapper";
 import { Box, Text, Table, Thead, Tbody, Tr, Th, Td } from "@chakra-ui/react";
+import { motion } from "framer-motion";
+
+export interface ElementAnimation {
+  type: "flyInFade";
+  direction: "left" | "right" | "top" | "bottom";
+  delay: number;
+}
 
 export interface SlideElementDnDItemProps {
   id: string;
@@ -44,6 +51,7 @@ export interface SlideElementDnDItemProps {
     textAlign?: string;
   };
   wrapperStyles?: ElementWrapperStyles;
+  animation?: ElementAnimation;
 }
 
 interface SlideElementDnDItemComponentProps {
@@ -63,6 +71,30 @@ export const SlideElementDnDItem = ({
     onClick: onSelect,
   };
 
+  const MotionBox = motion(Box);
+
+  const animationProps = item.animation
+    ? {
+        initial: {
+          opacity: 0,
+          x:
+            item.animation.direction === "left"
+              ? -50
+              : item.animation.direction === "right"
+              ? 50
+              : 0,
+          y:
+            item.animation.direction === "top"
+              ? -50
+              : item.animation.direction === "bottom"
+              ? 50
+              : 0,
+        },
+        animate: { opacity: 1, x: 0, y: 0 },
+        transition: { delay: item.animation.delay / 1000 },
+      }
+    : {};
+
   const wrapperStyles: ElementWrapperStyles = {
     ...item.wrapperStyles,
     borderColor: isSelected ? "blue.400" : item.wrapperStyles?.borderColor,
@@ -70,8 +102,16 @@ export const SlideElementDnDItem = ({
     borderRadius: item.wrapperStyles?.borderRadius,
   };
 
+  let content: React.ReactElement = (
+    <ElementWrapper styles={wrapperStyles} {...baseProps}>
+      <Text fontSize={14} fontWeight="bold">
+        {item.type}
+      </Text>
+    </ElementWrapper>
+  );
+
   if (item.type === "text") {
-    return (
+    content = (
       <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Text
           color={item.styles?.color}
@@ -85,10 +125,8 @@ export const SlideElementDnDItem = ({
         </Text>
       </ElementWrapper>
     );
-  }
-
-  if (item.type === "table") {
-    return (
+  } else if (item.type === "table") {
+    content = (
       <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Table size="sm">
           <Thead>
@@ -106,18 +144,14 @@ export const SlideElementDnDItem = ({
         </Table>
       </ElementWrapper>
     );
-  }
-
-  if (item.type === "video") {
-    return (
+  } else if (item.type === "video") {
+    content = (
       <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Box as="video" src={item.url} controls width="100%" />
       </ElementWrapper>
     );
-  }
-
-  if (item.type === "image") {
-    return (
+  } else if (item.type === "image") {
+    content = (
       <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <img
           src={item.src}
@@ -127,21 +161,13 @@ export const SlideElementDnDItem = ({
         />
       </ElementWrapper>
     );
-  }
-
-  if (item.type === "quiz") {
-    return (
+  } else if (item.type === "quiz") {
+    content = (
       <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Text fontWeight="bold">{item.title || "Quiz"}</Text>
       </ElementWrapper>
     );
   }
 
-  return (
-    <ElementWrapper styles={wrapperStyles} {...baseProps}>
-      <Text fontSize={14} fontWeight="bold">
-        {item.type}
-      </Text>
-    </ElementWrapper>
-  );
+  return <MotionBox {...animationProps}>{content}</MotionBox>;
 };

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -95,6 +95,15 @@ export default function ElementAttributesPane({
   const [borderRadius, setBorderRadius] = useState(
     element.wrapperStyles?.borderRadius || "none"
   );
+  const [animationEnabled, setAnimationEnabled] = useState(
+    !!element.animation
+  );
+  const [animationDirection, setAnimationDirection] = useState(
+    element.animation?.direction || "left"
+  );
+  const [animationDelay, setAnimationDelay] = useState(
+    element.animation?.delay ?? 0
+  );
 
   // Reset local state only when a new element is selected
   // using id/type avoids resets when the parent simply updates
@@ -125,6 +134,9 @@ export default function ElementAttributesPane({
     setBorderColor(element.wrapperStyles?.borderColor || "#000000");
     setBorderWidth(element.wrapperStyles?.borderWidth ?? 0);
     setBorderRadius(element.wrapperStyles?.borderRadius || "none");
+    setAnimationEnabled(!!element.animation);
+    setAnimationDirection(element.animation?.direction || "left");
+    setAnimationDelay(element.animation?.delay ?? 0);
   }, [element.id, element.type]);
 
   useEffect(() => {
@@ -145,6 +157,9 @@ export default function ElementAttributesPane({
         borderWidth,
         borderRadius,
       },
+      animation: animationEnabled
+        ? { type: "flyInFade", direction: animationDirection, delay: animationDelay }
+        : undefined,
     };
     if (element.type === "text") {
       updated.text = text;
@@ -196,6 +211,9 @@ export default function ElementAttributesPane({
     borderColor,
     borderWidth,
     borderRadius,
+    animationEnabled,
+    animationDirection,
+    animationDelay,
   ]);
 
   return (
@@ -252,6 +270,60 @@ export default function ElementAttributesPane({
                 w="60px"
                 value={gradientDirection}
                 onChange={(e) => setGradientDirection(parseInt(e.target.value))}
+              />
+            </FormControl>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem
+        borderWidth="1px"
+        borderColor="orange.300"
+        borderRadius="md"
+        mb={2}
+      >
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">Animation</Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Enable</FormLabel>
+              <Select
+                size="sm"
+                value={animationEnabled ? "on" : "off"}
+                onChange={(e) => setAnimationEnabled(e.target.value === "on")}
+              >
+                <option value="on">On</option>
+                <option value="off">Off</option>
+              </Select>
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
+              <Select
+                size="sm"
+                value={animationDirection}
+                onChange={(e) =>
+                  setAnimationDirection(e.target.value as any)
+                }
+              >
+                <option value="left">Left</option>
+                <option value="right">Right</option>
+                <option value="top">Top</option>
+                <option value="bottom">Bottom</option>
+              </Select>
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Delay (ms)</FormLabel>
+              <Input
+                size="sm"
+                type="number"
+                w="60px"
+                value={animationDelay}
+                onChange={(e) => setAnimationDelay(parseInt(e.target.value))}
               />
             </FormControl>
           </Stack>

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -412,6 +412,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
               borderWidth: 0,
               borderRadius: "none",
             },
+            animation: undefined,
           };
 
           const firstColumn = s.boards[0].orderedColumnIds[0];

--- a/insight-fe/src/components/lesson/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementRenderer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import React from "react";
 import { Box, Text, Table, Thead, Tbody, Tr, Th, Td } from "@chakra-ui/react";
+import { motion } from "framer-motion";
 import ElementWrapper from "./ElementWrapper";
 import ImageElement from "./ImageElement";
 import VideoElement from "./VideoElement";
@@ -14,8 +16,36 @@ interface SlideElementRendererProps {
 export default function SlideElementRenderer({
   item,
 }: SlideElementRendererProps) {
+  const MotionBox = motion(Box);
+  const animationProps = item.animation
+    ? {
+        initial: {
+          opacity: 0,
+          x:
+            item.animation.direction === "left"
+              ? -50
+              : item.animation.direction === "right"
+              ? 50
+              : 0,
+          y:
+            item.animation.direction === "top"
+              ? -50
+              : item.animation.direction === "bottom"
+              ? 50
+              : 0,
+        },
+        animate: { opacity: 1, x: 0, y: 0 },
+        transition: { delay: item.animation.delay / 1000 },
+      }
+    : {};
+  let content: React.ReactElement = (
+    <ElementWrapper styles={item.wrapperStyles} data-testid="unknown-element">
+      <Text fontSize={14} fontWeight="bold">{item.type}</Text>
+    </ElementWrapper>
+  );
+
   if (item.type === "text") {
-    return (
+    content = (
       <ElementWrapper styles={item.wrapperStyles} data-testid="text-element">
         <Text
           color={item.styles?.color}
@@ -29,10 +59,8 @@ export default function SlideElementRenderer({
         </Text>
       </ElementWrapper>
     );
-  }
-
-  if (item.type === "table") {
-    return (
+  } else if (item.type === "table") {
+    content = (
       <ElementWrapper styles={item.wrapperStyles} data-testid="table-element">
         <Table size="sm">
           <Thead>
@@ -50,22 +78,16 @@ export default function SlideElementRenderer({
         </Table>
       </ElementWrapper>
     );
-  }
-
-  if (item.type === "image") {
-    return (
+  } else if (item.type === "image") {
+    content = (
       <ImageElement src={item.src || ""} wrapperStyles={item.wrapperStyles} />
     );
-  }
-
-  if (item.type === "video") {
-    return (
+  } else if (item.type === "video") {
+    content = (
       <VideoElement url={item.url || ""} wrapperStyles={item.wrapperStyles} />
     );
-  }
-
-  if (item.type === "quiz") {
-    return (
+  } else if (item.type === "quiz") {
+    content = (
       <QuizElement
         title={item.title || "Untitled Quiz"}
         description={item.description}
@@ -75,11 +97,5 @@ export default function SlideElementRenderer({
     );
   }
 
-  return (
-    <ElementWrapper styles={item.wrapperStyles} data-testid="unknown-element">
-      <Text fontSize={14} fontWeight="bold">
-        {item.type}
-      </Text>
-    </ElementWrapper>
-  );
+  return <MotionBox {...animationProps}>{content}</MotionBox>;
 }


### PR DESCRIPTION
## Summary
- support `ElementAnimation` on slide elements
- add animation settings to element attribute pane
- animate DnD cards and slide preview elements with Framer Motion

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run lint` in `insight-be` *(fails: missing @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_683ffa617d988326a89214f4467226d5