### PR TITLE
Refactor lesson element settings

### DIFF
--- a/insight-fe/src/components/lesson/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/ElementAttributesPane.tsx
@@ -2,28 +2,22 @@
 
 import {
   Box,
-  Stack,
-  Text,
   Button,
-  FormControl,
-  FormLabel,
-  Input,
-  Select,
   Accordion,
-  AccordionItem,
-  AccordionButton,
-  AccordionPanel,
-  AccordionIcon,
   HStack,
-  VStack,
   Icon,
 } from "@chakra-ui/react";
 import { availableFonts } from "@/theme/fonts";
 import { Trash2 } from "lucide-react";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
-import EditQuizModal from "./EditQuizModal";
 import { useEffect, useState } from "react";
 import useStyleAttributes from "./hooks/useStyleAttributes";
+import WrapperSettings from "./attributes/WrapperSettings";
+import AnimationSettings from "./attributes/AnimationSettings";
+import TextAttributes from "./attributes/TextAttributes";
+import ImageAttributes from "./attributes/ImageAttributes";
+import VideoAttributes from "./attributes/VideoAttributes";
+import QuizAttributes from "./attributes/QuizAttributes";
 
 interface ElementAttributesPaneProps {
   element: SlideElementDnDItemProps;
@@ -61,6 +55,10 @@ export default function ElementAttributesPane({
     element.questions || ([] as SlideElementDnDItemProps["questions"])
   );
   const [isQuizModalOpen, setIsQuizModalOpen] = useState(false);
+  const styleAttrs = useStyleAttributes({
+    wrapperStyles: element.wrapperStyles,
+    deps: [element.id, element.type],
+  });
   const {
     bgColor,
     setBgColor,
@@ -90,10 +88,7 @@ export default function ElementAttributesPane({
     setBorderWidth,
     borderRadius,
     setBorderRadius,
-  } = useStyleAttributes({
-    wrapperStyles: element.wrapperStyles,
-    deps: [element.id, element.type],
-  });
+  } = styleAttrs;
   const [animationEnabled, setAnimationEnabled] = useState(
     !!element.animation
   );
@@ -206,522 +201,49 @@ export default function ElementAttributesPane({
   return (
     <>
       <Accordion allowMultiple>
-      <AccordionItem
-        borderWidth="1px"
-        borderColor="blue.300"
-        borderRadius="md"
-        mb={2}
-      >
-        <h2>
-          <AccordionButton>
-            <Box flex="1" textAlign="left">
-              Background
-            </Box>
-            <AccordionIcon />
-          </AccordionButton>
-        </h2>
-        <AccordionPanel pb={2}>
-          <Stack spacing={2}>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Type</FormLabel>
-              <Select
-                size="sm"
-                value={backgroundType}
-                onChange={(e) => {
-                  const value = e.target.value as "color" | "gradient";
-                  setBackgroundType(value);
-                  if (value === "color") {
-                    setGradientFrom("");
-                    setGradientTo("");
-                    setGradientDirection(0);
-                  } else {
-                    setBgColor("#ffffff");
-                  }
-                }}
-              >
-                <option value="color">Color</option>
-                <option value="gradient">Gradient</option>
-              </Select>
-            </FormControl>
-            {backgroundType === "color" && (
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
-                <Input
-                  type="color"
-                  value={bgColor}
-                  onChange={(e) => {
-                    setBgColor(e.target.value);
-                    setBgOpacity(1);
-                  }}
-                />
-              </FormControl>
-            )}
-            {backgroundType === "gradient" && (
-              <>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
-                  <Input
-                    type="color"
-                    value={gradientFrom}
-                    onChange={(e) => setGradientFrom(e.target.value)}
-                  />
-                </FormControl>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
-                  <Input
-                    type="color"
-                    value={gradientTo}
-                    onChange={(e) => setGradientTo(e.target.value)}
-                  />
-                </FormControl>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
-                  <Input
-                    size="sm"
-                    type="number"
-                    w="60px"
-                    value={gradientDirection}
-                    onChange={(e) =>
-                      setGradientDirection(parseInt(e.target.value))
-                    }
-                  />
-                </FormControl>
-              </>
-            )}
-          </Stack>
-        </AccordionPanel>
-      </AccordionItem>
-
-      <AccordionItem
-        borderWidth="1px"
-        borderColor="orange.300"
-        borderRadius="md"
-        mb={2}
-      >
-        <h2>
-          <AccordionButton>
-            <Box flex="1" textAlign="left">Animation</Box>
-            <AccordionIcon />
-          </AccordionButton>
-        </h2>
-        <AccordionPanel pb={2}>
-          <Stack spacing={2}>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Enable</FormLabel>
-              <Select
-                size="sm"
-                value={animationEnabled ? "on" : "off"}
-                onChange={(e) => setAnimationEnabled(e.target.value === "on")}
-              >
-                <option value="on">On</option>
-                <option value="off">Off</option>
-              </Select>
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
-              <Select
-                size="sm"
-                value={animationDirection}
-                onChange={(e) =>
-                  setAnimationDirection(e.target.value as any)
-                }
-              >
-                <option value="left">Left</option>
-                <option value="right">Right</option>
-                <option value="top">Top</option>
-                <option value="bottom">Bottom</option>
-              </Select>
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">Delay (ms)</FormLabel>
-              <Input
-                size="sm"
-                type="number"
-                w="60px"
-                value={animationDelay}
-                onChange={(e) => setAnimationDelay(parseInt(e.target.value))}
-              />
-            </FormControl>
-          </Stack>
-        </AccordionPanel>
-      </AccordionItem>
-
-      <AccordionItem
-        borderWidth="1px"
-        borderColor="blue.300"
-        borderRadius="md"
-        mb={2}
-      >
-        <h2>
-          <AccordionButton>
-            <Box flex="1" textAlign="left">
-              Wrapper
-            </Box>
-            <AccordionIcon />
-          </AccordionButton>
-        </h2>
-        <AccordionPanel pb={2}>
-          <Stack spacing={2}>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">
-                Shadow
-              </FormLabel>
-              <Select
-                size="sm"
-                value={shadow}
-                onChange={(e) => setShadow(e.target.value)}
-              >
-                <option value="none">None</option>
-                <option value="sm">Small</option>
-                <option value="md">Medium</option>
-                <option value="lg">Large</option>
-                <option value="xl">XL</option>
-                <option value="2xl">2XL</option>
-              </Select>
-            </FormControl>
-            <Box>
-              <Text fontSize="sm" mb={1}>
-                Padding
-              </Text>
-              <HStack spacing={2}>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel mb="0" fontSize="sm">
-                    Horiz.
-                  </FormLabel>
-                  <Input
-                    size="sm"
-                    type="number"
-                    w="60px"
-                    value={paddingX}
-                    onChange={(e) => setPaddingX(parseInt(e.target.value))}
-                  />
-                </FormControl>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel mb="0" fontSize="sm">
-                    Vert.
-                  </FormLabel>
-                  <Input
-                    size="sm"
-                    type="number"
-                    w="60px"
-                    value={paddingY}
-                    onChange={(e) => setPaddingY(parseInt(e.target.value))}
-                  />
-                </FormControl>
-              </HStack>
-            </Box>
-            <Box>
-              <Text fontSize="sm" mb={1}>
-                Margin
-              </Text>
-              <HStack spacing={2}>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel mb="0" fontSize="sm">
-                    Horiz.
-                  </FormLabel>
-                  <Input
-                    size="sm"
-                    type="number"
-                    w="60px"
-                    value={marginX}
-                    onChange={(e) => setMarginX(parseInt(e.target.value))}
-                  />
-                </FormControl>
-                <FormControl display="flex" alignItems="center">
-                  <FormLabel mb="0" fontSize="sm">
-                    Vert.
-                  </FormLabel>
-                  <Input
-                    size="sm"
-                    type="number"
-                    w="60px"
-                    value={marginY}
-                    onChange={(e) => setMarginY(parseInt(e.target.value))}
-                  />
-                </FormControl>
-              </HStack>
-            </Box>
-          </Stack>
-        </AccordionPanel>
-      </AccordionItem>
-
-      <AccordionItem
-        borderWidth="1px"
-        borderColor="green.300"
-        borderRadius="md"
-        mb={2}
-      >
-        <h2>
-          <AccordionButton>
-            <Box flex="1" textAlign="left">
-              Borders
-            </Box>
-            <AccordionIcon />
-          </AccordionButton>
-        </h2>
-        <AccordionPanel pb={2}>
-          <Stack spacing={2}>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">
-                Color
-              </FormLabel>
-              <Input
-                type="color"
-                value={borderColor}
-                onChange={(e) => setBorderColor(e.target.value)}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">
-                Width
-              </FormLabel>
-              <Input
-                size="sm"
-                type="number"
-                w="60px"
-                value={borderWidth}
-                onChange={(e) => setBorderWidth(parseInt(e.target.value))}
-              />
-            </FormControl>
-            <FormControl display="flex" alignItems="center">
-              <FormLabel mb="0" fontSize="sm" w="40%">
-                Radius
-              </FormLabel>
-              <Select
-                size="sm"
-                value={borderRadius}
-                onChange={(e) => setBorderRadius(e.target.value)}
-              >
-                <option value="none">None</option>
-                <option value="sm">Small</option>
-                <option value="md">Medium</option>
-                <option value="lg">Large</option>
-                <option value="xl">Extra Large</option>
-                <option value="2xl">2x Large</option>
-                <option value="3xl">3x Large</option>
-                <option value="full">Fully Rounded</option>
-                <option value="50%">Circular</option>
-              </Select>
-            </FormControl>
-          </Stack>
-        </AccordionPanel>
-      </AccordionItem>
-
-      {element.type === "text" && (
-        <AccordionItem
-          borderWidth="1px"
-          borderColor="purple.300"
-          borderRadius="md"
-          mb={2}
-        >
-          <h2>
-            <AccordionButton>
-              <Box flex="1" textAlign="left">
-                Text
-              </Box>
-              <AccordionIcon />
-            </AccordionButton>
-          </h2>
-          <AccordionPanel pb={2}>
-            <Stack spacing={2}>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  Content
-                </FormLabel>
-                <Input
-                  size="sm"
-                  value={text}
-                  onChange={(e) => setText(e.target.value)}
-                />
-              </FormControl>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  Color
-                </FormLabel>
-                <Input
-                  type="color"
-                  value={color}
-                  onChange={(e) => setColor(e.target.value)}
-                />
-              </FormControl>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  Size
-                </FormLabel>
-                <Input
-                  size="sm"
-                  type="number"
-                  w="60px"
-                  value={parseInt(fontSize)}
-                  onChange={(e) => setFontSize(e.target.value + "px")}
-                />
-              </FormControl>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  Font
-                </FormLabel>
-                <Select
-                  size="sm"
-                  value={fontFamily}
-                  onChange={(e) => setFontFamily(e.target.value)}
-                >
-                  {availableFonts.map((f) => (
-                    <option key={f.fontFamily} value={f.fontFamily}>
-                      {f.label}
-                    </option>
-                  ))}
-                </Select>
-              </FormControl>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  Weight
-                </FormLabel>
-                <Select
-                  size="sm"
-                  value={fontWeight}
-                  onChange={(e) => setFontWeight(e.target.value)}
-                >
-                  <option value="normal">Normal</option>
-                  <option value="bold">Bold</option>
-                  <option value="bolder">Bolder</option>
-                  <option value="lighter">Lighter</option>
-                  <option value="100">100</option>
-                  <option value="200">200</option>
-                  <option value="300">300</option>
-                  <option value="400">400</option>
-                  <option value="500">500</option>
-                  <option value="600">600</option>
-                  <option value="700">700</option>
-                  <option value="800">800</option>
-                  <option value="900">900</option>
-                </Select>
-              </FormControl>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  Line Height
-                </FormLabel>
-                <Input
-                  size="sm"
-                  type="number"
-                  w="60px"
-                  value={parseFloat(lineHeight)}
-                  onChange={(e) => setLineHeight(e.target.value)}
-                />
-              </FormControl>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  Align
-                </FormLabel>
-                <Select
-                  size="sm"
-                  value={textAlign}
-                  onChange={(e) => setTextAlign(e.target.value)}
-                >
-                  <option value="left">Left</option>
-                  <option value="center">Center</option>
-                  <option value="right">Right</option>
-                  <option value="justify">Justify</option>
-                </Select>
-              </FormControl>
-            </Stack>
-          </AccordionPanel>
-        </AccordionItem>
-      )}
-
-      {element.type === "image" && (
-        <AccordionItem
-          borderWidth="1px"
-          borderColor="purple.300"
-          borderRadius="md"
-          mb={2}
-        >
-          <h2>
-            <AccordionButton>
-              <Box flex="1" textAlign="left">
-                Image
-              </Box>
-              <AccordionIcon />
-            </AccordionButton>
-          </h2>
-          <AccordionPanel pb={2}>
-            <Stack spacing={2}>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  Source
-                </FormLabel>
-                <Input
-                  size="sm"
-                  value={src}
-                  onChange={(e) => setSrc(e.target.value)}
-                />
-              </FormControl>
-            </Stack>
-          </AccordionPanel>
-        </AccordionItem>
-      )}
-
-      {element.type === "video" && (
-        <AccordionItem
-          borderWidth="1px"
-          borderColor="purple.300"
-          borderRadius="md"
-          mb={2}
-        >
-          <h2>
-            <AccordionButton>
-              <Box flex="1" textAlign="left">
-                Video
-              </Box>
-              <AccordionIcon />
-            </AccordionButton>
-          </h2>
-          <AccordionPanel pb={2}>
-            <Stack spacing={2}>
-              <FormControl display="flex" alignItems="center">
-                <FormLabel mb="0" fontSize="sm" w="40%">
-                  URL
-                </FormLabel>
-                <Input
-                  size="sm"
-                  value={url}
-                  onChange={(e) => setUrl(e.target.value)}
-                />
-              </FormControl>
-            </Stack>
-          </AccordionPanel>
-        </AccordionItem>
-      )}
-
-      {element.type === "quiz" && (
-        <AccordionItem
-          borderWidth="1px"
-          borderColor="purple.300"
-          borderRadius="md"
-          mb={2}
-        >
-          <h2>
-            <AccordionButton>
-              <Box flex="1" textAlign="left">Quiz</Box>
-              <AccordionIcon />
-            </AccordionButton>
-          </h2>
-          <AccordionPanel pb={2}>
-            <Button size="sm" onClick={() => setIsQuizModalOpen(true)}>
-              Edit Quiz
-            </Button>
-            <EditQuizModal
-              isOpen={isQuizModalOpen}
-              onClose={() => setIsQuizModalOpen(false)}
-              title={title}
-              onTitleChange={setTitle}
-              description={description}
-              onDescriptionChange={setDescription}
-              questions={questions}
-              setQuestions={setQuestions}
-            />
-          </AccordionPanel>
-        </AccordionItem>
-      )}
+        <WrapperSettings attrs={styleAttrs} />
+        <AnimationSettings
+          enabled={animationEnabled}
+          setEnabled={setAnimationEnabled}
+          direction={animationDirection}
+          setDirection={setAnimationDirection}
+          delay={animationDelay}
+          setDelay={setAnimationDelay}
+        />
+        {element.type === "text" && (
+          <TextAttributes
+            text={text}
+            setText={setText}
+            color={color}
+            setColor={setColor}
+            fontSize={fontSize}
+            setFontSize={setFontSize}
+            fontFamily={fontFamily}
+            setFontFamily={setFontFamily}
+            fontWeight={fontWeight}
+            setFontWeight={setFontWeight}
+            lineHeight={lineHeight}
+            setLineHeight={setLineHeight}
+            textAlign={textAlign}
+            setTextAlign={setTextAlign}
+          />
+        )}
+        {element.type === "image" && (
+          <ImageAttributes src={src} setSrc={setSrc} />
+        )}
+        {element.type === "video" && (
+          <VideoAttributes url={url} setUrl={setUrl} />
+        )}
+        {element.type === "quiz" && (
+          <QuizAttributes
+            title={title}
+            setTitle={setTitle}
+            description={description}
+            setDescription={setDescription}
+            questions={questions}
+            setQuestions={setQuestions}
+          />
+        )}
       </Accordion>
       {(onClone || onDelete) && (
         <HStack mt={4} spacing={2} align="stretch">

--- a/insight-fe/src/components/lesson/attributes/AnimationSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/AnimationSettings.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import {
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  FormControl,
+  FormLabel,
+  Select,
+  Stack,
+  Input,
+} from "@chakra-ui/react";
+
+interface AnimationSettingsProps {
+  enabled: boolean;
+  setEnabled: (val: boolean) => void;
+  direction: string;
+  setDirection: (val: string) => void;
+  delay: number;
+  setDelay: (val: number) => void;
+}
+
+export default function AnimationSettings({
+  enabled,
+  setEnabled,
+  direction,
+  setDirection,
+  delay,
+  setDelay,
+}: AnimationSettingsProps) {
+  return (
+    <AccordionItem borderWidth="1px" borderColor="orange.300" borderRadius="md" mb={2}>
+      <h2>
+        <AccordionButton>
+          <Box flex="1" textAlign="left">Animation</Box>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
+      <AccordionPanel pb={2}>
+        <Stack spacing={2}>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Enable
+            </FormLabel>
+            <Select
+              size="sm"
+              value={enabled ? "on" : "off"}
+              onChange={(e) => setEnabled(e.target.value === "on")}
+            >
+              <option value="on">On</option>
+              <option value="off">Off</option>
+            </Select>
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Direction
+            </FormLabel>
+            <Select
+              size="sm"
+              value={direction}
+              onChange={(e) => setDirection(e.target.value)}
+            >
+              <option value="left">Left</option>
+              <option value="right">Right</option>
+              <option value="top">Top</option>
+              <option value="bottom">Bottom</option>
+            </Select>
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Delay (ms)
+            </FormLabel>
+            <Input
+              size="sm"
+              type="number"
+              w="60px"
+              value={delay}
+              onChange={(e) => setDelay(parseInt(e.target.value))}
+            />
+          </FormControl>
+        </Stack>
+      </AccordionPanel>
+    </AccordionItem>
+  );
+}
+

--- a/insight-fe/src/components/lesson/attributes/ImageAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/ImageAttributes.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import {
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+} from "@chakra-ui/react";
+
+interface ImageAttributesProps {
+  src: string;
+  setSrc: (val: string) => void;
+}
+
+export default function ImageAttributes({ src, setSrc }: ImageAttributesProps) {
+  return (
+    <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>
+      <h2>
+        <AccordionButton>
+          <Box flex="1" textAlign="left">Image</Box>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
+      <AccordionPanel pb={2}>
+        <Stack spacing={2}>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Source
+            </FormLabel>
+            <Input size="sm" value={src} onChange={(e) => setSrc(e.target.value)} />
+          </FormControl>
+        </Stack>
+      </AccordionPanel>
+    </AccordionItem>
+  );
+}
+

--- a/insight-fe/src/components/lesson/attributes/QuizAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/QuizAttributes.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  Button,
+} from "@chakra-ui/react";
+import { useState } from "react";
+import EditQuizModal from "../EditQuizModal";
+import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
+
+interface QuizAttributesProps {
+  title: string;
+  setTitle: (val: string) => void;
+  description: string;
+  setDescription: (val: string) => void;
+  questions: SlideElementDnDItemProps["questions"];
+  setQuestions: React.Dispatch<React.SetStateAction<SlideElementDnDItemProps["questions"]>>;
+}
+
+export default function QuizAttributes({
+  title,
+  setTitle,
+  description,
+  setDescription,
+  questions,
+  setQuestions,
+}: QuizAttributesProps) {
+  const [isQuizModalOpen, setIsQuizModalOpen] = useState(false);
+  return (
+    <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>
+      <h2>
+        <AccordionButton>
+          <Box flex="1" textAlign="left">Quiz</Box>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
+      <AccordionPanel pb={2}>
+        <Button size="sm" onClick={() => setIsQuizModalOpen(true)}>
+          Edit Quiz
+        </Button>
+        <EditQuizModal
+          isOpen={isQuizModalOpen}
+          onClose={() => setIsQuizModalOpen(false)}
+          title={title}
+          onTitleChange={setTitle}
+          description={description}
+          onDescriptionChange={setDescription}
+          questions={questions}
+          setQuestions={setQuestions}
+        />
+      </AccordionPanel>
+    </AccordionItem>
+  );
+}
+

--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import {
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Stack,
+} from "@chakra-ui/react";
+import { availableFonts } from "@/theme/fonts";
+
+interface TextAttributesProps {
+  text: string;
+  setText: (val: string) => void;
+  color: string;
+  setColor: (val: string) => void;
+  fontSize: string;
+  setFontSize: (val: string) => void;
+  fontFamily: string;
+  setFontFamily: (val: string) => void;
+  fontWeight: string;
+  setFontWeight: (val: string) => void;
+  lineHeight: string;
+  setLineHeight: (val: string) => void;
+  textAlign: string;
+  setTextAlign: (val: string) => void;
+}
+
+export default function TextAttributes({
+  text,
+  setText,
+  color,
+  setColor,
+  fontSize,
+  setFontSize,
+  fontFamily,
+  setFontFamily,
+  fontWeight,
+  setFontWeight,
+  lineHeight,
+  setLineHeight,
+  textAlign,
+  setTextAlign,
+}: TextAttributesProps) {
+  return (
+    <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>
+      <h2>
+        <AccordionButton>
+          <Box flex="1" textAlign="left">Text</Box>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
+      <AccordionPanel pb={2}>
+        <Stack spacing={2}>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Content
+            </FormLabel>
+            <Input size="sm" value={text} onChange={(e) => setText(e.target.value)} />
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Color
+            </FormLabel>
+            <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Size
+            </FormLabel>
+            <Input
+              size="sm"
+              type="number"
+              w="60px"
+              value={parseInt(fontSize)}
+              onChange={(e) => setFontSize(e.target.value + "px")}
+            />
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Font
+            </FormLabel>
+            <Select size="sm" value={fontFamily} onChange={(e) => setFontFamily(e.target.value)}>
+              {availableFonts.map((f) => (
+                <option key={f.fontFamily} value={f.fontFamily}>
+                  {f.label}
+                </option>
+              ))}
+            </Select>
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Weight
+            </FormLabel>
+            <Select size="sm" value={fontWeight} onChange={(e) => setFontWeight(e.target.value)}>
+              <option value="normal">Normal</option>
+              <option value="bold">Bold</option>
+              <option value="bolder">Bolder</option>
+              <option value="lighter">Lighter</option>
+              <option value="100">100</option>
+              <option value="200">200</option>
+              <option value="300">300</option>
+              <option value="400">400</option>
+              <option value="500">500</option>
+              <option value="600">600</option>
+              <option value="700">700</option>
+              <option value="800">800</option>
+              <option value="900">900</option>
+            </Select>
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Line Height
+            </FormLabel>
+            <Input
+              size="sm"
+              type="number"
+              w="60px"
+              value={parseFloat(lineHeight)}
+              onChange={(e) => setLineHeight(e.target.value)}
+            />
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Align
+            </FormLabel>
+            <Select size="sm" value={textAlign} onChange={(e) => setTextAlign(e.target.value)}>
+              <option value="left">Left</option>
+              <option value="center">Center</option>
+              <option value="right">Right</option>
+              <option value="justify">Justify</option>
+            </Select>
+          </FormControl>
+        </Stack>
+      </AccordionPanel>
+    </AccordionItem>
+  );
+}
+

--- a/insight-fe/src/components/lesson/attributes/VideoAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/VideoAttributes.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import {
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+} from "@chakra-ui/react";
+
+interface VideoAttributesProps {
+  url: string;
+  setUrl: (val: string) => void;
+}
+
+export default function VideoAttributes({ url, setUrl }: VideoAttributesProps) {
+  return (
+    <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>
+      <h2>
+        <AccordionButton>
+          <Box flex="1" textAlign="left">Video</Box>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
+      <AccordionPanel pb={2}>
+        <Stack spacing={2}>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              URL
+            </FormLabel>
+            <Input size="sm" value={url} onChange={(e) => setUrl(e.target.value)} />
+          </FormControl>
+        </Stack>
+      </AccordionPanel>
+    </AccordionItem>
+  );
+}
+

--- a/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import {
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Select,
+  Stack,
+  Text,
+  HStack,
+} from "@chakra-ui/react";
+import type useStyleAttributes from "../hooks/useStyleAttributes";
+
+interface WrapperSettingsProps {
+  attrs: ReturnType<typeof useStyleAttributes>;
+}
+
+export default function WrapperSettings({ attrs }: WrapperSettingsProps) {
+  const {
+    bgColor,
+    setBgColor,
+    bgOpacity,
+    setBgOpacity,
+    gradientFrom,
+    setGradientFrom,
+    gradientTo,
+    setGradientTo,
+    gradientDirection,
+    setGradientDirection,
+    backgroundType,
+    setBackgroundType,
+    shadow,
+    setShadow,
+    paddingX,
+    setPaddingX,
+    paddingY,
+    setPaddingY,
+    marginX,
+    setMarginX,
+    marginY,
+    setMarginY,
+    borderColor,
+    setBorderColor,
+    borderWidth,
+    setBorderWidth,
+    borderRadius,
+    setBorderRadius,
+  } = attrs;
+
+  return (
+    <>
+      <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">Background</Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">Type</FormLabel>
+              <Select
+                size="sm"
+                value={backgroundType}
+                onChange={(e) => {
+                  const value = e.target.value as "color" | "gradient";
+                  setBackgroundType(value);
+                  if (value === "color") {
+                    setGradientFrom("");
+                    setGradientTo("");
+                    setGradientDirection(0);
+                  } else {
+                    setBgColor("#ffffff");
+                  }
+                }}
+              >
+                <option value="color">Color</option>
+                <option value="gradient">Gradient</option>
+              </Select>
+            </FormControl>
+            {backgroundType === "color" && (
+              <FormControl display="flex" alignItems="center">
+                <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
+                <Input
+                  type="color"
+                  value={bgColor}
+                  onChange={(e) => {
+                    setBgColor(e.target.value);
+                    setBgOpacity(1);
+                  }}
+                />
+              </FormControl>
+            )}
+            {backgroundType === "gradient" && (
+              <>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
+                  <Input
+                    type="color"
+                    value={gradientFrom}
+                    onChange={(e) => setGradientFrom(e.target.value)}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
+                  <Input
+                    type="color"
+                    value={gradientTo}
+                    onChange={(e) => setGradientTo(e.target.value)}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm" w="40%">Direction</FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    w="60px"
+                    value={gradientDirection}
+                    onChange={(e) => setGradientDirection(parseInt(e.target.value))}
+                  />
+                </FormControl>
+              </>
+            )}
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">Wrapper</Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Shadow
+              </FormLabel>
+              <Select size="sm" value={shadow} onChange={(e) => setShadow(e.target.value)}>
+                <option value="none">None</option>
+                <option value="sm">Small</option>
+                <option value="md">Medium</option>
+                <option value="lg">Large</option>
+                <option value="xl">XL</option>
+                <option value="2xl">2XL</option>
+              </Select>
+            </FormControl>
+            <Box>
+              <Text fontSize="sm" mb={1}>
+                Padding
+              </Text>
+              <HStack spacing={2}>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">
+                    Horiz.
+                  </FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    w="60px"
+                    value={paddingX}
+                    onChange={(e) => setPaddingX(parseInt(e.target.value))}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">
+                    Vert.
+                  </FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    w="60px"
+                    value={paddingY}
+                    onChange={(e) => setPaddingY(parseInt(e.target.value))}
+                  />
+                </FormControl>
+              </HStack>
+            </Box>
+            <Box>
+              <Text fontSize="sm" mb={1}>
+                Margin
+              </Text>
+              <HStack spacing={2}>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">
+                    Horiz.
+                  </FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    w="60px"
+                    value={marginX}
+                    onChange={(e) => setMarginX(parseInt(e.target.value))}
+                  />
+                </FormControl>
+                <FormControl display="flex" alignItems="center">
+                  <FormLabel mb="0" fontSize="sm">
+                    Vert.
+                  </FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    w="60px"
+                    value={marginY}
+                    onChange={(e) => setMarginY(parseInt(e.target.value))}
+                  />
+                </FormControl>
+              </HStack>
+            </Box>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+
+      <AccordionItem borderWidth="1px" borderColor="green.300" borderRadius="md" mb={2}>
+        <h2>
+          <AccordionButton>
+            <Box flex="1" textAlign="left">Borders</Box>
+            <AccordionIcon />
+          </AccordionButton>
+        </h2>
+        <AccordionPanel pb={2}>
+          <Stack spacing={2}>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Color
+              </FormLabel>
+              <Input type="color" value={borderColor} onChange={(e) => setBorderColor(e.target.value)} />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Width
+              </FormLabel>
+              <Input
+                size="sm"
+                type="number"
+                w="60px"
+                value={borderWidth}
+                onChange={(e) => setBorderWidth(parseInt(e.target.value))}
+              />
+            </FormControl>
+            <FormControl display="flex" alignItems="center">
+              <FormLabel mb="0" fontSize="sm" w="40%">
+                Radius
+              </FormLabel>
+              <Select size="sm" value={borderRadius} onChange={(e) => setBorderRadius(e.target.value)}>
+                <option value="none">None</option>
+                <option value="sm">Small</option>
+                <option value="md">Medium</option>
+                <option value="lg">Large</option>
+                <option value="xl">Extra Large</option>
+                <option value="2xl">2x Large</option>
+                <option value="3xl">3x Large</option>
+                <option value="full">Fully Rounded</option>
+                <option value="50%">Circular</option>
+              </Select>
+            </FormControl>
+          </Stack>
+        </AccordionPanel>
+      </AccordionItem>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- split `ElementAttributesPane` into smaller components
- share animation and wrapper editors across elements
- add dedicated attribute components for text, image, video and quiz elements

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d805da708326aaeac7424ea4aa28