### PR TITLE
Create lesson filter hook

### DIFF
--- a/insight-fe/src/components/lesson/LoadLessonModal.tsx
+++ b/insight-fe/src/components/lesson/LoadLessonModal.tsx
@@ -3,6 +3,7 @@
 import { BaseModal } from "../modals/BaseModal";
 import { Button, FormControl, FormLabel, HStack, Stack } from "@chakra-ui/react";
 import { useState } from "react";
+import { useLessonFilters } from "@/hooks/useLessonFilters";
 import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
 import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
 import TopicDropdown from "@/components/dropdowns/TopicDropdown";
@@ -21,9 +22,14 @@ export default function LoadLessonModal({
   onLoad,
   isLoading = false,
 }: LoadLessonModalProps) {
-  const [yearGroupId, setYearGroupId] = useState<string | null>(null);
-  const [subjectId, setSubjectId] = useState<string | null>(null);
-  const [topicId, setTopicId] = useState<string | null>(null);
+  const {
+    yearGroupId,
+    subjectId,
+    topicId,
+    setYearGroupId,
+    setSubjectId,
+    setTopicId,
+  } = useLessonFilters();
   const [lessonId, setLessonId] = useState<string | null>(null);
 
   return (
@@ -52,8 +58,6 @@ export default function LoadLessonModal({
             value={yearGroupId}
             onChange={(id) => {
               setYearGroupId(id);
-              setSubjectId(null);
-              setTopicId(null);
               setLessonId(null);
             }}
           />
@@ -65,7 +69,6 @@ export default function LoadLessonModal({
             value={subjectId}
             onChange={(id) => {
               setSubjectId(id);
-              setTopicId(null);
               setLessonId(null);
             }}
           />

--- a/insight-fe/src/components/lesson/SaveLessonModal.tsx
+++ b/insight-fe/src/components/lesson/SaveLessonModal.tsx
@@ -12,7 +12,7 @@ import {
   Stack,
   Textarea,
 } from "@chakra-ui/react";
-import { useState } from "react";
+import { useLessonFilters } from "@/hooks/useLessonFilters";
 import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
 import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
 import TopicDropdown from "@/components/dropdowns/TopicDropdown";
@@ -43,9 +43,14 @@ export default function SaveLessonModal({ isOpen, onClose, onSave, isSaving = fa
     mode: "onChange",
   });
 
-  const [yearGroupId, setYearGroupId] = useState<string | null>(null);
-  const [subjectId, setSubjectId] = useState<string | null>(null);
-  const [topicId, setTopicId] = useState<string | null>(null);
+  const {
+    yearGroupId,
+    subjectId,
+    topicId,
+    setYearGroupId,
+    setSubjectId,
+    setTopicId,
+  } = useLessonFilters();
 
   const onSubmit: SubmitHandler<FormValues> = async (values) => {
     await onSave({
@@ -57,8 +62,6 @@ export default function SaveLessonModal({ isOpen, onClose, onSave, isSaving = fa
     });
     reset();
     setYearGroupId(null);
-    setSubjectId(null);
-    setTopicId(null);
   };
 
   return (
@@ -86,11 +89,7 @@ export default function SaveLessonModal({ isOpen, onClose, onSave, isSaving = fa
           <FormLabel>Year Group</FormLabel>
           <YearGroupDropdown
             value={yearGroupId}
-            onChange={(id) => {
-              setYearGroupId(id);
-              setSubjectId(null);
-              setTopicId(null);
-            }}
+            onChange={(id) => setYearGroupId(id)}
           />
         </FormControl>
         <FormControl isRequired>
@@ -98,10 +97,7 @@ export default function SaveLessonModal({ isOpen, onClose, onSave, isSaving = fa
           <SubjectDropdown
             yearGroupId={yearGroupId}
             value={subjectId}
-            onChange={(id) => {
-              setSubjectId(id);
-              setTopicId(null);
-            }}
+            onChange={(id) => setSubjectId(id)}
           />
         </FormControl>
         <FormControl isRequired>

--- a/insight-fe/src/hooks/useLessonFilters.tsx
+++ b/insight-fe/src/hooks/useLessonFilters.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+export function useLessonFilters() {
+  const [yearGroupId, setYearGroupIdState] = useState<string | null>(null);
+  const [subjectId, setSubjectIdState] = useState<string | null>(null);
+  const [topicId, setTopicIdState] = useState<string | null>(null);
+
+  const setYearGroupId = useCallback((id: string | null) => {
+    setYearGroupIdState(id);
+    setSubjectIdState(null);
+    setTopicIdState(null);
+  }, []);
+
+  const setSubjectId = useCallback((id: string | null) => {
+    setSubjectIdState(id);
+    setTopicIdState(null);
+  }, []);
+
+  const setTopicId = useCallback((id: string | null) => {
+    setTopicIdState(id);
+  }, []);
+
+  return {
+    yearGroupId,
+    subjectId,
+    topicId,
+    setYearGroupId,
+    setSubjectId,
+    setTopicId,
+  };
+}


### PR DESCRIPTION
## Summary
- add a new `useLessonFilters` hook for shared lesson filter state
- simplify `SaveLessonModal` and `LoadLessonModal` to use the new hook

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429b93316c8326b07a688b266b0321