### PR TITLE
Animate column controls on hover

### DIFF
--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -377,6 +377,7 @@ function ColumnBase<TCard extends BaseCardDnD>({
                 transition="transform 0.2s"
                 _groupHover={{ transform: "translateY(0)" }}
                 _hover={{ transform: "translateY(0)" }}
+                _active={{ transform: "translateY(0)" }}
               >
                 {enableColumnReorder && (
                   <IconButton

--- a/insight-fe/src/components/lesson/slide/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementsBoard.tsx
@@ -193,6 +193,7 @@ export default function SlideElementsBoard({
           transition="transform 0.2s"
           _groupHover={{ transform: "translateY(0)" }}
           _hover={{ transform: "translateY(0)" }}
+          _active={{ transform: "translateY(0)" }}
         >
         {onRemoveBoard && (
           <IconButton


### PR DESCRIPTION
## Summary
- animate column icon controls to slide in on hover like container controls

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843026705008326a3090d0935457ce0