### PR TITLE
Fix compile error due to unexported interface

### DIFF
--- a/insight-be/src/common/base.service.ts
+++ b/insight-be/src/common/base.service.ts
@@ -22,7 +22,7 @@ import { RelationIdsInput } from './base.inputs';
 //   ids: number[];
 // }
 
-interface FindAllOpts {
+export interface FindAllOpts {
   limit?: number;
   offset?: number;
   all?: boolean;


### PR DESCRIPTION
## Summary
- export `FindAllOpts` interface in `base.service.ts`

## Testing
- `npm run lint` *(fails: Cannot find package `@eslint/js`)*
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845a6764758832691f6a6d201babd90