### PR TITLE
Refactor attribute panes with reusable style hook

### DIFF
--- a/insight-fe/src/components/lesson/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/BoardAttributesPane.tsx
@@ -15,7 +15,7 @@ import {
   AccordionIcon,
   HStack,
 } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import useStyleAttributes from "./hooks/useStyleAttributes";
 import type { BoardRow } from "./SlideElementsContainer";
 
 interface BoardAttributesPaneProps {
@@ -24,71 +24,45 @@ interface BoardAttributesPaneProps {
 }
 
 export default function BoardAttributesPane({ board, onChange }: BoardAttributesPaneProps) {
-  const [bgColor, setBgColor] = useState(board.wrapperStyles?.bgColor || "#ffffff");
-  const [bgOpacity, setBgOpacity] = useState(board.wrapperStyles?.bgOpacity ?? 1);
-  const [gradientFrom, setGradientFrom] = useState(board.wrapperStyles?.gradientFrom || "");
-  const [gradientTo, setGradientTo] = useState(board.wrapperStyles?.gradientTo || "");
-  const [gradientDirection, setGradientDirection] = useState(
-    board.wrapperStyles?.gradientDirection ?? 0
-  );
-  const [backgroundType, setBackgroundType] = useState(
-    board.wrapperStyles?.gradientFrom && board.wrapperStyles?.gradientTo
-      ? "gradient"
-      : "color"
-  );
-  const [shadow, setShadow] = useState(board.wrapperStyles?.dropShadow || "none");
-  const [paddingX, setPaddingX] = useState(board.wrapperStyles?.paddingX ?? 0);
-  const [paddingY, setPaddingY] = useState(board.wrapperStyles?.paddingY ?? 0);
-  const [marginX, setMarginX] = useState(board.wrapperStyles?.marginX ?? 0);
-  const [marginY, setMarginY] = useState(board.wrapperStyles?.marginY ?? 0);
-  const [borderColor, setBorderColor] = useState(board.wrapperStyles?.borderColor || "#000000");
-  const [borderWidth, setBorderWidth] = useState(board.wrapperStyles?.borderWidth ?? 0);
-  const [borderRadius, setBorderRadius] = useState(board.wrapperStyles?.borderRadius || "none");
-  const [spacing, setSpacing] = useState(board.spacing ?? 0);
-
-  useEffect(() => {
-    setBgColor(board.wrapperStyles?.bgColor || "#ffffff");
-    setBgOpacity(board.wrapperStyles?.bgOpacity ?? 1);
-    setGradientFrom(board.wrapperStyles?.gradientFrom || "");
-    setGradientTo(board.wrapperStyles?.gradientTo || "");
-    setGradientDirection(board.wrapperStyles?.gradientDirection ?? 0);
-    setBackgroundType(
-      board.wrapperStyles?.gradientFrom && board.wrapperStyles?.gradientTo
-        ? "gradient"
-        : "color"
-    );
-    setShadow(board.wrapperStyles?.dropShadow || "none");
-    setPaddingX(board.wrapperStyles?.paddingX ?? 0);
-    setPaddingY(board.wrapperStyles?.paddingY ?? 0);
-    setMarginX(board.wrapperStyles?.marginX ?? 0);
-    setMarginY(board.wrapperStyles?.marginY ?? 0);
-    setBorderColor(board.wrapperStyles?.borderColor || "#000000");
-    setBorderWidth(board.wrapperStyles?.borderWidth ?? 0);
-    setBorderRadius(board.wrapperStyles?.borderRadius || "none");
-    setSpacing(board.spacing ?? 0);
-  }, [board.id]);
-
-  useEffect(() => {
-    onChange({
-      ...board,
-      wrapperStyles: {
-        bgColor,
-        bgOpacity,
-        gradientFrom,
-        gradientTo,
-        gradientDirection,
-        dropShadow: shadow,
-        paddingX,
-        paddingY,
-        marginX,
-        marginY,
-        borderColor,
-        borderWidth,
-        borderRadius,
-      },
-      spacing,
-    });
-  }, [bgColor, bgOpacity, gradientFrom, gradientTo, gradientDirection, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing, backgroundType]);
+  const {
+    bgColor,
+    setBgColor,
+    bgOpacity,
+    setBgOpacity,
+    gradientFrom,
+    setGradientFrom,
+    gradientTo,
+    setGradientTo,
+    gradientDirection,
+    setGradientDirection,
+    backgroundType,
+    setBackgroundType,
+    shadow,
+    setShadow,
+    paddingX,
+    setPaddingX,
+    paddingY,
+    setPaddingY,
+    marginX,
+    setMarginX,
+    marginY,
+    setMarginY,
+    borderColor,
+    setBorderColor,
+    borderWidth,
+    setBorderWidth,
+    borderRadius,
+    setBorderRadius,
+    spacing,
+    setSpacing,
+  } = useStyleAttributes({
+    wrapperStyles: board.wrapperStyles,
+    spacing: board.spacing,
+    deps: [board.id],
+    defaultBgOpacity: 1,
+    onChange: ({ wrapperStyles, spacing }) =>
+      onChange({ ...board, wrapperStyles, spacing }),
+  });
 
   return (
     <Accordion allowMultiple>

--- a/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ColumnAttributesPane.tsx
@@ -15,7 +15,7 @@ import {
   AccordionIcon,
   HStack,
 } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import useStyleAttributes from "./hooks/useStyleAttributes";
 import { ColumnType } from "@/components/DnD/types";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
@@ -25,71 +25,44 @@ interface ColumnAttributesPaneProps {
 }
 
 export default function ColumnAttributesPane({ column, onChange }: ColumnAttributesPaneProps) {
-  const [bgColor, setBgColor] = useState(column.wrapperStyles?.bgColor || "#ffffff");
-  const [bgOpacity, setBgOpacity] = useState(column.wrapperStyles?.bgOpacity ?? 0);
-  const [gradientFrom, setGradientFrom] = useState(column.wrapperStyles?.gradientFrom || "");
-  const [gradientTo, setGradientTo] = useState(column.wrapperStyles?.gradientTo || "");
-  const [gradientDirection, setGradientDirection] = useState(
-    column.wrapperStyles?.gradientDirection ?? 0
-  );
-  const [backgroundType, setBackgroundType] = useState(
-    column.wrapperStyles?.gradientFrom && column.wrapperStyles?.gradientTo
-      ? "gradient"
-      : "color"
-  );
-  const [shadow, setShadow] = useState(column.wrapperStyles?.dropShadow || "none");
-  const [paddingX, setPaddingX] = useState(column.wrapperStyles?.paddingX ?? 0);
-  const [paddingY, setPaddingY] = useState(column.wrapperStyles?.paddingY ?? 0);
-  const [marginX, setMarginX] = useState(column.wrapperStyles?.marginX ?? 0);
-  const [marginY, setMarginY] = useState(column.wrapperStyles?.marginY ?? 0);
-  const [borderColor, setBorderColor] = useState(column.wrapperStyles?.borderColor || "#000000");
-  const [borderWidth, setBorderWidth] = useState(column.wrapperStyles?.borderWidth ?? 0);
-  const [borderRadius, setBorderRadius] = useState(column.wrapperStyles?.borderRadius || "none");
-  const [spacing, setSpacing] = useState(column.spacing ?? 0);
-
-  useEffect(() => {
-    setBgColor(column.wrapperStyles?.bgColor || "#ffffff");
-    setBgOpacity(column.wrapperStyles?.bgOpacity ?? 0);
-    setGradientFrom(column.wrapperStyles?.gradientFrom || "");
-    setGradientTo(column.wrapperStyles?.gradientTo || "");
-    setGradientDirection(column.wrapperStyles?.gradientDirection ?? 0);
-    setBackgroundType(
-      column.wrapperStyles?.gradientFrom && column.wrapperStyles?.gradientTo
-        ? "gradient"
-        : "color"
-    );
-    setShadow(column.wrapperStyles?.dropShadow || "none");
-    setPaddingX(column.wrapperStyles?.paddingX ?? 0);
-    setPaddingY(column.wrapperStyles?.paddingY ?? 0);
-    setMarginX(column.wrapperStyles?.marginX ?? 0);
-    setMarginY(column.wrapperStyles?.marginY ?? 0);
-    setBorderColor(column.wrapperStyles?.borderColor || "#000000");
-    setBorderWidth(column.wrapperStyles?.borderWidth ?? 0);
-    setBorderRadius(column.wrapperStyles?.borderRadius || "none");
-    setSpacing(column.spacing ?? 0);
-  }, [column.columnId]);
-
-  useEffect(() => {
-    onChange({
-      ...column,
-      wrapperStyles: {
-        bgColor,
-        bgOpacity,
-        gradientFrom,
-        gradientTo,
-        gradientDirection,
-        dropShadow: shadow,
-        paddingX,
-        paddingY,
-        marginX,
-        marginY,
-        borderColor,
-        borderWidth,
-        borderRadius,
-      },
-      spacing,
-    });
-  }, [bgColor, bgOpacity, gradientFrom, gradientTo, gradientDirection, shadow, paddingX, paddingY, marginX, marginY, borderColor, borderWidth, borderRadius, spacing, backgroundType]);
+  const {
+    bgColor,
+    setBgColor,
+    bgOpacity,
+    setBgOpacity,
+    gradientFrom,
+    setGradientFrom,
+    gradientTo,
+    setGradientTo,
+    gradientDirection,
+    setGradientDirection,
+    backgroundType,
+    setBackgroundType,
+    shadow,
+    setShadow,
+    paddingX,
+    setPaddingX,
+    paddingY,
+    setPaddingY,
+    marginX,
+    setMarginX,
+    marginY,
+    setMarginY,
+    borderColor,
+    setBorderColor,
+    borderWidth,
+    setBorderWidth,
+    borderRadius,
+    setBorderRadius,
+    spacing,
+    setSpacing,
+  } = useStyleAttributes({
+    wrapperStyles: column.wrapperStyles,
+    spacing: column.spacing,
+    deps: [column.columnId],
+    onChange: ({ wrapperStyles, spacing }) =>
+      onChange({ ...column, wrapperStyles, spacing }),
+  });
 
   return (
     <Accordion allowMultiple>

--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -23,6 +23,7 @@ import { Trash2 } from "lucide-react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import EditQuizModal from "./EditQuizModal";
 import { useEffect, useState } from "react";
+import useStyleAttributes from "./hooks/useStyleAttributes";
 
 interface ElementAttributesPaneProps {
   element: SlideElementDnDItemProps;
@@ -60,46 +61,39 @@ export default function ElementAttributesPane({
     element.questions || ([] as SlideElementDnDItemProps["questions"])
   );
   const [isQuizModalOpen, setIsQuizModalOpen] = useState(false);
-  const [bgColor, setBgColor] = useState(
-    element.wrapperStyles?.bgColor || "#ffffff"
-  );
-  const [bgOpacity, setBgOpacity] = useState(
-    element.wrapperStyles?.bgOpacity ?? 0
-  );
-  const [gradientFrom, setGradientFrom] = useState(
-    element.wrapperStyles?.gradientFrom || ""
-  );
-  const [gradientTo, setGradientTo] = useState(
-    element.wrapperStyles?.gradientTo || ""
-  );
-  const [gradientDirection, setGradientDirection] = useState(
-    element.wrapperStyles?.gradientDirection ?? 0
-  );
-  const [backgroundType, setBackgroundType] = useState(
-    element.wrapperStyles?.gradientFrom && element.wrapperStyles?.gradientTo
-      ? "gradient"
-      : "color"
-  );
-  const [shadow, setShadow] = useState(
-    element.wrapperStyles?.dropShadow || "none"
-  );
-  const [paddingX, setPaddingX] = useState(
-    element.wrapperStyles?.paddingX ?? 0
-  );
-  const [paddingY, setPaddingY] = useState(
-    element.wrapperStyles?.paddingY ?? 0
-  );
-  const [marginX, setMarginX] = useState(element.wrapperStyles?.marginX ?? 0);
-  const [marginY, setMarginY] = useState(element.wrapperStyles?.marginY ?? 0);
-  const [borderColor, setBorderColor] = useState(
-    element.wrapperStyles?.borderColor || "#000000"
-  );
-  const [borderWidth, setBorderWidth] = useState(
-    element.wrapperStyles?.borderWidth ?? 0
-  );
-  const [borderRadius, setBorderRadius] = useState(
-    element.wrapperStyles?.borderRadius || "none"
-  );
+  const {
+    bgColor,
+    setBgColor,
+    bgOpacity,
+    setBgOpacity,
+    gradientFrom,
+    setGradientFrom,
+    gradientTo,
+    setGradientTo,
+    gradientDirection,
+    setGradientDirection,
+    backgroundType,
+    setBackgroundType,
+    shadow,
+    setShadow,
+    paddingX,
+    setPaddingX,
+    paddingY,
+    setPaddingY,
+    marginX,
+    setMarginX,
+    marginY,
+    setMarginY,
+    borderColor,
+    setBorderColor,
+    borderWidth,
+    setBorderWidth,
+    borderRadius,
+    setBorderRadius,
+  } = useStyleAttributes({
+    wrapperStyles: element.wrapperStyles,
+    deps: [element.id, element.type],
+  });
   const [animationEnabled, setAnimationEnabled] = useState(
     !!element.animation
   );
@@ -126,24 +120,6 @@ export default function ElementAttributesPane({
     setTitle(element.title || "");
     setDescription(element.description || "");
     setQuestions(element.questions || []);
-    setBgColor(element.wrapperStyles?.bgColor || "#ffffff");
-    setBgOpacity(element.wrapperStyles?.bgOpacity ?? 0);
-    setGradientFrom(element.wrapperStyles?.gradientFrom || "");
-    setGradientTo(element.wrapperStyles?.gradientTo || "");
-    setGradientDirection(element.wrapperStyles?.gradientDirection ?? 0);
-    setBackgroundType(
-      element.wrapperStyles?.gradientFrom && element.wrapperStyles?.gradientTo
-        ? "gradient"
-        : "color"
-    );
-    setShadow(element.wrapperStyles?.dropShadow || "none");
-    setPaddingX(element.wrapperStyles?.paddingX ?? 0);
-    setPaddingY(element.wrapperStyles?.paddingY ?? 0);
-    setMarginX(element.wrapperStyles?.marginX ?? 0);
-    setMarginY(element.wrapperStyles?.marginY ?? 0);
-    setBorderColor(element.wrapperStyles?.borderColor || "#000000");
-    setBorderWidth(element.wrapperStyles?.borderWidth ?? 0);
-    setBorderRadius(element.wrapperStyles?.borderRadius || "none");
     setAnimationEnabled(!!element.animation);
     setAnimationDirection(element.animation?.direction || "left");
     setAnimationDelay(element.animation?.delay ?? 0);

--- a/insight-fe/src/components/lesson/hooks/useStyleAttributes.ts
+++ b/insight-fe/src/components/lesson/hooks/useStyleAttributes.ts
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useState, type DependencyList } from "react";
+import type { ElementWrapperStyles } from "../ElementWrapper";
+
+export interface StyleAttributesChange {
+  wrapperStyles: ElementWrapperStyles;
+  spacing?: number;
+}
+
+interface UseStyleAttributesOptions {
+  wrapperStyles?: ElementWrapperStyles;
+  spacing?: number;
+  deps: DependencyList;
+  onChange?: (values: StyleAttributesChange) => void;
+  /** Default opacity when wrapperStyles doesn't provide one */
+  defaultBgOpacity?: number;
+}
+
+export default function useStyleAttributes({
+  wrapperStyles,
+  spacing: initialSpacing,
+  deps,
+  onChange,
+  defaultBgOpacity = 0,
+}: UseStyleAttributesOptions) {
+  const [bgColor, setBgColor] = useState(wrapperStyles?.bgColor || "#ffffff");
+  const [bgOpacity, setBgOpacity] = useState(
+    wrapperStyles?.bgOpacity ?? defaultBgOpacity
+  );
+  const [gradientFrom, setGradientFrom] = useState(
+    wrapperStyles?.gradientFrom || ""
+  );
+  const [gradientTo, setGradientTo] = useState(
+    wrapperStyles?.gradientTo || ""
+  );
+  const [gradientDirection, setGradientDirection] = useState(
+    wrapperStyles?.gradientDirection ?? 0
+  );
+  const [backgroundType, setBackgroundType] = useState(
+    wrapperStyles?.gradientFrom && wrapperStyles?.gradientTo ? "gradient" : "color"
+  );
+  const [shadow, setShadow] = useState(wrapperStyles?.dropShadow || "none");
+  const [paddingX, setPaddingX] = useState(wrapperStyles?.paddingX ?? 0);
+  const [paddingY, setPaddingY] = useState(wrapperStyles?.paddingY ?? 0);
+  const [marginX, setMarginX] = useState(wrapperStyles?.marginX ?? 0);
+  const [marginY, setMarginY] = useState(wrapperStyles?.marginY ?? 0);
+  const [borderColor, setBorderColor] = useState(
+    wrapperStyles?.borderColor || "#000000"
+  );
+  const [borderWidth, setBorderWidth] = useState(
+    wrapperStyles?.borderWidth ?? 0
+  );
+  const [borderRadius, setBorderRadius] = useState(
+    wrapperStyles?.borderRadius || "none"
+  );
+  const [spacing, setSpacing] = useState(initialSpacing ?? 0);
+
+  // Reset when dependencies change (new item selected)
+  useEffect(() => {
+    setBgColor(wrapperStyles?.bgColor || "#ffffff");
+    setBgOpacity(wrapperStyles?.bgOpacity ?? defaultBgOpacity);
+    setGradientFrom(wrapperStyles?.gradientFrom || "");
+    setGradientTo(wrapperStyles?.gradientTo || "");
+    setGradientDirection(wrapperStyles?.gradientDirection ?? 0);
+    setBackgroundType(
+      wrapperStyles?.gradientFrom && wrapperStyles?.gradientTo
+        ? "gradient"
+        : "color"
+    );
+    setShadow(wrapperStyles?.dropShadow || "none");
+    setPaddingX(wrapperStyles?.paddingX ?? 0);
+    setPaddingY(wrapperStyles?.paddingY ?? 0);
+    setMarginX(wrapperStyles?.marginX ?? 0);
+    setMarginY(wrapperStyles?.marginY ?? 0);
+    setBorderColor(wrapperStyles?.borderColor || "#000000");
+    setBorderWidth(wrapperStyles?.borderWidth ?? 0);
+    setBorderRadius(wrapperStyles?.borderRadius || "none");
+    setSpacing(initialSpacing ?? 0);
+  }, deps);
+
+  // Propagate changes upwards
+  useEffect(() => {
+    if (!onChange) return;
+    const values: StyleAttributesChange = {
+      wrapperStyles: {
+        bgColor,
+        bgOpacity,
+        gradientFrom,
+        gradientTo,
+        gradientDirection,
+        dropShadow: shadow,
+        paddingX,
+        paddingY,
+        marginX,
+        marginY,
+        borderColor,
+        borderWidth,
+        borderRadius,
+      },
+    };
+    if (typeof initialSpacing !== "undefined") {
+      values.spacing = spacing;
+    }
+    onChange(values);
+  }, [
+    bgColor,
+    bgOpacity,
+    gradientFrom,
+    gradientTo,
+    gradientDirection,
+    shadow,
+    paddingX,
+    paddingY,
+    marginX,
+    marginY,
+    borderColor,
+    borderWidth,
+    borderRadius,
+    spacing,
+    backgroundType,
+  ]);
+
+  return {
+    bgColor,
+    setBgColor,
+    bgOpacity,
+    setBgOpacity,
+    gradientFrom,
+    setGradientFrom,
+    gradientTo,
+    setGradientTo,
+    gradientDirection,
+    setGradientDirection,
+    backgroundType,
+    setBackgroundType,
+    shadow,
+    setShadow,
+    paddingX,
+    setPaddingX,
+    paddingY,
+    setPaddingY,
+    marginX,
+    setMarginX,
+    marginY,
+    setMarginY,
+    borderColor,
+    setBorderColor,
+    borderWidth,
+    setBorderWidth,
+    borderRadius,
+    setBorderRadius,
+    spacing,
+    setSpacing,
+  };
+}


### PR DESCRIPTION
## Summary
- add `useStyleAttributes` hook to manage wrapper style fields
- refactor board, column and element attribute panes to use the hook

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6841b651b7388326a293215f18ebf599