### PR TITLE
Fix enum circular import causing TypeORM error

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/style-group/style-group.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-group/style-group.entity.ts
@@ -1,7 +1,8 @@
 import { Column, Entity, ManyToOne, OneToMany, RelationId, JoinColumn } from 'typeorm';
 import { Field, ObjectType, ID } from '@nestjs/graphql';
 import { AbstractBaseEntity } from 'src/common/base.entity';
-import { PageElementType, StyleEntity } from '../style/style.entity';
+import { StyleEntity } from '../style/style.entity';
+import { PageElementType } from '../style/page-element-type';
 import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
 
 @ObjectType()

--- a/insight-be/src/modules/timbuktu/administrative/style-group/style-group.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-group/style-group.inputs.ts
@@ -1,5 +1,5 @@
 import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
-import { PageElementType } from '../style/style.entity';
+import { PageElementType } from '../style/page-element-type';
 import { HasRelationsInput } from 'src/common/base.inputs';
 
 @InputType()

--- a/insight-be/src/modules/timbuktu/administrative/style/page-element-type.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/page-element-type.ts
@@ -1,0 +1,11 @@
+import { registerEnumType } from '@nestjs/graphql';
+
+export enum PageElementType {
+  Text = 'text',
+  Table = 'table',
+  Image = 'image',
+  Video = 'video',
+  Quiz = 'quiz',
+}
+
+registerEnumType(PageElementType, { name: 'PageElementType' });

--- a/insight-be/src/modules/timbuktu/administrative/style/style.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.entity.ts
@@ -1,19 +1,10 @@
 import { Column, Entity, ManyToOne, RelationId, JoinColumn } from 'typeorm';
-import { Field, ObjectType, ID, registerEnumType } from '@nestjs/graphql';
+import { Field, ObjectType, ID } from '@nestjs/graphql';
 import { GraphQLJSONObject } from 'graphql-type-json';
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
 import { StyleGroupEntity } from '../style-group/style-group.entity';
-
-export enum PageElementType {
-  Text = 'text',
-  Table = 'table',
-  Image = 'image',
-  Video = 'video',
-  Quiz = 'quiz',
-}
-
-registerEnumType(PageElementType, { name: 'PageElementType' });
+import { PageElementType } from './page-element-type';
 
 @ObjectType()
 @Entity('styles')

--- a/insight-be/src/modules/timbuktu/administrative/style/style.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.inputs.ts
@@ -1,5 +1,5 @@
 import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
-import { PageElementType } from './style.entity';
+import { PageElementType } from './page-element-type';
 import { GraphQLJSONObject } from 'graphql-type-json';
 import { HasRelationsInput } from 'src/common/base.inputs';
 


### PR DESCRIPTION
## Summary
- extract `PageElementType` enum into its own file
- update style entities and inputs to use the new enum file

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find eslint dependencies)*
- `npx tsc -p tsconfig.build.json` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_6842c7184e60832686be41c027b96e14