### PR TITLE
Add CRUD dropdown for lesson style collections

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -182,6 +182,9 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         selectedGroupId={selectedGroupId}
         onSelectGroup={setSelectedGroupId}
         styleItems={styleItems}
+        onAddCollection={(collection) =>
+          setStyleCollections([...styleCollections, collection])
+        }
       />
 
       <SlideCanvas

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -44,6 +44,15 @@ export const CREATE_STYLE_GROUP = gql`
   }
 `;
 
+export const CREATE_STYLE_COLLECTION = gql`
+  mutation CreateStyleCollection($data: CreateStyleCollectionInput!) {
+    createStyleCollection(data: $data) {
+      id
+      name
+    }
+  }
+`;
+
 export const GET_STYLES_WITH_CONFIG = gql`
   query GetStylesWithConfig($collectionId: String!, $element: String!) {
     getAllStyle(


### PR DESCRIPTION
## Summary
- reuse existing CrudDropdown for lesson editor collections
- allow creating style collections from the toolbar
- expose CREATE_STYLE_COLLECTION GraphQL mutation

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p .` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6845ddc87f9083268f025ffc99cfdebc