### PR TITLE
Skip RBAC checks for disabled resolver methods

### DIFF
--- a/insight-be/src/common/decorators/disabled-operation.decorator.ts
+++ b/insight-be/src/common/decorators/disabled-operation.decorator.ts
@@ -1,0 +1,8 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const IS_DISABLED_OPERATION_KEY = 'IS_DISABLED_OPERATION';
+
+export function DisabledOperation() {
+  return SetMetadata(IS_DISABLED_OPERATION_KEY, true);
+}
+

--- a/insight-be/src/common/decorators/mutation-if.decorator.ts
+++ b/insight-be/src/common/decorators/mutation-if.decorator.ts
@@ -1,5 +1,7 @@
 // src/common/decorators/mutation-if.decorator.ts
 import { Mutation } from '@nestjs/graphql';
+import { SetMetadata } from '@nestjs/common';
+import { IS_DISABLED_OPERATION_KEY } from './disabled-operation.decorator';
 
 /**
  * Usage:
@@ -20,5 +22,11 @@ export function MutationIf(
     target: any,
     propertyKey: string | symbol,
     descriptor: PropertyDescriptor,
-  ) => {};
+  ) => {
+    SetMetadata(IS_DISABLED_OPERATION_KEY, true)(
+      target,
+      propertyKey,
+      descriptor,
+    );
+  };
 }

--- a/insight-be/src/common/decorators/query-if.decorator.ts
+++ b/insight-be/src/common/decorators/query-if.decorator.ts
@@ -1,5 +1,7 @@
 // src/common/decorators/query-if.decorator.ts
 import { Query } from '@nestjs/graphql';
+import { SetMetadata } from '@nestjs/common';
+import { IS_DISABLED_OPERATION_KEY } from './disabled-operation.decorator';
 
 /**
  * Usage:
@@ -21,5 +23,11 @@ export function QueryIf(
     target: any,
     propertyKey: string | symbol,
     descriptor: PropertyDescriptor,
-  ) => {};
+  ) => {
+    SetMetadata(IS_DISABLED_OPERATION_KEY, true)(
+      target,
+      propertyKey,
+      descriptor,
+    );
+  };
 }

--- a/insight-be/src/modules/rbac/rbac-bootstrap.service.ts
+++ b/insight-be/src/modules/rbac/rbac-bootstrap.service.ts
@@ -6,6 +6,7 @@ import { ApiPermissionMappingService } from './sub/api-permissions-mapping/api-p
 import { PermissionService } from './sub/permission/permission.service';
 import { PERMISSION_KEY_METADATA } from './decorators/resolver-permission-key.decorator';
 import { IS_PUBLIC_ROUTE_KEY } from 'src/decorators/public.decorator';
+import { IS_DISABLED_OPERATION_KEY } from 'src/common/decorators/disabled-operation.decorator';
 
 @Injectable()
 export class RbacBootstrapService implements OnModuleInit {
@@ -49,7 +50,12 @@ export class RbacBootstrapService implements OnModuleInit {
             [methodRef, currentProto.constructor],
           );
 
-          if (isPublic) continue;
+          const isDisabled = this.reflector.getAllAndOverride<boolean>(
+            IS_DISABLED_OPERATION_KEY,
+            [methodRef, currentProto.constructor],
+          );
+
+          if (isPublic || isDisabled) continue;
 
           const stableKey: string | undefined = Reflect.getMetadata(
             PERMISSION_KEY_METADATA,


### PR DESCRIPTION
## Summary
- create a marker for disabled GraphQL operations
- add the marker in `QueryIf` and `MutationIf`
- ignore disabled methods in `RbacBootstrapService`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845d3130ac4832688d6546ef58f2c88