### PR TITLE
Add lesson queries

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -8,8 +8,7 @@ import { Slide } from "@/components/lesson/SlideSequencer";
 import SaveLessonModal from "@/components/lesson/SaveLessonModal";
 import LoadLessonModal from "@/components/lesson/LoadLessonModal";
 import { useMutation, useLazyQuery } from "@apollo/client";
-import { typedGql } from "@/zeus/typedDocumentNode";
-import { $ } from "@/zeus";
+import { CREATE_LESSON, GET_LESSON } from "@/graphql/lesson";
 import { LessonEditorHandle } from "@/components/lesson/hooks/useLessonEditorState";
 
 export const LessonBuilderPageClient = () => {
@@ -19,16 +18,6 @@ export const LessonBuilderPageClient = () => {
   const [previewSlides, setPreviewSlides] = useState<Slide[]>([]);
   const editorRef = useRef<LessonEditorHandle>(null);
 
-  const CREATE_LESSON = typedGql("mutation")({
-    createLesson: [{ data: $("data", "CreateLessonInput!") }, { id: true }],
-  } as const);
-
-  const GET_LESSON = typedGql("query")({
-    getLesson: [
-      { data: $("data", "IdInput!") },
-      { id: true, title: true, content: true },
-    ],
-  } as const);
 
   const [createLesson, { loading: saving }] = useMutation(CREATE_LESSON, {
     onCompleted: () => setIsSaveOpen(false),

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -35,3 +35,21 @@ export const GET_STYLES_WITH_CONFIG = gql`
     }
   }
 `;
+
+export const CREATE_LESSON = gql`
+  mutation CreateLesson($data: CreateLessonInput!) {
+    createLesson(data: $data) {
+      id
+    }
+  }
+`;
+
+export const GET_LESSON = gql`
+  query GetLesson($data: IdInput!) {
+    getLesson(data: $data) {
+      id
+      title
+      content
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- centralize `CREATE_LESSON` and `GET_LESSON` GraphQL queries
- use the shared queries in `LessonBuilderPageClient`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in `insight-fe` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68429b9ce71083269712818d5d1fd611