### PR TITLE
Add style group state management to editor

### DIFF
--- a/insight-fe/src/components/lesson/StyleModals.tsx
+++ b/insight-fe/src/components/lesson/StyleModals.tsx
@@ -11,9 +11,11 @@ interface StyleModalsProps {
   closeSave: () => void;
   closeLoad: () => void;
   styleCollections: { id: number; name: string }[];
+  styleGroups: { id: number; name: string }[];
   selectedElement: SlideElementDnDItemProps | null;
   onSave: (data: { name: string; collectionId: number; groupId: number | null }) => void;
   onAddCollection: (collection: { id: number; name: string }) => void;
+  onAddGroup: (group: { id: number; name: string }) => void;
   onLoad: (styleId: number) => void;
 }
 
@@ -23,9 +25,11 @@ export default function StyleModals({
   closeSave,
   closeLoad,
   styleCollections,
+  styleGroups,
   selectedElement,
   onSave,
   onAddCollection,
+  onAddGroup,
   onLoad,
 }: StyleModalsProps) {
   return (
@@ -35,14 +39,17 @@ export default function StyleModals({
         onClose={closeSave}
         collections={styleCollections}
         elementType={selectedElement ? selectedElement.type : null}
+        groups={styleGroups}
         onSave={onSave}
         onAddCollection={onAddCollection}
+        onAddGroup={onAddGroup}
       />
       <LoadStyleModal
         isOpen={isLoadOpen}
         onClose={closeLoad}
         collections={styleCollections}
         elementType={selectedElement ? selectedElement.type : null}
+        groups={styleGroups}
         onLoad={onLoad}
       />
     </>

--- a/insight-fe/src/components/lesson/modals/LoadStyleModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LoadStyleModal.tsx
@@ -7,7 +7,6 @@ import {
   Stack,
 } from "@chakra-ui/react";
 import { gql, useQuery } from "@apollo/client";
-import { GET_STYLE_GROUPS } from "@/graphql/lesson";
 import { BaseModal } from "@/components/modals/BaseModal";
 
 const GET_STYLES = gql`
@@ -35,6 +34,8 @@ interface LoadStyleModalProps {
   collections: { id: number; name: string }[];
   /** Element type for filtering styles */
   elementType: string | null;
+  /** Groups for the selected collection/element */
+  groups: { id: number; name: string }[];
   /** Callback executed when user chooses a style */
   onLoad: (styleId: number) => void;
 }
@@ -44,13 +45,13 @@ export default function LoadStyleModal({
   onClose,
   collections,
   elementType,
+  groups,
   onLoad,
 }: LoadStyleModalProps) {
   const [collectionId, setCollectionId] = useState<number | "">("");
   const [groupId, setGroupId] = useState<number | "">("");
   const [styleId, setStyleId] = useState<number | "">("");
   const [styles, setStyles] = useState<{ id: number; name: string }[]>([]);
-  const [groups, setGroups] = useState<{ id: number; name: string }[]>([]);
 
   const { data: stylesData } = useQuery(GET_STYLES, {
     variables:
@@ -64,21 +65,6 @@ export default function LoadStyleModal({
     skip: collectionId === "" || !elementType,
   });
 
-  const { data: groupsData } = useQuery(GET_STYLE_GROUPS, {
-    variables:
-      collectionId !== "" && elementType
-        ? { collectionId: String(collectionId), element: elementType }
-        : undefined,
-    skip: collectionId === "" || !elementType,
-  });
-
-  const { data: groupsData, refetch: refetchGroups } = useQuery(GET_STYLE_GROUPS, {
-    variables:
-      collectionId !== "" && elementType
-        ? { collectionId: String(collectionId), element: elementType }
-        : undefined,
-    skip: collectionId === "" || !elementType,
-  });
 
   useEffect(() => {
     if (stylesData?.getAllStyle) {
@@ -88,13 +74,6 @@ export default function LoadStyleModal({
     }
   }, [stylesData]);
 
-  useEffect(() => {
-    if (groupsData?.getAllStyleGroup) {
-      setGroups(groupsData.getAllStyleGroup);
-    } else {
-      setGroups([]);
-    }
-  }, [groupsData]);
 
   useEffect(() => {
     setStyleId("");


### PR DESCRIPTION
## Summary
- fetch available style groups when changing collection or element
- provide style groups to `SaveStyleModal` and `LoadStyleModal`
- update modals to accept pre-fetched group lists
- add callbacks so newly created groups update the editor state

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c45eee908326b31cf50691b6767f