### PR TITLE
Add optional group support to Style module

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/style/style.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.inputs.ts
@@ -16,10 +16,16 @@ export class CreateStyleInput extends HasRelationsInput {
 
   @Field(() => ID)
   collectionId: number;
+
+  @Field(() => ID, { nullable: true })
+  groupId?: number;
 }
 
 @InputType()
 export class UpdateStyleInput extends PartialType(CreateStyleInput) {
   @Field(() => ID)
   id: number;
+
+  @Field(() => ID, { nullable: true })
+  groupId?: number;
 }

--- a/insight-be/src/modules/timbuktu/administrative/style/style.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.module.ts
@@ -4,9 +4,12 @@ import { StyleEntity } from './style.entity';
 import { StyleResolver } from './style.resolver';
 import { StyleService } from './style.service';
 import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
+import { StyleGroupEntity } from '../style-group/style-group.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([StyleEntity, StyleCollectionEntity])],
+  imports: [
+    TypeOrmModule.forFeature([StyleEntity, StyleCollectionEntity, StyleGroupEntity]),
+  ],
   providers: [StyleService, StyleResolver],
   exports: [StyleService],
 })

--- a/insight-be/src/modules/timbuktu/administrative/style/style.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.service.ts
@@ -19,19 +19,21 @@ export class StyleService extends BaseService<
   }
 
   async create(data: CreateStyleInput): Promise<StyleEntity> {
-    const { collectionId, relationIds = [], ...rest } = data;
+    const { collectionId, groupId, relationIds = [], ...rest } = data;
     const relations = [
       ...relationIds,
       { relation: 'collection', ids: [collectionId] },
+      ...(groupId ? [{ relation: 'group', ids: [groupId] }] : []),
     ];
     return super.create({ ...rest, relationIds: relations } as any);
   }
 
   async update(data: UpdateStyleInput): Promise<StyleEntity> {
-    const { collectionId, relationIds = [], ...rest } = data;
+    const { collectionId, groupId, relationIds = [], ...rest } = data;
     const relations = [
       ...relationIds,
       ...(collectionId ? [{ relation: 'collection', ids: [collectionId] }] : []),
+      ...(groupId ? [{ relation: 'group', ids: [groupId] }] : []),
     ];
     return super.update({ ...rest, relationIds: relations } as any);
   }


### PR DESCRIPTION
## Summary
- allow `groupId` in `CreateStyleInput` and `UpdateStyleInput`
- attach group relation in `StyleService`
- include `StyleGroupEntity` in `StyleModule`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bf7bd2c48326ab2269db2534d580