### PR TITLE
Refactor drag-drop logic into hooks

### DIFF
--- a/insight-fe/src/components/lesson/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/SlideElementsBoard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { Box, HStack, IconButton, Stack } from "@chakra-ui/react";
-import { useState, useRef, useEffect } from "react";
+import { Box, HStack, IconButton } from "@chakra-ui/react";
+import { useState, useRef } from "react";
 import { DnDBoardMain } from "@/components/DnD/DnDBoardMain";
 import {
   SlideElementDnDItemProps,
@@ -14,17 +14,9 @@ import ElementWrapper, { ElementWrapperStyles } from "./ElementWrapper";
 import { useCallback } from "react";
 import { X, Settings, Plus } from "lucide-react";
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
-import {
-  draggable,
-  dropTargetForElements,
-} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
-import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
-import {
-  attachClosestEdge,
-  extractClosestEdge,
-  type Edge,
-} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { type Edge } from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
 import { DropIndicator } from "@atlaskit/pragmatic-drag-and-drop-react-drop-indicator/box";
+import { useBoardDragDrop } from "@/hooks/useBoardDragDrop";
 
 interface SlideElementsBoardProps {
   boardId: string;
@@ -85,38 +77,13 @@ export default function SlideElementsBoard({
   const dragHandleRef = useRef<HTMLDivElement | null>(null);
   const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
 
-  useEffect(() => {
-    if (!boardRef.current || !dragHandleRef.current) return;
-    const el = boardRef.current;
-    return combine(
-      draggable({
-        element: el,
-        dragHandle: dragHandleRef.current,
-        getInitialData: () => ({
-          type: "board",
-          boardId,
-          instanceId: boardInstanceId,
-        }),
-      }),
-      dropTargetForElements({
-        element: el,
-        canDrop: ({ source }) =>
-          source.data.instanceId === boardInstanceId &&
-          source.data.type === "board",
-        getIsSticky: () => true,
-        getData: ({ input, element }) =>
-          attachClosestEdge(
-            { type: "board", boardId },
-            { input, element, allowedEdges: ["top", "bottom"] }
-          ),
-        onDragEnter: (args) =>
-          setClosestEdge(extractClosestEdge(args.self.data)),
-        onDrag: (args) => setClosestEdge(extractClosestEdge(args.self.data)),
-        onDragLeave: () => setClosestEdge(null),
-        onDrop: () => setClosestEdge(null),
-      })
-    );
-  }, [boardInstanceId, boardId]);
+  useBoardDragDrop(
+    boardRef,
+    dragHandleRef,
+    boardId,
+    boardInstanceId,
+    setClosestEdge
+  );
 
   const addColumn = () => {
     const idx = orderedColumnIds.length;

--- a/insight-fe/src/hooks/useBoardDragDrop.tsx
+++ b/insight-fe/src/hooks/useBoardDragDrop.tsx
@@ -1,0 +1,61 @@
+import { RefObject, Dispatch, SetStateAction, useEffect } from "react";
+import {
+  draggable,
+  dropTargetForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+  type Edge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+
+/**
+ * Registers a board DOM node as a draggable and drop target.
+ * Updates the provided closest edge state while dragging.
+ *
+ * @param boardRef - Ref pointing to the board element
+ * @param dragHandleRef - Ref for the drag handle element
+ * @param boardId - Identifier of the board
+ * @param boardInstanceId - Symbol representing the board DnD scope
+ * @param setClosestEdge - Setter to update the closest edge during drag
+ */
+export function useBoardDragDrop(
+  boardRef: RefObject<HTMLDivElement>,
+  dragHandleRef: RefObject<HTMLDivElement>,
+  boardId: string,
+  boardInstanceId: symbol,
+  setClosestEdge: Dispatch<SetStateAction<Edge | null>>
+) {
+  useEffect(() => {
+    if (!boardRef.current || !dragHandleRef.current) return;
+    const el = boardRef.current;
+    return combine(
+      draggable({
+        element: el,
+        dragHandle: dragHandleRef.current,
+        getInitialData: () => ({
+          type: "board",
+          boardId,
+          instanceId: boardInstanceId,
+        }),
+      }),
+      dropTargetForElements({
+        element: el,
+        canDrop: ({ source }) =>
+          source.data.instanceId === boardInstanceId &&
+          source.data.type === "board",
+        getIsSticky: () => true,
+        getData: ({ input, element }) =>
+          attachClosestEdge(
+            { type: "board", boardId },
+            { input, element, allowedEdges: ["top", "bottom"] }
+          ),
+        onDragEnter: (args) => setClosestEdge(extractClosestEdge(args.self.data)),
+        onDrag: (args) => setClosestEdge(extractClosestEdge(args.self.data)),
+        onDragLeave: () => setClosestEdge(null),
+        onDrop: () => setClosestEdge(null),
+      })
+    );
+  }, [boardRef, dragHandleRef, boardInstanceId, boardId, setClosestEdge]);
+}

--- a/insight-fe/src/hooks/useContainerDragDrop.tsx
+++ b/insight-fe/src/hooks/useContainerDragDrop.tsx
@@ -1,0 +1,167 @@
+import { RefObject, MutableRefObject, useEffect } from "react";
+import {
+  dropTargetForElements,
+  monitorForElements,
+} from "@atlaskit/pragmatic-drag-and-drop/element/adapter";
+import { autoScrollWindowForElements } from "@atlaskit/pragmatic-drag-and-drop-auto-scroll/element";
+import { combine } from "@atlaskit/pragmatic-drag-and-drop/combine";
+import { reorder } from "@atlaskit/pragmatic-drag-and-drop/reorder";
+import {
+  attachClosestEdge,
+  extractClosestEdge,
+  type Edge,
+} from "@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge";
+import { getReorderDestinationIndex } from "@atlaskit/pragmatic-drag-and-drop-hitbox/util/get-reorder-destination-index";
+import { ColumnMap } from "@/components/DnD/types";
+import type { BoardRow } from "@/components/lesson/SlideElementsContainer";
+
+/**
+ * Hooks up drag-and-drop behaviour for the board container.
+ * Handles drop target registration, auto scroll, board reordering and
+ * moving columns between boards.
+ *
+ * @param containerRef - Ref for the container element
+ * @param boards - Current board rows
+ * @param columnMap - Map of columns indexed by id
+ * @param onChange - Callback when boards or columns change
+ * @param boardInstanceId - Symbol used for board level DnD
+ * @param instanceId - Symbol used for column level DnD
+ */
+export function useContainerDragDrop(
+  containerRef: RefObject<HTMLDivElement>,
+  boards: BoardRow[],
+  columnMap: ColumnMap<any>,
+  onChange: (map: ColumnMap<any>, boards: BoardRow[]) => void,
+  boardInstanceId: MutableRefObject<symbol>,
+  instanceId: MutableRefObject<symbol>
+) {
+  useEffect(() => {
+    if (!containerRef.current) return;
+    return dropTargetForElements({
+      element: containerRef.current,
+      canDrop: ({ source }) =>
+        source.data.instanceId === boardInstanceId.current &&
+        source.data.type === "board",
+      getData: () => ({ columnId: "boards" }),
+      getIsSticky: () => true,
+    });
+  }, [containerRef, boardInstanceId]);
+
+  useEffect(() => {
+    return autoScrollWindowForElements({
+      canScroll: ({ source }) =>
+        source.data.instanceId === boardInstanceId.current &&
+        source.data.type === "board",
+    });
+  }, [boardInstanceId]);
+
+  useEffect(() => {
+    return monitorForElements({
+      canMonitor: ({ source }) =>
+        source.data.instanceId === boardInstanceId.current,
+      onDrop: ({ source, location }) => {
+        if (source.data.type !== "board") return;
+        if (!location.current.dropTargets.length) return;
+
+        const startIndex = boards.findIndex(
+          (b) => b.id === source.data.boardId
+        );
+        if (startIndex === -1) return;
+
+        if (location.current.dropTargets.length === 1) {
+          const destinationIndex = getReorderDestinationIndex({
+            startIndex,
+            indexOfTarget: boards.length - 1,
+            closestEdgeOfTarget: null,
+            axis: "vertical",
+          });
+          const reordered = reorder({
+            list: boards,
+            startIndex,
+            finishIndex: destinationIndex,
+          });
+          onChange(columnMap, reordered);
+          return;
+        }
+
+        if (location.current.dropTargets.length === 2) {
+          const [destinationRecord] = location.current.dropTargets;
+          const indexOfTarget = boards.findIndex(
+            (b) => b.id === destinationRecord.data.boardId
+          );
+          const closestEdgeOfTarget = extractClosestEdge(
+            destinationRecord.data
+          );
+          const destinationIndex = getReorderDestinationIndex({
+            startIndex,
+            indexOfTarget,
+            closestEdgeOfTarget,
+            axis: "vertical",
+          });
+          const reordered = reorder({
+            list: boards,
+            startIndex,
+            finishIndex: destinationIndex,
+          });
+          onChange(columnMap, reordered);
+        }
+      },
+    });
+  }, [boards, columnMap, onChange, boardInstanceId]);
+
+  useEffect(() => {
+    return monitorForElements({
+      canMonitor: ({ source }) => source.data.instanceId === instanceId.current,
+      onDrop: ({ source, location }) => {
+        if (source.data.type !== "column") return;
+        if (!location.current.dropTargets.length) return;
+
+        const columnId = source.data.columnId as string;
+
+        const startBoardIdx = boards.findIndex((b) =>
+          b.orderedColumnIds.includes(columnId)
+        );
+        if (startBoardIdx === -1) return;
+
+        const target = location.current.dropTargets[0];
+        const targetColumnId = target.data.columnId as string;
+        const destBoardIdx = boards.findIndex((b) =>
+          b.orderedColumnIds.includes(targetColumnId)
+        );
+        if (destBoardIdx === -1) return;
+
+        if (startBoardIdx === destBoardIdx) {
+          return;
+        }
+
+        const indexOfTarget = boards[destBoardIdx].orderedColumnIds.findIndex(
+          (id) => id === targetColumnId
+        );
+        const closestEdge: Edge | null = extractClosestEdge(target.data);
+        const insertIndex =
+          closestEdge === "right" ? indexOfTarget + 1 : indexOfTarget;
+
+        const updatedBoards = boards
+          .map((b, idx) => {
+            if (idx === startBoardIdx) {
+              return {
+                ...b,
+                orderedColumnIds: b.orderedColumnIds.filter(
+                  (id) => id !== columnId
+                ),
+              };
+            }
+            if (idx === destBoardIdx) {
+              const ids = Array.from(b.orderedColumnIds);
+              ids.splice(insertIndex, 0, columnId);
+              return { ...b, orderedColumnIds: ids };
+            }
+            return b;
+          })
+          .filter((b) => b.orderedColumnIds.length > 0);
+
+        onChange(columnMap, updatedBoards);
+      },
+    });
+  }, [boards, columnMap, onChange, instanceId]);
+}


### PR DESCRIPTION
## Summary
- add `useBoardDragDrop` and `useContainerDragDrop` hooks
- use the new hooks in `SlideElementsBoard` and `SlideElementsContainer`

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d86e509883268fb1dea8fdbbc623