### PR TITLE
Fix style group creation enum mapping

### DIFF
--- a/insight-fe/src/components/lesson/modals/SaveStyleModal.tsx
+++ b/insight-fe/src/components/lesson/modals/SaveStyleModal.tsx
@@ -13,6 +13,14 @@ import AddStyleCollectionModal from "./AddStyleCollectionModal";
 import AddStyleGroupModal from "./AddStyleGroupModal";
 import { CREATE_STYLE_GROUP } from "@/graphql/lesson";
 
+const ELEMENT_TYPE_TO_ENUM: Record<string, string> = {
+  text: "Text",
+  table: "Table",
+  image: "Image",
+  video: "Video",
+  quiz: "Quiz",
+};
+
 const CREATE_STYLE_COLLECTION = gql`
   mutation CreateStyleCollection($data: CreateStyleCollectionInput!) {
     createStyleCollection(data: $data) {
@@ -163,7 +171,7 @@ export default function SaveStyleModal({
               data: {
                 name,
                 collectionId,
-                element: elementType,
+                element: ELEMENT_TYPE_TO_ENUM[elementType],
               },
             },
           });


### PR DESCRIPTION
## Summary
- map selected element type to GraphQL enum before creating style group

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `insight-fe` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6842c9067a948326992ead3849d15298