### PR TITLE
Refactor DnD setup into hooks

### DIFF
--- a/insight-fe/src/hooks/useBoardDnD.tsx
+++ b/insight-fe/src/hooks/useBoardDnD.tsx
@@ -1,0 +1,138 @@
+import { useEffect } from "react";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import { monitorForElements } from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { extractClosestEdge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { getReorderDestinationIndex } from "@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index";
+import type { Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/types";
+import { BaseCardDnD, ColumnMap } from "@/components/DnD/types";
+
+/**
+ * Hook that wires up the board level drag-and-drop monitor.
+ * It listens for drop events on columns and cards and delegates to the
+ * provided mutator callbacks.
+ */
+export function useBoardDnD<TCard extends BaseCardDnD>(
+  instanceId: symbol,
+  getBoard: () => { columnMap: ColumnMap<TCard>; orderedColumnIds: string[] },
+  reorderColumn: (args: { startIndex: number; finishIndex: number; trigger?: "pointer" | "keyboard" }) => void,
+  reorderCard: (args: { columnId: string; startIndex: number; finishIndex: number; trigger?: "pointer" | "keyboard" }) => void,
+  moveCard: (args: { startColumnId: string; finishColumnId: string; itemIndexInStartColumn: number; itemIndexInFinishColumn?: number; trigger?: "pointer" | "keyboard" }) => void,
+) {
+  // Monitor the DOM for drop events from draggables belonging to this board
+  useEffect(() => {
+    return combine(
+      monitorForElements({
+        canMonitor({ source }) {
+          return source.data.instanceId === instanceId;
+        },
+        onDrop(args) {
+          const { location, source } = args;
+          if (!location.current.dropTargets.length) return;
+
+          // Column drop handling
+          if (source.data.type === "column") {
+            const board = getBoard();
+            const startIndex = board.orderedColumnIds.findIndex(
+              (id) => id === source.data.columnId
+            );
+            if (startIndex === -1) return;
+
+            const target = location.current.dropTargets[0];
+            const indexOfTarget = board.orderedColumnIds.findIndex(
+              (id) => id === target.data.columnId
+            );
+            if (indexOfTarget === -1) return;
+
+            const closestEdgeOfTarget: Edge | null = extractClosestEdge(target.data);
+            const finishIndex = getReorderDestinationIndex({
+              startIndex,
+              indexOfTarget,
+              closestEdgeOfTarget,
+              axis: "horizontal",
+            });
+            reorderColumn({ startIndex, finishIndex, trigger: "pointer" });
+            return;
+          }
+
+          // Card drop handling
+          if (source.data.type === "card") {
+            const board = getBoard();
+            const itemId = source.data.itemId as string;
+            const [, startColumnRecord] = location.initial.dropTargets;
+            const sourceColumnId = startColumnRecord.data.columnId as string;
+            const sourceColumn = board.columnMap[sourceColumnId];
+            const itemIndex = sourceColumn.items.findIndex((i) => i.id === itemId);
+
+            // Dropped directly onto a column
+            if (location.current.dropTargets.length === 1) {
+              const [destinationColumnRecord] = location.current.dropTargets;
+              const destinationId = destinationColumnRecord.data.columnId as string;
+              const destinationColumn = board.columnMap[destinationId];
+              if (sourceColumn === destinationColumn) {
+                const destinationIndex = getReorderDestinationIndex({
+                  startIndex: itemIndex,
+                  indexOfTarget: sourceColumn.items.length - 1,
+                  closestEdgeOfTarget: null,
+                  axis: "vertical",
+                });
+                reorderCard({
+                  columnId: sourceColumn.columnId,
+                  startIndex: itemIndex,
+                  finishIndex: destinationIndex,
+                  trigger: "pointer",
+                });
+              } else {
+                moveCard({
+                  itemIndexInStartColumn: itemIndex,
+                  startColumnId: sourceColumn.columnId,
+                  finishColumnId: destinationColumn.columnId,
+                  trigger: "pointer",
+                });
+              }
+              return;
+            }
+
+            // Dropped onto a card
+            if (location.current.dropTargets.length === 2) {
+              const [destinationCardRecord, destinationColumnRecord] =
+                location.current.dropTargets;
+              const destinationColumnId = destinationColumnRecord.data.columnId as string;
+              const destinationColumn = board.columnMap[destinationColumnId];
+              const indexOfTarget = destinationColumn.items.findIndex(
+                (i) => i.id === destinationCardRecord.data.itemId
+              );
+              const closestEdgeOfTarget: Edge | null = extractClosestEdge(
+                destinationCardRecord.data
+              );
+
+              if (sourceColumn === destinationColumn) {
+                const destinationIndex = getReorderDestinationIndex({
+                  startIndex: itemIndex,
+                  indexOfTarget,
+                  closestEdgeOfTarget,
+                  axis: "vertical",
+                });
+                reorderCard({
+                  columnId: sourceColumn.columnId,
+                  startIndex: itemIndex,
+                  finishIndex: destinationIndex,
+                  trigger: "pointer",
+                });
+              } else {
+                const destinationIndex =
+                  closestEdgeOfTarget === "bottom" ? indexOfTarget + 1 : indexOfTarget;
+                moveCard({
+                  itemIndexInStartColumn: itemIndex,
+                  startColumnId: sourceColumn.columnId,
+                  finishColumnId: destinationColumn.columnId,
+                  itemIndexInFinishColumn: destinationIndex,
+                  trigger: "pointer",
+                });
+              }
+            }
+          }
+        },
+      })
+    );
+  }, [instanceId, reorderColumn, reorderCard, moveCard, getBoard]);
+}

--- a/insight-fe/src/hooks/useSlideDnD.tsx
+++ b/insight-fe/src/hooks/useSlideDnD.tsx
@@ -1,0 +1,80 @@
+import { RefObject, useEffect } from "react";
+import {
+  dropTargetForElements,
+  monitorForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { reorder } from "@atlaskit/pragmatic-drag-and-drop/reorder";
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { getReorderDestinationIndex } from "@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index";
+import { Slide } from "@/components/lesson/SlideSequencer";
+
+/**
+ * Hook wiring up drag-and-drop behaviour for the slide sequencer.
+ * Handles registering the container as a drop target and monitors drop
+ * events to update ordering.
+ */
+export function useSlideDnD(
+  containerRef: RefObject<HTMLDivElement>,
+  slides: Slide[],
+  setSlides: React.Dispatch<React.SetStateAction<Slide[]>>,
+  instanceId: React.MutableRefObject<symbol>
+) {
+  // Register the container to accept slide drops
+  useEffect(() => {
+    if (!containerRef.current) return;
+    return dropTargetForElements({
+      element: containerRef.current,
+      canDrop: ({ source }) =>
+        source.data.instanceId === instanceId.current && source.data.type === "slide",
+      getData: () => ({ columnId: "slides" }),
+      getIsSticky: () => true,
+    });
+  }, [containerRef, instanceId]);
+
+  // Monitor drag events and update slide order on drop
+  useEffect(() => {
+    return monitorForElements({
+      canMonitor: ({ source }) => source.data.instanceId === instanceId.current,
+      onDrop: ({ source, location }) => {
+        if (source.data.type !== "slide") {
+          return;
+        }
+        if (!location.current.dropTargets.length) {
+          return;
+        }
+
+        const startIndex = slides.findIndex((s) => s.id === source.data.slideId);
+        if (startIndex === -1) return;
+
+        if (location.current.dropTargets.length === 1) {
+          const destinationIndex = getReorderDestinationIndex({
+            startIndex,
+            indexOfTarget: slides.length - 1,
+            closestEdgeOfTarget: null,
+            axis: "vertical",
+          });
+          setSlides((prev) => reorder({ list: prev, startIndex, finishIndex: destinationIndex }));
+          return;
+        }
+
+        if (location.current.dropTargets.length === 2) {
+          const [destinationRecord] = location.current.dropTargets;
+          const indexOfTarget = slides.findIndex(
+            (s) => s.id === destinationRecord.data.slideId
+          );
+          const closestEdgeOfTarget = extractClosestEdge(destinationRecord.data);
+          const destinationIndex = getReorderDestinationIndex({
+            startIndex,
+            indexOfTarget,
+            closestEdgeOfTarget,
+            axis: "vertical",
+          });
+          setSlides((prev) => reorder({ list: prev, startIndex, finishIndex: destinationIndex }));
+        }
+      },
+    });
+  }, [instanceId, slides, setSlides]);
+}


### PR DESCRIPTION
## Summary
- extract reusable drag-and-drop helpers into `useSlideDnD` and `useBoardDnD`
- document drag behaviour in `useEffect` blocks
- simplify `SlideSequencer` and `DnDBoardMain` by using the new hooks

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841b66c0ed08326911b1b51da4c65b1