### PR TITLE
Implement color palette fetching in lesson editor

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -9,6 +9,7 @@ import {
   CREATE_STYLE,
   GET_STYLES_WITH_CONFIG_BY_GROUP,
   GET_STYLE_GROUPS,
+  GET_COLOR_PALETTES,
 } from "@/graphql/lesson";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
@@ -49,9 +50,15 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     id: number;
     name: string;
   }[]>([]);
+  const [colorPalettes, setColorPalettes] = useState<{
+    id: number;
+    name: string;
+    colors: string[];
+  }[]>([]);
   const [selectedCollectionId, setSelectedCollectionId] = useState<number | "">(
     ""
   );
+  const [selectedPaletteId, setSelectedPaletteId] = useState<number | "">("");
   const [isSaveStyleOpen, setIsSaveStyleOpen] = useState(false);
   const [isLoadStyleOpen, setIsLoadStyleOpen] = useState(false);
   const [styleItems, setStyleItems] = useState<SlideElementDnDItemProps[]>([]);
@@ -72,6 +79,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     { fetchPolicy: "network-only" }
   );
   const [fetchGroups, { data: groupsData }] = useLazyQuery(GET_STYLE_GROUPS);
+  const [fetchPalettes, { data: palettesData }] = useLazyQuery(GET_COLOR_PALETTES);
 
   const { data: collectionsData } = useQuery(GET_STYLE_COLLECTIONS);
   const [createStyle] = useMutation(CREATE_STYLE);
@@ -87,6 +95,16 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
       setStyleItems([]);
       setSelectedElementType(null);
       setSelectedGroupId("");
+      setColorPalettes([]);
+      setSelectedPaletteId("");
+    }
+  }, [selectedCollectionId]);
+
+  useEffect(() => {
+    if (selectedCollectionId !== "") {
+      fetchPalettes({
+        variables: { collectionId: String(selectedCollectionId) },
+      });
     }
   }, [selectedCollectionId]);
 
@@ -129,6 +147,14 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
       setStyleItems([]);
     }
   }, [selectedCollectionId, selectedElementType, selectedGroupId]);
+
+  useEffect(() => {
+    if (palettesData?.getAllColorPalette) {
+      setColorPalettes(palettesData.getAllColorPalette);
+    } else {
+      setColorPalettes([]);
+    }
+  }, [palettesData]);
 
   useEffect(() => {
     if (stylesData?.getAllStyle) {
@@ -179,6 +205,8 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         handleDropElement={editor.handleDropElement}
         openSaveStyle={() => setIsSaveStyleOpen(true)}
         openLoadStyle={() => setIsLoadStyleOpen(true)}
+        colorPalettes={colorPalettes}
+        selectedPaletteId={selectedPaletteId}
       />
 
       <StyleModals

--- a/insight-fe/src/components/lesson/attributes-pane/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/BoardAttributesPane.tsx
@@ -8,11 +8,15 @@ import { BoardRow } from "../slide/SlideElementsContainer";
 interface BoardAttributesPaneProps {
   board: BoardRow;
   onChange: (updated: BoardRow) => void;
+  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  selectedPaletteId?: number | "";
 }
 
 export default function BoardAttributesPane({
   board,
   onChange,
+  colorPalettes,
+  selectedPaletteId,
 }: BoardAttributesPaneProps) {
   const styleAttrs = useStyleAttributes({
     wrapperStyles: board.wrapperStyles,
@@ -25,7 +29,11 @@ export default function BoardAttributesPane({
 
   return (
     <Accordion allowMultiple>
-      <WrapperSettings attrs={styleAttrs} />
+      <WrapperSettings
+        attrs={styleAttrs}
+        colorPalettes={colorPalettes}
+        selectedPaletteId={selectedPaletteId}
+      />
     </Accordion>
   );
 }

--- a/insight-fe/src/components/lesson/attributes-pane/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ColumnAttributesPane.tsx
@@ -10,11 +10,15 @@ import useStyleAttributes from "../hooks/useStyleAttributes";
 interface ColumnAttributesPaneProps {
   column: ColumnType<SlideElementDnDItemProps>;
   onChange: (updated: ColumnType<SlideElementDnDItemProps>) => void;
+  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  selectedPaletteId?: number | "";
 }
 
 export default function ColumnAttributesPane({
   column,
   onChange,
+  colorPalettes,
+  selectedPaletteId,
 }: ColumnAttributesPaneProps) {
   const styleAttrs = useStyleAttributes({
     wrapperStyles: column.wrapperStyles,
@@ -26,7 +30,11 @@ export default function ColumnAttributesPane({
 
   return (
     <Accordion allowMultiple>
-      <WrapperSettings attrs={styleAttrs} />
+      <WrapperSettings
+        attrs={styleAttrs}
+        colorPalettes={colorPalettes}
+        selectedPaletteId={selectedPaletteId}
+      />
     </Accordion>
   );
 }

--- a/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
@@ -18,6 +18,8 @@ interface ElementAttributesPaneProps {
   onChange: (updated: SlideElementDnDItemProps) => void;
   onClone?: () => void;
   onDelete?: () => void;
+  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  selectedPaletteId?: number | "";
 }
 
 export default function ElementAttributesPane({
@@ -25,6 +27,8 @@ export default function ElementAttributesPane({
   onChange,
   onClone,
   onDelete,
+  colorPalettes,
+  selectedPaletteId,
 }: ElementAttributesPaneProps) {
   const [color, setColor] = useState(element.styles?.color || "#000000");
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
@@ -197,7 +201,11 @@ export default function ElementAttributesPane({
   return (
     <>
       <Accordion allowMultiple>
-        <WrapperSettings attrs={styleAttrs} />
+        <WrapperSettings
+          attrs={styleAttrs}
+          colorPalettes={colorPalettes}
+          selectedPaletteId={selectedPaletteId}
+        />
         <AnimationSettings
           enabled={animationEnabled}
           setEnabled={setAnimationEnabled}
@@ -222,6 +230,8 @@ export default function ElementAttributesPane({
             setLineHeight={setLineHeight}
             textAlign={textAlign}
             setTextAlign={setTextAlign}
+            colorPalettes={colorPalettes}
+            selectedPaletteId={selectedPaletteId}
           />
         )}
         {element.type === "image" && (

--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -29,6 +29,8 @@ interface TextAttributesProps {
   setLineHeight: (val: string) => void;
   textAlign: string;
   setTextAlign: (val: string) => void;
+  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  selectedPaletteId?: number | "";
 }
 
 export default function TextAttributes({
@@ -46,6 +48,8 @@ export default function TextAttributes({
   setLineHeight,
   textAlign,
   setTextAlign,
+  colorPalettes,
+  selectedPaletteId,
 }: TextAttributesProps) {
   return (
     <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>

--- a/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
@@ -18,9 +18,15 @@ import type useStyleAttributes from "../hooks/useStyleAttributes";
 
 interface WrapperSettingsProps {
   attrs: ReturnType<typeof useStyleAttributes>;
+  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  selectedPaletteId?: number | "";
 }
 
-export default function WrapperSettings({ attrs }: WrapperSettingsProps) {
+export default function WrapperSettings({
+  attrs,
+  colorPalettes,
+  selectedPaletteId,
+}: WrapperSettingsProps) {
   const {
     bgColor,
     setBgColor,

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -32,6 +32,8 @@ interface SlideCanvasProps {
   handleDropElement: (e: React.DragEvent<HTMLDivElement>) => void;
   openSaveStyle: () => void;
   openLoadStyle: () => void;
+  colorPalettes: { id: number; name: string; colors: string[] }[];
+  selectedPaletteId: number | "";
 }
 
 export default function SlideCanvas({
@@ -56,6 +58,8 @@ export default function SlideCanvas({
   handleDropElement,
   openSaveStyle,
   openLoadStyle,
+  colorPalettes,
+  selectedPaletteId,
 }: SlideCanvasProps) {
   return (
     <Flex gap={6} alignItems="flex-start">
@@ -116,18 +120,24 @@ export default function SlideCanvas({
                 onChange={updateElement}
                 onClone={cloneElement}
                 onDelete={deleteElement}
+                colorPalettes={colorPalettes}
+                selectedPaletteId={selectedPaletteId}
               />
             )}
             {selectedColumn && (
               <ColumnAttributesPane
                 column={selectedColumn}
                 onChange={updateColumn}
+                colorPalettes={colorPalettes}
+                selectedPaletteId={selectedPaletteId}
               />
             )}
             {selectedBoard && (
               <BoardAttributesPane
                 board={selectedBoard}
                 onChange={updateBoard}
+                colorPalettes={colorPalettes}
+                selectedPaletteId={selectedPaletteId}
               />
             )}
           </Box>


### PR DESCRIPTION
## Summary
- track color palettes and selected palette in LessonEditor state
- fetch palettes when a collection is selected
- forward palette information through SlideCanvas to attribute panes

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432ce481048326a6b72ac4416a8f3a