### PR TITLE
Add background type selector

### DIFF
--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -31,6 +31,11 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
   const [gradientDirection, setGradientDirection] = useState(
     board.wrapperStyles?.gradientDirection ?? 0
   );
+  const [backgroundType, setBackgroundType] = useState(
+    board.wrapperStyles?.gradientFrom && board.wrapperStyles?.gradientTo
+      ? "gradient"
+      : "color"
+  );
   const [shadow, setShadow] = useState(board.wrapperStyles?.dropShadow || "none");
   const [paddingX, setPaddingX] = useState(board.wrapperStyles?.paddingX ?? 0);
   const [paddingY, setPaddingY] = useState(board.wrapperStyles?.paddingY ?? 0);
@@ -47,6 +52,11 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
     setGradientFrom(board.wrapperStyles?.gradientFrom || "");
     setGradientTo(board.wrapperStyles?.gradientTo || "");
     setGradientDirection(board.wrapperStyles?.gradientDirection ?? 0);
+    setBackgroundType(
+      board.wrapperStyles?.gradientFrom && board.wrapperStyles?.gradientTo
+        ? "gradient"
+        : "color"
+    );
     setShadow(board.wrapperStyles?.dropShadow || "none");
     setPaddingX(board.wrapperStyles?.paddingX ?? 0);
     setPaddingY(board.wrapperStyles?.paddingY ?? 0);
@@ -78,7 +88,7 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
       },
       spacing,
     });
-  }, [bgColor, bgOpacity, gradientFrom, gradientTo, gradientDirection, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
+  }, [bgColor, bgOpacity, gradientFrom, gradientTo, gradientDirection, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing, backgroundType]);
 
   return (
     <Accordion allowMultiple>
@@ -92,42 +102,71 @@ export default function BoardAttributesPane({ board, onChange }: BoardAttributes
         <AccordionPanel pb={2}>
           <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
-              <Input
-                type="color"
-                value={bgColor}
-                onChange={(e) => {
-                  setBgColor(e.target.value);
-                  setBgOpacity(1);
-                }}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
-              <Input
-                type="color"
-                value={gradientFrom}
-                onChange={(e) => setGradientFrom(e.target.value)}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
-              <Input
-                type="color"
-                value={gradientTo}
-                onChange={(e) => setGradientTo(e.target.value)}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
-              <Input
+              <FormLabel mb="0" fontSize="sm" w="40%">Type</FormLabel>
+              <Select
                 size="sm"
-                type="number"
-                w="60px"
-                value={gradientDirection}
-                onChange={(e) => setGradientDirection(parseInt(e.target.value))}
-              />
+                value={backgroundType}
+                onChange={(e) => {
+                  const value = e.target.value as "color" | "gradient";
+                  setBackgroundType(value);
+                  if (value === "color") {
+                    setGradientFrom("");
+                    setGradientTo("");
+                    setGradientDirection(0);
+                  } else {
+                    setBgColor("#ffffff");
+                  }
+                }}
+              >
+                <option value="color">Color</option>
+                <option value="gradient">Gradient</option>
+              </Select>
             </FormControl>
+            {backgroundType === "color" && (
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
+                <Input
+                  type="color"
+                  value={bgColor}
+                  onChange={(e) => {
+                    setBgColor(e.target.value);
+                    setBgOpacity(1);
+                  }}
+                />
+              </FormControl>
+            )}
+            {backgroundType === "gradient" && (
+              <>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
+                  <Input
+                    type="color"
+                    value={gradientFrom}
+                    onChange={(e) => setGradientFrom(e.target.value)}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
+                  <Input
+                    type="color"
+                    value={gradientTo}
+                    onChange={(e) => setGradientTo(e.target.value)}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    w="60px"
+                    value={gradientDirection}
+                    onChange={(e) =>
+                      setGradientDirection(parseInt(e.target.value))
+                    }
+                  />
+                </FormControl>
+              </>
+            )}
           </Stack>
         </AccordionPanel>
       </AccordionItem>

--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -32,6 +32,11 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
   const [gradientDirection, setGradientDirection] = useState(
     column.wrapperStyles?.gradientDirection ?? 0
   );
+  const [backgroundType, setBackgroundType] = useState(
+    column.wrapperStyles?.gradientFrom && column.wrapperStyles?.gradientTo
+      ? "gradient"
+      : "color"
+  );
   const [shadow, setShadow] = useState(column.wrapperStyles?.dropShadow || "none");
   const [paddingX, setPaddingX] = useState(column.wrapperStyles?.paddingX ?? 0);
   const [paddingY, setPaddingY] = useState(column.wrapperStyles?.paddingY ?? 0);
@@ -48,6 +53,11 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
     setGradientFrom(column.wrapperStyles?.gradientFrom || "");
     setGradientTo(column.wrapperStyles?.gradientTo || "");
     setGradientDirection(column.wrapperStyles?.gradientDirection ?? 0);
+    setBackgroundType(
+      column.wrapperStyles?.gradientFrom && column.wrapperStyles?.gradientTo
+        ? "gradient"
+        : "color"
+    );
     setShadow(column.wrapperStyles?.dropShadow || "none");
     setPaddingX(column.wrapperStyles?.paddingX ?? 0);
     setPaddingY(column.wrapperStyles?.paddingY ?? 0);
@@ -79,7 +89,7 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
       },
       spacing,
     });
-  }, [bgColor, bgOpacity, gradientFrom, gradientTo, gradientDirection, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing]);
+  }, [bgColor, bgOpacity, gradientFrom, gradientTo, gradientDirection, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing, backgroundType]);
 
   return (
     <Accordion allowMultiple>
@@ -93,42 +103,71 @@ export default function ColumnAttributesPane({ column, onChange }: ColumnAttribu
         <AccordionPanel pb={2}>
           <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
-              <Input
-                type="color"
-                value={bgColor}
-                onChange={(e) => {
-                  setBgColor(e.target.value);
-                  setBgOpacity(1);
-                }}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
-              <Input
-                type="color"
-                value={gradientFrom}
-                onChange={(e) => setGradientFrom(e.target.value)}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
-              <Input
-                type="color"
-                value={gradientTo}
-                onChange={(e) => setGradientTo(e.target.value)}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
-              <Input
+              <FormLabel mb="0" fontSize="sm" w="40%">Type</FormLabel>
+              <Select
                 size="sm"
-                type="number"
-                w="60px"
-                value={gradientDirection}
-                onChange={(e) => setGradientDirection(parseInt(e.target.value))}
-              />
+                value={backgroundType}
+                onChange={(e) => {
+                  const value = e.target.value as "color" | "gradient";
+                  setBackgroundType(value);
+                  if (value === "color") {
+                    setGradientFrom("");
+                    setGradientTo("");
+                    setGradientDirection(0);
+                  } else {
+                    setBgColor("#ffffff");
+                  }
+                }}
+              >
+                <option value="color">Color</option>
+                <option value="gradient">Gradient</option>
+              </Select>
             </FormControl>
+            {backgroundType === "color" && (
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
+                <Input
+                  type="color"
+                  value={bgColor}
+                  onChange={(e) => {
+                    setBgColor(e.target.value);
+                    setBgOpacity(1);
+                  }}
+                />
+              </FormControl>
+            )}
+            {backgroundType === "gradient" && (
+              <>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
+                  <Input
+                    type="color"
+                    value={gradientFrom}
+                    onChange={(e) => setGradientFrom(e.target.value)}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
+                  <Input
+                    type="color"
+                    value={gradientTo}
+                    onChange={(e) => setGradientTo(e.target.value)}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    w="60px"
+                    value={gradientDirection}
+                    onChange={(e) =>
+                      setGradientDirection(parseInt(e.target.value))
+                    }
+                  />
+                </FormControl>
+              </>
+            )}
           </Stack>
         </AccordionPanel>
       </AccordionItem>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -75,6 +75,11 @@ export default function ElementAttributesPane({
   const [gradientDirection, setGradientDirection] = useState(
     element.wrapperStyles?.gradientDirection ?? 0
   );
+  const [backgroundType, setBackgroundType] = useState(
+    element.wrapperStyles?.gradientFrom && element.wrapperStyles?.gradientTo
+      ? "gradient"
+      : "color"
+  );
   const [shadow, setShadow] = useState(
     element.wrapperStyles?.dropShadow || "none"
   );
@@ -126,6 +131,11 @@ export default function ElementAttributesPane({
     setGradientFrom(element.wrapperStyles?.gradientFrom || "");
     setGradientTo(element.wrapperStyles?.gradientTo || "");
     setGradientDirection(element.wrapperStyles?.gradientDirection ?? 0);
+    setBackgroundType(
+      element.wrapperStyles?.gradientFrom && element.wrapperStyles?.gradientTo
+        ? "gradient"
+        : "color"
+    );
     setShadow(element.wrapperStyles?.dropShadow || "none");
     setPaddingX(element.wrapperStyles?.paddingX ?? 0);
     setPaddingY(element.wrapperStyles?.paddingY ?? 0);
@@ -214,6 +224,7 @@ export default function ElementAttributesPane({
     animationEnabled,
     animationDirection,
     animationDelay,
+    backgroundType,
   ]);
 
   return (
@@ -236,42 +247,71 @@ export default function ElementAttributesPane({
         <AccordionPanel pb={2}>
           <Stack spacing={2}>
             <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
-              <Input
-                type="color"
-                value={bgColor}
-                onChange={(e) => {
-                  setBgColor(e.target.value);
-                  setBgOpacity(1);
-                }}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
-              <Input
-                type="color"
-                value={gradientFrom}
-                onChange={(e) => setGradientFrom(e.target.value)}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
-              <Input
-                type="color"
-                value={gradientTo}
-                onChange={(e) => setGradientTo(e.target.value)}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
-              <Input
+              <FormLabel mb="0" fontSize="sm" w="40%">Type</FormLabel>
+              <Select
                 size="sm"
-                type="number"
-                w="60px"
-                value={gradientDirection}
-                onChange={(e) => setGradientDirection(parseInt(e.target.value))}
-              />
+                value={backgroundType}
+                onChange={(e) => {
+                  const value = e.target.value as "color" | "gradient";
+                  setBackgroundType(value);
+                  if (value === "color") {
+                    setGradientFrom("");
+                    setGradientTo("");
+                    setGradientDirection(0);
+                  } else {
+                    setBgColor("#ffffff");
+                  }
+                }}
+              >
+                <option value="color">Color</option>
+                <option value="gradient">Gradient</option>
+              </Select>
             </FormControl>
+            {backgroundType === "color" && (
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
+                <Input
+                  type="color"
+                  value={bgColor}
+                  onChange={(e) => {
+                    setBgColor(e.target.value);
+                    setBgOpacity(1);
+                  }}
+                />
+              </FormControl>
+            )}
+            {backgroundType === "gradient" && (
+              <>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
+                  <Input
+                    type="color"
+                    value={gradientFrom}
+                    onChange={(e) => setGradientFrom(e.target.value)}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
+                  <Input
+                    type="color"
+                    value={gradientTo}
+                    onChange={(e) => setGradientTo(e.target.value)}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    w="60px"
+                    value={gradientDirection}
+                    onChange={(e) =>
+                      setGradientDirection(parseInt(e.target.value))
+                    }
+                  />
+                </FormControl>
+              </>
+            )}
           </Stack>
         </AccordionPanel>
       </AccordionItem>


### PR DESCRIPTION
## Summary
- allow picking color vs gradient backgrounds for boards, columns and elements
- update attribute panes to show fields conditionally

## Testing
- `npm --prefix insight-fe run lint` *(fails: next not found)*
- `npm --prefix insight-be test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ad0f03e88326be66cae492675c53