### PR TITLE
Add style group selection to style modals

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -133,13 +133,14 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         closeLoad={() => setIsLoadStyleOpen(false)}
         styleCollections={styleCollections}
         selectedElement={editor.selectedElement}
-        onSave={async ({ name, collectionId }) => {
+        onSave={async ({ name, collectionId, groupId }) => {
           if (!editor.selectedElement) return;
           await createStyle({
             variables: {
               data: {
                 name,
                 collectionId,
+                groupId: groupId ?? undefined,
                 element: ELEMENT_TYPE_TO_ENUM[editor.selectedElement.type],
                 config: editor.selectedElement,
               },
@@ -154,6 +155,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
               variables: {
                 collectionId: String(selectedCollectionId),
                 element: editor.selectedElement.type,
+                groupId: groupId ?? null,
               },
             });
           }

--- a/insight-fe/src/components/lesson/StyleModals.tsx
+++ b/insight-fe/src/components/lesson/StyleModals.tsx
@@ -12,7 +12,7 @@ interface StyleModalsProps {
   closeLoad: () => void;
   styleCollections: { id: number; name: string }[];
   selectedElement: SlideElementDnDItemProps | null;
-  onSave: (data: { name: string; collectionId: number }) => void;
+  onSave: (data: { name: string; collectionId: number; groupId: number | null }) => void;
   onAddCollection: (collection: { id: number; name: string }) => void;
   onLoad: (styleId: number) => void;
 }
@@ -34,6 +34,7 @@ export default function StyleModals({
         isOpen={isSaveOpen}
         onClose={closeSave}
         collections={styleCollections}
+        elementType={selectedElement ? selectedElement.type : null}
         onSave={onSave}
         onAddCollection={onAddCollection}
       />

--- a/insight-fe/src/components/lesson/modals/AddStyleGroupModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddStyleGroupModal.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import { Button, HStack, Input } from "@chakra-ui/react";
+import { BaseModal } from "@/components/modals/BaseModal";
+
+interface AddStyleGroupModalProps {
+  isOpen: boolean;
+  onSave: (name: string) => void;
+  onClose: () => void;
+}
+
+export default function AddStyleGroupModal({
+  isOpen,
+  onSave,
+  onClose,
+}: AddStyleGroupModalProps) {
+  const [name, setName] = useState("");
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Add Style Group"
+      footer={
+        <HStack>
+          <Button
+            colorScheme="blue"
+            onClick={() => {
+              onSave(name);
+              setName("");
+            }}
+          >
+            Save
+          </Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </HStack>
+      }
+    >
+      <Input
+        placeholder="Group name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- support creating style groups
- fetch style groups when saving/loading a style
- select a style group before loading or saving
- wire up new props for lesson editor

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c2d751d88326a5994674b03dd9ab