### PR TITLE
Add drag handle to container hover menu

### DIFF
--- a/insight-fe/src/components/lesson/slide/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementsBoard.tsx
@@ -195,7 +195,14 @@ export default function SlideElementsBoard({
           _hover={{ transform: "translateY(0)" }}
           _active={{ transform: "translateY(0)" }}
         >
-        {onRemoveBoard && (
+          <IconButton
+            aria-label="Drag container"
+            icon={<GripVertical size={12} />}
+            size="xs"
+            variant="ghost"
+            cursor="grab"
+          />
+          {onRemoveBoard && (
           <IconButton
             aria-label="Delete container"
             icon={<X size={12} />}


### PR DESCRIPTION
## Summary
- show drag handle icon in container hover menu of lesson editor

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run lint` in `insight-be` *(fails: cannot find `@eslint/js`)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430ad47384832695c529b8e912b50b