### PR TITLE
Fix style fetch/load element types

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -620,7 +620,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
                 fetchStyles({
                   variables: {
                     collectionId: String(selectedCollectionId),
-                    element: ELEMENT_TYPE_TO_ENUM[el.type],
+                    element: el.type,
                   },
                 });
               }}
@@ -757,9 +757,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         isOpen={isLoadStyleOpen}
         onClose={() => setIsLoadStyleOpen(false)}
         collections={styleCollections}
-        elementType={
-          selectedElement ? ELEMENT_TYPE_TO_ENUM[selectedElement.type] : null
-        }
+        elementType={selectedElement ? selectedElement.type : null}
         onLoad={(styleId) => {
           if (!selectedElement) return;
           // Placeholder for backend call using style module


### PR DESCRIPTION
## Summary
- fix style fetch calls to use plain `el.type`
- ensure `LoadStyleModal` receives the element type directly

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841b451128483268bcb116dbef538d5