### PR TITLE
Add palette selection to lesson editor

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -214,6 +214,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         isAddPaletteDisabled={selectedCollectionId === ""}
         colorPalettes={colorPalettes}
         selectedPaletteId={selectedPaletteId}
+        onSelectPalette={setSelectedPaletteId}
       />
 
       <StyleModals

--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -52,7 +52,10 @@ export default function TextAttributes({
   colorPalettes,
   selectedPaletteId,
 }: TextAttributesProps) {
-  const paletteColors = colorPalettes?.find((p) => p.id === selectedPaletteId)?.colors ?? [];
+  const paletteColors =
+    colorPalettes?.find(
+      (p) => Number(p.id) === Number(selectedPaletteId)
+    )?.colors ?? [];
 
   return (
     <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>

--- a/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
@@ -61,7 +61,10 @@ export default function WrapperSettings({
     setSpacing,
   } = attrs;
 
-  const paletteColors = colorPalettes?.find((p) => p.id === selectedPaletteId)?.colors ?? [];
+  const paletteColors =
+    colorPalettes?.find(
+      (p) => Number(p.id) === Number(selectedPaletteId)
+    )?.colors ?? [];
 
   return (
     <>

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Flex, Grid, Box, Text, HStack, Button } from "@chakra-ui/react";
+import { Flex, Grid, Box, Text, HStack, Button, Select } from "@chakra-ui/react";
 
 import BoardAttributesPane from "../attributes-pane/BoardAttributesPane";
 import { ColumnType } from "@/components/DnD/types";
@@ -36,6 +36,7 @@ interface SlideCanvasProps {
   isAddPaletteDisabled?: boolean;
   colorPalettes: { id: number; name: string; colors: string[] }[];
   selectedPaletteId: number | "";
+  onSelectPalette: (id: number | "") => void;
 }
 
 export default function SlideCanvas({
@@ -64,6 +65,7 @@ export default function SlideCanvas({
   isAddPaletteDisabled,
   colorPalettes,
   selectedPaletteId,
+  onSelectPalette,
 }: SlideCanvasProps) {
   return (
     <Flex gap={6} alignItems="flex-start">
@@ -116,6 +118,23 @@ export default function SlideCanvas({
                 <Button size="xs" onClick={openSaveStyle}>
                   Save Style
                 </Button>
+                <Select
+                  size="xs"
+                  placeholder="Select Palette"
+                  value={selectedPaletteId}
+                  onChange={(e) =>
+                    onSelectPalette(
+                      e.target.value === "" ? "" : parseInt(e.target.value, 10)
+                    )
+                  }
+                  maxW="120px"
+                >
+                  {colorPalettes.map((p) => (
+                    <option key={p.id} value={p.id}>
+                      {p.name}
+                    </option>
+                  ))}
+                </Select>
                 <Button
                   size="xs"
                   onClick={openAddPalette}


### PR DESCRIPTION
## Summary
- allow selecting color palettes when editing slides

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845d99306d083268f4843ce33da0df1