### PR TITLE
Implement color palette creation modal

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -61,6 +61,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
   const [selectedPaletteId, setSelectedPaletteId] = useState<number | "">("");
   const [isSaveStyleOpen, setIsSaveStyleOpen] = useState(false);
   const [isLoadStyleOpen, setIsLoadStyleOpen] = useState(false);
+  const [isPaletteOpen, setIsPaletteOpen] = useState(false);
   const [styleItems, setStyleItems] = useState<SlideElementDnDItemProps[]>([]);
   const [selectedElementType, setSelectedElementType] = useState<string | null>(
     null
@@ -205,6 +206,11 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         handleDropElement={editor.handleDropElement}
         openSaveStyle={() => setIsSaveStyleOpen(true)}
         openLoadStyle={() => setIsLoadStyleOpen(true)}
+        openAddPalette={() => {
+          if (selectedCollectionId !== "") {
+            setIsPaletteOpen(true);
+          }
+        }}
         colorPalettes={colorPalettes}
         selectedPaletteId={selectedPaletteId}
       />
@@ -212,10 +218,13 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
       <StyleModals
         isSaveOpen={isSaveStyleOpen}
         isLoadOpen={isLoadStyleOpen}
+        isPaletteOpen={isPaletteOpen}
         closeSave={() => setIsSaveStyleOpen(false)}
         closeLoad={() => setIsLoadStyleOpen(false)}
+        closePalette={() => setIsPaletteOpen(false)}
         styleCollections={styleCollections}
         styleGroups={styleGroups}
+        selectedCollectionId={selectedCollectionId}
         selectedElement={editor.selectedElement}
         onSave={async ({ name, collectionId, groupId }) => {
           if (!editor.selectedElement) return;
@@ -251,6 +260,12 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
           setStyleCollections([...styleCollections, collection])
         }
         onAddGroup={(group) => setStyleGroups([...styleGroups, group])}
+        onAddPalette={(palette) => {
+          setColorPalettes((p) => [...p, palette]);
+          fetchPalettes({
+            variables: { collectionId: String(selectedCollectionId) },
+          });
+        }}
         onLoad={(styleId) => {
           if (!editor.selectedElement) return;
           console.log("load style", { styleId });

--- a/insight-fe/src/components/lesson/StyleModals.tsx
+++ b/insight-fe/src/components/lesson/StyleModals.tsx
@@ -2,34 +2,43 @@
 
 import LoadStyleModal from "./modals/LoadStyleModal";
 import SaveStyleModal from "./modals/SaveStyleModal";
+import AddColorPaletteModal from "./modals/AddColorPaletteModal";
 
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface StyleModalsProps {
   isSaveOpen: boolean;
   isLoadOpen: boolean;
+  isPaletteOpen: boolean;
   closeSave: () => void;
   closeLoad: () => void;
+  closePalette: () => void;
   styleCollections: { id: number; name: string }[];
   styleGroups: { id: number; name: string }[];
+  selectedCollectionId: number | "";
   selectedElement: SlideElementDnDItemProps | null;
   onSave: (data: { name: string; collectionId: number; groupId: number | null }) => void;
   onAddCollection: (collection: { id: number; name: string }) => void;
   onAddGroup: (group: { id: number; name: string }) => void;
+  onAddPalette: (palette: { id: number; name: string; colors: string[] }) => void;
   onLoad: (styleId: number) => void;
 }
 
 export default function StyleModals({
   isSaveOpen,
   isLoadOpen,
+  isPaletteOpen,
   closeSave,
   closeLoad,
+  closePalette,
   styleCollections,
   styleGroups,
+  selectedCollectionId,
   selectedElement,
   onSave,
   onAddCollection,
   onAddGroup,
+  onAddPalette,
   onLoad,
 }: StyleModalsProps) {
   return (
@@ -52,6 +61,14 @@ export default function StyleModals({
         groups={styleGroups}
         onLoad={onLoad}
       />
+      {selectedCollectionId !== "" && (
+        <AddColorPaletteModal
+          isOpen={isPaletteOpen}
+          onClose={closePalette}
+          collectionId={selectedCollectionId as number}
+          onSave={onAddPalette}
+        />
+      )}
     </>
   );
 }

--- a/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Button,
+  HStack,
+  Input,
+  VStack,
+  IconButton,
+} from "@chakra-ui/react";
+import { Plus, Trash2 } from "lucide-react";
+import { BaseModal } from "@/components/modals/BaseModal";
+import { gql, useMutation } from "@apollo/client";
+import { CREATE_COLOR_PALETTE } from "@/graphql/lesson";
+
+interface AddColorPaletteModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  collectionId: number;
+  onSave?: (palette: { id: number; name: string; colors: string[] }) => void;
+}
+
+export default function AddColorPaletteModal({
+  isOpen,
+  onClose,
+  collectionId,
+  onSave,
+}: AddColorPaletteModalProps) {
+  const [name, setName] = useState("");
+  const [colors, setColors] = useState<string[]>(["#000000"]);
+
+  const [createPalette] = useMutation(CREATE_COLOR_PALETTE);
+
+  const handleColorChange = (idx: number, value: string) => {
+    setColors((cols) => cols.map((c, i) => (i === idx ? value : c)));
+  };
+
+  const addColor = () => setColors((cols) => [...cols, "#000000"]);
+
+  const removeColor = (idx: number) =>
+    setColors((cols) => cols.filter((_, i) => i !== idx));
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title="Add Color Palette"
+      footer={
+        <HStack>
+          <Button
+            colorScheme="blue"
+            onClick={async () => {
+              const { data } = await createPalette({
+                variables: {
+                  data: { name, colors, collectionId },
+                },
+              });
+              if (data?.createColorPalette) {
+                onSave?.(data.createColorPalette);
+                setName("");
+                setColors(["#000000"]);
+              }
+              onClose();
+            }}
+          >
+            Save
+          </Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </HStack>
+      }
+    >
+      <VStack align="stretch" spacing={2}>
+        <Input
+          placeholder="Palette name"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        {colors.map((color, idx) => (
+          <HStack key={idx}>
+            <Input
+              type="color"
+              value={color}
+              onChange={(e) => handleColorChange(idx, e.target.value)}
+              w="40px"
+              h="40px"
+              p={0}
+            />
+            <IconButton
+              aria-label="Remove color"
+              size="sm"
+              icon={<Trash2 size={16} />}
+              onClick={() => removeColor(idx)}
+            />
+          </HStack>
+        ))}
+        <Button leftIcon={<Plus size={16} />} size="sm" onClick={addColor}>
+          Add Color
+        </Button>
+      </VStack>
+    </BaseModal>
+  );
+}
+

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -32,6 +32,7 @@ interface SlideCanvasProps {
   handleDropElement: (e: React.DragEvent<HTMLDivElement>) => void;
   openSaveStyle: () => void;
   openLoadStyle: () => void;
+  openAddPalette: () => void;
   colorPalettes: { id: number; name: string; colors: string[] }[];
   selectedPaletteId: number | "";
 }
@@ -58,6 +59,7 @@ export default function SlideCanvas({
   handleDropElement,
   openSaveStyle,
   openLoadStyle,
+  openAddPalette,
   colorPalettes,
   selectedPaletteId,
 }: SlideCanvasProps) {
@@ -111,6 +113,9 @@ export default function SlideCanvas({
                 </Button>
                 <Button size="xs" onClick={openSaveStyle}>
                   Save Style
+                </Button>
+                <Button size="xs" onClick={openAddPalette}>
+                  Add Palette
                 </Button>
               </HStack>
             </HStack>


### PR DESCRIPTION
## Summary
- create `AddColorPaletteModal` for making new palettes
- show palette modal from `StyleModals`
- enable palette creation from the lesson editor
- add button on slide canvas to open palette modal

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843317fcfc483268f45e43e6cfdfc56