### PR TITLE
Add container drag handle

### DIFF
--- a/insight-fe/src/components/lesson/slide/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementsBoard.tsx
@@ -195,6 +195,13 @@ export default function SlideElementsBoard({
           _hover={{ transform: "translateY(0)" }}
           _active={{ transform: "translateY(0)" }}
         >
+          <IconButton
+            aria-label="Drag container"
+            icon={<GripVertical size={12} />}
+            size="xs"
+            variant="ghost"
+            cursor="grab"
+          />
           {onRemoveBoard && (
             <IconButton
               aria-label="Delete container"


### PR DESCRIPTION
## Summary
- allow dragging containers in the lesson builder

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68430d2d23bc83268ed7acee977955d8