### PR TITLE
Fix Add Color Palette button

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -211,6 +211,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
             setIsPaletteOpen(true);
           }
         }}
+        isAddPaletteDisabled={selectedCollectionId === ""}
         colorPalettes={colorPalettes}
         selectedPaletteId={selectedPaletteId}
       />

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -33,6 +33,7 @@ interface SlideCanvasProps {
   openSaveStyle: () => void;
   openLoadStyle: () => void;
   openAddPalette: () => void;
+  isAddPaletteDisabled?: boolean;
   colorPalettes: { id: number; name: string; colors: string[] }[];
   selectedPaletteId: number | "";
 }
@@ -60,6 +61,7 @@ export default function SlideCanvas({
   openSaveStyle,
   openLoadStyle,
   openAddPalette,
+  isAddPaletteDisabled,
   colorPalettes,
   selectedPaletteId,
 }: SlideCanvasProps) {
@@ -114,7 +116,11 @@ export default function SlideCanvas({
                 <Button size="xs" onClick={openSaveStyle}>
                   Save Style
                 </Button>
-                <Button size="xs" onClick={openAddPalette}>
+                <Button
+                  size="xs"
+                  onClick={openAddPalette}
+                  isDisabled={isAddPaletteDisabled}
+                >
                   Add Palette
                 </Button>
               </HStack>


### PR DESCRIPTION
## Summary
- disable Add Palette button when no collection selected

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845a95344f883268e3e14dded7f9d5f