### PR TITLE
Add StyleGroup support

### DIFF
--- a/insight-be/src/app.module.ts
+++ b/insight-be/src/app.module.ts
@@ -33,6 +33,7 @@ import { YearGroupModule } from './modules/timbuktu/administrative/year-group/ye
 import { TopicModule } from './modules/timbuktu/administrative/topic/topic.module';
 import { StyleCollectionModule } from './modules/timbuktu/administrative/style-collection/style-collection.module';
 import { StyleModule } from './modules/timbuktu/administrative/style/style.module';
+import { StyleGroupModule } from './modules/timbuktu/administrative/style-group/style-group.module';
 import { AssignmentSubmissionModule } from './modules/timbuktu/administrative/assignment-submission/assignment-submission.model';
 import { AssignmentModule } from './modules/timbuktu/administrative/assignment/assignment.module';
 import { AssignmentSubmissionEntity } from './modules/timbuktu/administrative/assignment-submission/assignment-submission.entity';
@@ -48,6 +49,7 @@ import { TopicEntity } from './modules/timbuktu/administrative/topic/topic.entit
 import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-tables/class-lesson/class-lesson.entity';
 import { StyleCollectionEntity } from './modules/timbuktu/administrative/style-collection/style-collection.entity';
 import { StyleEntity } from './modules/timbuktu/administrative/style/style.entity';
+import { StyleGroupEntity } from './modules/timbuktu/administrative/style-group/style-group.entity';
 
 @Module({
   imports: [
@@ -89,6 +91,7 @@ import { StyleEntity } from './modules/timbuktu/administrative/style/style.entit
         ClassLessonEntity,
         StyleCollectionEntity,
         StyleEntity,
+        StyleGroupEntity,
       ],
       synchronize: true,
     }),
@@ -110,6 +113,7 @@ import { StyleEntity } from './modules/timbuktu/administrative/style/style.entit
     TopicModule,
     StyleCollectionModule,
     StyleModule,
+    StyleGroupModule,
     ClassModule,
     LessonModule,
     QuizModule,

--- a/insight-be/src/modules/timbuktu/administrative/style-group/style-group.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-group/style-group.inputs.ts
@@ -1,0 +1,21 @@
+import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
+import { PageElementType } from '../style/style.entity';
+import { HasRelationsInput } from 'src/common/base.inputs';
+
+@InputType()
+export class CreateStyleGroupInput extends HasRelationsInput {
+  @Field()
+  name: string;
+
+  @Field(() => PageElementType)
+  element: PageElementType;
+
+  @Field(() => ID)
+  collectionId: number;
+}
+
+@InputType()
+export class UpdateStyleGroupInput extends PartialType(CreateStyleGroupInput) {
+  @Field(() => ID)
+  id: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/style-group/style-group.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-group/style-group.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { StyleGroupEntity } from './style-group.entity';
+import { StyleGroupResolver } from './style-group.resolver';
+import { StyleGroupService } from './style-group.service';
+import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([StyleGroupEntity, StyleCollectionEntity])],
+  providers: [StyleGroupService, StyleGroupResolver],
+  exports: [StyleGroupService],
+})
+export class StyleGroupModule {}

--- a/insight-be/src/modules/timbuktu/administrative/style-group/style-group.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-group/style-group.resolver.ts
@@ -1,0 +1,30 @@
+import { Resolver } from '@nestjs/graphql';
+import { createBaseResolver } from 'src/common/base.resolver';
+import { StyleGroupEntity } from './style-group.entity';
+import { CreateStyleGroupInput, UpdateStyleGroupInput } from './style-group.inputs';
+import { StyleGroupService } from './style-group.service';
+
+const BaseStyleGroupResolver = createBaseResolver<
+  StyleGroupEntity,
+  CreateStyleGroupInput,
+  UpdateStyleGroupInput
+>(StyleGroupEntity, CreateStyleGroupInput, UpdateStyleGroupInput, {
+  queryName: 'StyleGroup',
+  stableKeyPrefix: 'styleGroup',
+  enabledOperations: [
+    'findAll',
+    'findOne',
+    'findOneBy',
+    'create',
+    'update',
+    'remove',
+    'search',
+  ],
+});
+
+@Resolver(() => StyleGroupEntity)
+export class StyleGroupResolver extends BaseStyleGroupResolver {
+  constructor(private readonly groupService: StyleGroupService) {
+    super(groupService);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/style-group/style-group.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-group/style-group.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BaseService } from 'src/common/base.service';
+import { StyleGroupEntity } from './style-group.entity';
+import { CreateStyleGroupInput, UpdateStyleGroupInput } from './style-group.inputs';
+
+@Injectable()
+export class StyleGroupService extends BaseService<
+  StyleGroupEntity,
+  CreateStyleGroupInput,
+  UpdateStyleGroupInput
+> {
+  constructor(
+    @InjectRepository(StyleGroupEntity) groupRepository: Repository<StyleGroupEntity>,
+    @InjectDataSource() dataSource: DataSource,
+  ) {
+    super(groupRepository, dataSource);
+  }
+
+  async create(data: CreateStyleGroupInput): Promise<StyleGroupEntity> {
+    const { collectionId, relationIds = [], ...rest } = data;
+    const relations = [
+      ...relationIds,
+      { relation: 'collection', ids: [collectionId] },
+    ];
+    return super.create({ ...rest, relationIds: relations } as any);
+  }
+
+  async update(data: UpdateStyleGroupInput): Promise<StyleGroupEntity> {
+    const { collectionId, relationIds = [], ...rest } = data;
+    const relations = [
+      ...relationIds,
+      ...(collectionId ? [{ relation: 'collection', ids: [collectionId] }] : []),
+    ];
+    return super.update({ ...rest, relationIds: relations } as any);
+  }
+}


### PR DESCRIPTION
## Summary
- add input DTOs for style group
- implement StyleGroup service, resolver and module
- register StyleGroup module and entity in app module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842be542f08832699ad86fa181e33f6