### PR TITLE
Add ColorPalette module

### DIFF
--- a/insight-be/src/app.module.ts
+++ b/insight-be/src/app.module.ts
@@ -34,6 +34,7 @@ import { TopicModule } from './modules/timbuktu/administrative/topic/topic.modul
 import { StyleCollectionModule } from './modules/timbuktu/administrative/style-collection/style-collection.module';
 import { StyleModule } from './modules/timbuktu/administrative/style/style.module';
 import { StyleGroupModule } from './modules/timbuktu/administrative/style-group/style-group.module';
+import { ColorPaletteModule } from './modules/timbuktu/administrative/color-palette/color-palette.module';
 import { AssignmentSubmissionModule } from './modules/timbuktu/administrative/assignment-submission/assignment-submission.model';
 import { AssignmentModule } from './modules/timbuktu/administrative/assignment/assignment.module';
 import { AssignmentSubmissionEntity } from './modules/timbuktu/administrative/assignment-submission/assignment-submission.entity';
@@ -50,6 +51,7 @@ import { ClassLessonEntity } from './modules/timbuktu/administrative/pivot-table
 import { StyleCollectionEntity } from './modules/timbuktu/administrative/style-collection/style-collection.entity';
 import { StyleEntity } from './modules/timbuktu/administrative/style/style.entity';
 import { StyleGroupEntity } from './modules/timbuktu/administrative/style-group/style-group.entity';
+import { ColorPaletteEntity } from './modules/timbuktu/administrative/color-palette/color-palette.entity';
 
 @Module({
   imports: [
@@ -92,6 +94,7 @@ import { StyleGroupEntity } from './modules/timbuktu/administrative/style-group/
         StyleCollectionEntity,
         StyleEntity,
         StyleGroupEntity,
+        ColorPaletteEntity,
       ],
       synchronize: true,
     }),
@@ -114,6 +117,7 @@ import { StyleGroupEntity } from './modules/timbuktu/administrative/style-group/
     StyleCollectionModule,
     StyleModule,
     StyleGroupModule,
+    ColorPaletteModule,
     ClassModule,
     LessonModule,
     QuizModule,

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.entity.ts
@@ -1,0 +1,26 @@
+import { Column, Entity, ManyToOne, JoinColumn, RelationId } from 'typeorm';
+import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { AbstractBaseEntity } from 'src/common/base.entity';
+import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
+
+@ObjectType()
+@Entity('color_palettes')
+export class ColorPaletteEntity extends AbstractBaseEntity {
+  @Field()
+  @Column()
+  name: string;
+
+  @Field(() => [String])
+  @Column({ type: 'jsonb' })
+  colors: string[];
+
+  @Field(() => StyleCollectionEntity)
+  @ManyToOne(() => StyleCollectionEntity, (collection) => collection.colorPalettes, { nullable: false })
+  @JoinColumn({ name: 'collection_id' })
+  collection!: StyleCollectionEntity;
+
+  @Field(() => ID)
+  @Column({ name: 'collection_id' })
+  @RelationId((palette: ColorPaletteEntity) => palette.collection)
+  collectionId!: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
@@ -1,0 +1,20 @@
+import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
+import { HasRelationsInput } from 'src/common/base.inputs';
+
+@InputType()
+export class CreateColorPaletteInput extends HasRelationsInput {
+  @Field()
+  name: string;
+
+  @Field(() => [String])
+  colors: string[];
+
+  @Field(() => ID)
+  collectionId: number;
+}
+
+@InputType()
+export class UpdateColorPaletteInput extends PartialType(CreateColorPaletteInput) {
+  @Field(() => ID)
+  id: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ColorPaletteEntity } from './color-palette.entity';
+import { ColorPaletteResolver } from './color-palette.resolver';
+import { ColorPaletteService } from './color-palette.service';
+import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ColorPaletteEntity, StyleCollectionEntity])],
+  providers: [ColorPaletteService, ColorPaletteResolver],
+  exports: [ColorPaletteService],
+})
+export class ColorPaletteModule {}

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.resolver.ts
@@ -1,0 +1,30 @@
+import { Resolver } from '@nestjs/graphql';
+import { createBaseResolver } from 'src/common/base.resolver';
+import { ColorPaletteEntity } from './color-palette.entity';
+import { CreateColorPaletteInput, UpdateColorPaletteInput } from './color-palette.inputs';
+import { ColorPaletteService } from './color-palette.service';
+
+const BaseColorPaletteResolver = createBaseResolver<
+  ColorPaletteEntity,
+  CreateColorPaletteInput,
+  UpdateColorPaletteInput
+>(ColorPaletteEntity, CreateColorPaletteInput, UpdateColorPaletteInput, {
+  queryName: 'ColorPalette',
+  stableKeyPrefix: 'colorPalette',
+  enabledOperations: [
+    'findAll',
+    'findOne',
+    'findOneBy',
+    'create',
+    'update',
+    'remove',
+    'search',
+  ],
+});
+
+@Resolver(() => ColorPaletteEntity)
+export class ColorPaletteResolver extends BaseColorPaletteResolver {
+  constructor(private readonly paletteService: ColorPaletteService) {
+    super(paletteService);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.service.ts
@@ -1,0 +1,38 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BaseService } from 'src/common/base.service';
+import { ColorPaletteEntity } from './color-palette.entity';
+import { CreateColorPaletteInput, UpdateColorPaletteInput } from './color-palette.inputs';
+
+@Injectable()
+export class ColorPaletteService extends BaseService<
+  ColorPaletteEntity,
+  CreateColorPaletteInput,
+  UpdateColorPaletteInput
+> {
+  constructor(
+    @InjectRepository(ColorPaletteEntity) paletteRepository: Repository<ColorPaletteEntity>,
+    @InjectDataSource() dataSource: DataSource,
+  ) {
+    super(paletteRepository, dataSource);
+  }
+
+  async create(data: CreateColorPaletteInput): Promise<ColorPaletteEntity> {
+    const { collectionId, relationIds = [], ...rest } = data;
+    const relations = [
+      ...relationIds,
+      { relation: 'collection', ids: [collectionId] },
+    ];
+    return super.create({ ...rest, relationIds: relations } as any);
+  }
+
+  async update(data: UpdateColorPaletteInput): Promise<ColorPaletteEntity> {
+    const { collectionId, relationIds = [], ...rest } = data;
+    const relations = [
+      ...relationIds,
+      ...(collectionId ? [{ relation: 'collection', ids: [collectionId] }] : []),
+    ];
+    return super.update({ ...rest, relationIds: relations } as any);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
@@ -3,6 +3,7 @@ import { Field, ObjectType } from '@nestjs/graphql';
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { StyleEntity } from '../style/style.entity';
 import { StyleGroupEntity } from '../style-group/style-group.entity';
+import { ColorPaletteEntity } from '../color-palette/color-palette.entity';
 
 @ObjectType()
 @Entity('style_collections')
@@ -18,4 +19,8 @@ export class StyleCollectionEntity extends AbstractBaseEntity {
   @Field(() => [StyleGroupEntity], { nullable: true })
   @OneToMany(() => StyleGroupEntity, (group) => group.collection)
   styleGroups?: StyleGroupEntity[];
+
+  @Field(() => [ColorPaletteEntity], { nullable: true })
+  @OneToMany(() => ColorPaletteEntity, (palette) => palette.collection)
+  colorPalettes?: ColorPaletteEntity[];
 }


### PR DESCRIPTION
## Summary
- add ColorPalette entity, inputs, service, resolver & module
- link color palettes to style collections
- register ColorPalette in AppModule

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684327bc2df08326ac61662b319f6700