### PR TITLE
Fix style modal imports

### DIFF
--- a/insight-fe/src/components/lesson/modals/AddStyleCollectionModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddStyleCollectionModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import { Button, HStack, Input } from "@chakra-ui/react";
 import { BaseModal } from "@/components/modals/BaseModal";

--- a/insight-fe/src/components/lesson/modals/AddStyleGroupModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddStyleGroupModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from "react";
 import { Button, HStack, Input } from "@chakra-ui/react";
 import { BaseModal } from "@/components/modals/BaseModal";

--- a/insight-fe/src/components/lesson/modals/SaveStyleModal.tsx
+++ b/insight-fe/src/components/lesson/modals/SaveStyleModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState, useEffect } from "react";
 import {
   Button,


### PR DESCRIPTION
## Summary
- mark style modal files as client components so they can run in the browser

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845af744c608326a71d85e474cde837