### PR TITLE
Add PaletteColorPicker to attributes

### DIFF
--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -13,6 +13,7 @@ import {
   Stack,
 } from "@chakra-ui/react";
 import { availableFonts } from "@/theme/fonts";
+import PaletteColorPicker from "../PaletteColorPicker";
 
 interface TextAttributesProps {
   text: string;
@@ -51,6 +52,8 @@ export default function TextAttributes({
   colorPalettes,
   selectedPaletteId,
 }: TextAttributesProps) {
+  const paletteColors = colorPalettes?.find((p) => p.id === selectedPaletteId)?.colors ?? [];
+
   return (
     <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>
       <h2>
@@ -71,7 +74,11 @@ export default function TextAttributes({
             <FormLabel mb="0" fontSize="sm" w="40%">
               Color
             </FormLabel>
-            <Input type="color" value={color} onChange={(e) => setColor(e.target.value)} />
+            <PaletteColorPicker
+              value={color}
+              onChange={setColor}
+              paletteColors={paletteColors}
+            />
           </FormControl>
           <FormControl display="flex" alignItems="center">
             <FormLabel mb="0" fontSize="sm" w="40%">

--- a/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
@@ -15,6 +15,7 @@ import {
   HStack,
 } from "@chakra-ui/react";
 import type useStyleAttributes from "../hooks/useStyleAttributes";
+import PaletteColorPicker from "../PaletteColorPicker";
 
 interface WrapperSettingsProps {
   attrs: ReturnType<typeof useStyleAttributes>;
@@ -60,6 +61,8 @@ export default function WrapperSettings({
     setSpacing,
   } = attrs;
 
+  const paletteColors = colorPalettes?.find((p) => p.id === selectedPaletteId)?.colors ?? [];
+
   return (
     <>
       <AccordionItem borderWidth="1px" borderColor="blue.300" borderRadius="md" mb={2}>
@@ -95,13 +98,13 @@ export default function WrapperSettings({
             {backgroundType === "color" && (
               <FormControl display="flex" alignItems="center">
                 <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
-                <Input
-                  type="color"
+                <PaletteColorPicker
                   value={bgColor}
-                  onChange={(e) => {
-                    setBgColor(e.target.value);
+                  onChange={(val) => {
+                    setBgColor(val);
                     setBgOpacity(1);
                   }}
+                  paletteColors={paletteColors}
                 />
               </FormControl>
             )}
@@ -109,18 +112,18 @@ export default function WrapperSettings({
               <>
                 <FormControl display="flex" alignItems="center">
                   <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
-                  <Input
-                    type="color"
+                  <PaletteColorPicker
                     value={gradientFrom}
-                    onChange={(e) => setGradientFrom(e.target.value)}
+                    onChange={setGradientFrom}
+                    paletteColors={paletteColors}
                   />
                 </FormControl>
                 <FormControl display="flex" alignItems="center">
                   <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
-                  <Input
-                    type="color"
+                  <PaletteColorPicker
                     value={gradientTo}
-                    onChange={(e) => setGradientTo(e.target.value)}
+                    onChange={setGradientTo}
+                    paletteColors={paletteColors}
                   />
                 </FormControl>
                 <FormControl display="flex" alignItems="center">
@@ -254,7 +257,11 @@ export default function WrapperSettings({
               <FormLabel mb="0" fontSize="sm" w="40%">
                 Color
               </FormLabel>
-              <Input type="color" value={borderColor} onChange={(e) => setBorderColor(e.target.value)} />
+              <PaletteColorPicker
+                value={borderColor}
+                onChange={setBorderColor}
+                paletteColors={paletteColors}
+              />
             </FormControl>
             <FormControl display="flex" alignItems="center">
               <FormLabel mb="0" fontSize="sm" w="40%">


### PR DESCRIPTION
## Summary
- use `PaletteColorPicker` in `TextAttributes`
- switch background, gradient and border color pickers to `PaletteColorPicker` in `WrapperSettings`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run lint` in insight-fe *(fails: `next` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843304c97a48326a6bfd6b8abdb6a85