### PR TITLE
Fix palette update after style save

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -127,9 +127,9 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(_, ref
         closeLoad={() => setIsLoadStyleOpen(false)}
         styleCollections={styleCollections}
         selectedElement={editor.selectedElement}
-        onSave={({ name, collectionId }) => {
+        onSave={async ({ name, collectionId }) => {
           if (!editor.selectedElement) return;
-          createStyle({
+          await createStyle({
             variables: {
               data: {
                 name,
@@ -139,6 +139,18 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(_, ref
               },
             },
           });
+
+          if (
+            selectedCollectionId !== "" &&
+            collectionId === selectedCollectionId
+          ) {
+            fetchStyles({
+              variables: {
+                collectionId: String(selectedCollectionId),
+                element: editor.selectedElement.type,
+              },
+            });
+          }
         }}
         onAddCollection={(collection) =>
           setStyleCollections([...styleCollections, collection])


### PR DESCRIPTION
## Summary
- refresh style palette when saving a new style

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842b4962bd0832686e06fdaef17e3c9