### PR TITLE
Centralize lesson builder wrapper styles

### DIFF
--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -11,6 +11,9 @@ import { ColumnType, ColumnMap } from "@/components/DnD/types";
 import { createRegistry } from "@/components/DnD/registry";
 import { ContentCard } from "../layout/Card";
 import ElementWrapper, { ElementWrapperStyles } from "./ElementWrapper";
+import {
+  defaultColumnWrapperStyles,
+} from "./defaultStyles";
 import { useCallback } from "react";
 import { X, Settings, Plus } from "lucide-react";
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
@@ -130,21 +133,7 @@ export default function SlideElementsBoard({
         container: { border: "1px dashed gray", width: "100%" },
         header: { bg: color, color: "white", px: 2, py: 1 },
       },
-      wrapperStyles: {
-        bgColor: "#ffffff",
-        bgOpacity: 0,
-        gradientFrom: "",
-        gradientTo: "",
-        gradientDirection: 0,
-        dropShadow: "none",
-        paddingX: 0,
-        paddingY: 0,
-        marginX: 0,
-        marginY: 0,
-        borderColor: "#000000",
-        borderWidth: 0,
-        borderRadius: "none",
-      },
+      wrapperStyles: { ...defaultColumnWrapperStyles },
       items: [],
       spacing: 0,
     };

--- a/insight-fe/src/components/lesson/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsContainer.tsx
@@ -7,6 +7,10 @@ import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnD
 import { ColumnMap, ColumnType } from "@/components/DnD/types";
 import { createRegistry } from "@/components/DnD/registry";
 import type { ElementWrapperStyles } from "./ElementWrapper";
+import {
+  defaultBoardWrapperStyles,
+  defaultColumnWrapperStyles,
+} from "./defaultStyles";
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 import {
   monitorForElements,
@@ -85,21 +89,7 @@ export default function SlideElementsContainer({
         container: { border: "1px dashed gray", width: "100%" },
         header: { bg: color, color: "white", px: 2, py: 1 },
       },
-      wrapperStyles: {
-        bgColor: "#ffffff",
-        bgOpacity: 0,
-        gradientFrom: "",
-        gradientTo: "",
-        gradientDirection: 0,
-        dropShadow: "none",
-        paddingX: 0,
-        paddingY: 0,
-        marginX: 0,
-        marginY: 0,
-        borderColor: "#000000",
-        borderWidth: 0,
-        borderRadius: "none",
-      },
+      wrapperStyles: { ...defaultColumnWrapperStyles },
       items: [],
       spacing: 0,
     };
@@ -109,21 +99,7 @@ export default function SlideElementsContainer({
       {
         id: boardId,
         orderedColumnIds: [columnId],
-      wrapperStyles: {
-        bgColor: "#ffffff",
-        bgOpacity: 1,
-        gradientFrom: "",
-        gradientTo: "",
-        gradientDirection: 0,
-        dropShadow: "none",
-          paddingX: 0,
-          paddingY: 0,
-          marginX: 0,
-          marginY: 0,
-          borderColor: "#000000",
-          borderWidth: 0,
-          borderRadius: "none",
-        },
+        wrapperStyles: { ...defaultBoardWrapperStyles },
         spacing: 0,
       },
     ]);

--- a/insight-fe/src/components/lesson/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/SlideSequencer.tsx
@@ -5,6 +5,10 @@ import { Box, Button, Stack } from "@chakra-ui/react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap } from "@/components/DnD/types";
 import type { ElementWrapperStyles } from "./ElementWrapper";
+import {
+  defaultBoardWrapperStyles,
+  defaultColumnWrapperStyles,
+} from "./defaultStyles";
 import { DropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box";
 import {
   draggable,
@@ -47,21 +51,7 @@ export const createInitialBoard = (): {
           container: { border: "1px dashed gray", width: "100%" },
           header: { bg: "red.300", color: "white", px: 2, py: 1 },
         },
-        wrapperStyles: {
-          bgColor: "#ffffff",
-          bgOpacity: 0,
-          gradientFrom: "",
-          gradientTo: "",
-          gradientDirection: 0,
-          dropShadow: "none",
-          paddingX: 0,
-          paddingY: 0,
-          marginX: 0,
-          marginY: 0,
-          borderColor: "#000000",
-          borderWidth: 0,
-          borderRadius: "none",
-        },
+        wrapperStyles: { ...defaultColumnWrapperStyles },
         items: [],
       },
     },
@@ -69,21 +59,7 @@ export const createInitialBoard = (): {
       {
         id: boardId,
         orderedColumnIds: [columnId],
-        wrapperStyles: {
-          bgColor: "#ffffff",
-          bgOpacity: 1,
-          gradientFrom: "",
-          gradientTo: "",
-          gradientDirection: 0,
-          dropShadow: "none",
-          paddingX: 0,
-          paddingY: 0,
-          marginX: 0,
-          marginY: 0,
-          borderColor: "#000000",
-          borderWidth: 0,
-          borderRadius: "none",
-        },
+        wrapperStyles: { ...defaultBoardWrapperStyles },
       },
     ],
   };

--- a/insight-fe/src/components/lesson/defaultStyles.ts
+++ b/insight-fe/src/components/lesson/defaultStyles.ts
@@ -1,0 +1,22 @@
+import type { ElementWrapperStyles } from "./ElementWrapper";
+
+export const defaultColumnWrapperStyles: ElementWrapperStyles = {
+  bgColor: "#ffffff",
+  bgOpacity: 0,
+  gradientFrom: "",
+  gradientTo: "",
+  gradientDirection: 0,
+  dropShadow: "none",
+  paddingX: 0,
+  paddingY: 0,
+  marginX: 0,
+  marginY: 0,
+  borderColor: "#000000",
+  borderWidth: 0,
+  borderRadius: "none",
+};
+
+export const defaultBoardWrapperStyles: ElementWrapperStyles = {
+  ...defaultColumnWrapperStyles,
+  bgOpacity: 1,
+};

--- a/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
+++ b/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
@@ -13,6 +13,7 @@ import {
 } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnType } from "@/components/DnD/types";
 import { availableFonts } from "@/theme/fonts";
+import { defaultColumnWrapperStyles } from "../defaultStyles";
 
 export interface LessonEditorHandle {
   getContent: () => { slides: Slide[] };
@@ -353,21 +354,7 @@ export function useLessonEditorState(ref?: React.Ref<LessonEditorHandle>) {
                       questions: [],
                     }
                   : {}),
-                wrapperStyles: {
-                  bgColor: "#ffffff",
-                  bgOpacity: 0,
-                  gradientFrom: "",
-                  gradientTo: "",
-                  gradientDirection: 0,
-                  dropShadow: "none",
-                  paddingX: 0,
-                  paddingY: 0,
-                  marginX: 0,
-                  marginY: 0,
-                  borderColor: "#000000",
-                  borderWidth: 0,
-                  borderRadius: "none",
-                },
+                wrapperStyles: { ...defaultColumnWrapperStyles },
                 animation: undefined,
               };
 


### PR DESCRIPTION
## Summary
- add `lesson/defaultStyles.ts` with shared wrapper style objects
- use the shared wrapper styles in lesson builder components and state hook

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d81da8808326b69f22baa93ef518