### PR TITLE
Fix style group query handling

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -186,7 +186,6 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
               variables: {
                 collectionId: String(selectedCollectionId),
                 element: editor.selectedElement.type,
-                groupId: groupId ?? null,
               },
             });
           }

--- a/insight-fe/src/components/lesson/modals/LoadStyleModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LoadStyleModal.tsx
@@ -10,7 +10,7 @@ import { gql, useQuery } from "@apollo/client";
 import { BaseModal } from "@/components/modals/BaseModal";
 
 const GET_STYLES = gql`
-  query GetStyles($collectionId: String!, $element: String!, $groupId: String) {
+  query GetStyles($collectionId: String!, $element: String!, $groupId: String!) {
     getAllStyle(
       data: {
         all: true
@@ -55,14 +55,14 @@ export default function LoadStyleModal({
 
   const { data: stylesData } = useQuery(GET_STYLES, {
     variables:
-      collectionId !== "" && elementType
+      collectionId !== "" && elementType && groupId !== ""
         ? {
             collectionId: String(collectionId),
             element: elementType,
-            groupId: groupId === "" ? null : String(groupId),
+            groupId: String(groupId),
           }
         : undefined,
-    skip: collectionId === "" || !elementType,
+    skip: collectionId === "" || !elementType || groupId === "",
   });
 
 

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -45,18 +45,13 @@ export const CREATE_STYLE_GROUP = gql`
 `;
 
 export const GET_STYLES_WITH_CONFIG = gql`
-  query GetStylesWithConfig(
-    $collectionId: String!
-    $element: String!
-    $groupId: String
-  ) {
+  query GetStylesWithConfig($collectionId: String!, $element: String!) {
     getAllStyle(
       data: {
         all: true
         filters: [
           { column: "collectionId", value: $collectionId }
           { column: "element", value: $element }
-          { column: "groupId", value: $groupId }
         ]
       }
     ) {


### PR DESCRIPTION
## Summary
- adjust style queries to not require a `groupId`
- load styles for a group only when a group is chosen

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842cb2fa66c8326b07b7672c73ea5b6