### PR TITLE
Add bottom padding to droppable list

### DIFF
--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -69,7 +69,6 @@ const idleStyles = { cursor: "grab" };
 const cardOverStyles = { bg: "blue.50" };
 const isDraggingStyles = { opacity: 0.4 };
 
-
 const scrollContainerStyles = {
   height: "100%",
   overflowY: "auto",
@@ -82,7 +81,7 @@ const cardListStyles = {
   boxSizing: "border-box",
   minHeight: "100%",
   px: 1,
-  pb: 4,
+  pb: 6,
   overflowY: "auto",
 };
 


### PR DESCRIPTION
## Summary
- add padding bottom to `cardListStyles` to give more space for dropping items in DnD columns

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e0c0e64c8326a3432cfff17fada7