### PR TITLE
Add update/delete for style collections

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -185,6 +185,17 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         onAddCollection={(collection) =>
           setStyleCollections([...styleCollections, collection])
         }
+        onUpdateCollection={(collection) =>
+          setStyleCollections((cols) =>
+            cols.map((c) => (c.id === collection.id ? collection : c))
+          )
+        }
+        onDeleteCollection={(id) => {
+          setStyleCollections((cols) => cols.filter((c) => c.id !== id));
+          if (selectedCollectionId === id) {
+            setSelectedCollectionId("");
+          }
+        }}
       />
 
       <SlideCanvas

--- a/insight-fe/src/components/lesson/modals/AddStyleCollectionModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddStyleCollectionModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button, HStack, Input } from "@chakra-ui/react";
 import { BaseModal } from "@/components/modals/BaseModal";
 
@@ -6,20 +6,36 @@ interface AddStyleCollectionModalProps {
   isOpen: boolean;
   onSave: (name: string) => void;
   onClose: () => void;
+  /** Pre-populated name when editing an existing collection */
+  initialName?: string;
+  /** Modal title, defaults to "Add Style Collection" */
+  title?: string;
+  /** Text displayed on the confirmation button */
+  confirmLabel?: string;
 }
 
 export default function AddStyleCollectionModal({
   isOpen,
   onSave,
   onClose,
+  initialName = "",
+  title = "Add Style Collection",
+  confirmLabel = "Save",
 }: AddStyleCollectionModalProps) {
-  const [name, setName] = useState("");
+  const [name, setName] = useState(initialName);
+
+  // Reset name whenever the modal is opened or the initial value changes
+  useEffect(() => {
+    if (isOpen) {
+      setName(initialName);
+    }
+  }, [isOpen, initialName]);
 
   return (
     <BaseModal
       isOpen={isOpen}
       onClose={onClose}
-      title="Add Style Collection"
+      title={title}
       footer={
         <HStack>
           <Button
@@ -29,7 +45,7 @@ export default function AddStyleCollectionModal({
               setName("");
             }}
           >
-            Save
+            {confirmLabel}
           </Button>
           <Button onClick={onClose}>Cancel</Button>
         </HStack>

--- a/insight-fe/src/components/lesson/modals/AddStyleCollectionModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddStyleCollectionModal.tsx
@@ -42,7 +42,9 @@ export default function AddStyleCollectionModal({
             colorScheme="blue"
             onClick={() => {
               onSave(name);
-              setName("");
+              if (initialName === "") {
+                setName("");
+              }
             }}
           >
             {confirmLabel}

--- a/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
@@ -8,8 +8,13 @@ import {
   SlideElementDnDItem,
 } from "@/components/DnD/cards/SlideElementDnDCard";
 import CrudDropdown from "@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown";
+import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 import AddStyleCollectionModal from "../modals/AddStyleCollectionModal";
-import { CREATE_STYLE_COLLECTION } from "@/graphql/lesson";
+import {
+  CREATE_STYLE_COLLECTION,
+  UPDATE_STYLE_COLLECTION,
+  DELETE_STYLE_COLLECTION,
+} from "@/graphql/lesson";
 
 interface SlideToolbarProps {
   availableElements: { type: string; label: string }[];
@@ -23,6 +28,8 @@ interface SlideToolbarProps {
   onSelectGroup: (id: number | "") => void;
   styleItems: SlideElementDnDItemProps[];
   onAddCollection: (collection: { id: number; name: string }) => void;
+  onUpdateCollection?: (collection: { id: number; name: string }) => void;
+  onDeleteCollection?: (id: number) => void;
 }
 
 export default function SlideToolbar({
@@ -37,9 +44,23 @@ export default function SlideToolbar({
   onSelectGroup,
   styleItems,
   onAddCollection,
+  onUpdateCollection,
+  onDeleteCollection,
 }: SlideToolbarProps) {
   const [isAddCollectionOpen, setIsAddCollectionOpen] = useState(false);
+  const [isEditCollectionOpen, setIsEditCollectionOpen] = useState(false);
+  const [isDeleteCollectionOpen, setIsDeleteCollectionOpen] = useState(false);
+
   const [createCollection] = useMutation(CREATE_STYLE_COLLECTION);
+  const [updateCollection] = useMutation(UPDATE_STYLE_COLLECTION);
+  const [deleteCollection, { loading: deleting }] = useMutation(
+    DELETE_STYLE_COLLECTION,
+  );
+
+  const selectedCollection =
+    selectedCollectionId !== ""
+      ? styleCollections.find((c) => c.id === selectedCollectionId)
+      : undefined;
   const collectionOptions = useMemo(
     () =>
       styleCollections.map((c) => ({ label: c.name, value: String(c.id) })),
@@ -74,10 +95,10 @@ export default function SlideToolbar({
             )
           }
           onCreate={() => setIsAddCollectionOpen(true)}
-          onUpdate={() => {}}
-          onDelete={() => {}}
-          isUpdateDisabled
-          isDeleteDisabled
+          onUpdate={() => setIsEditCollectionOpen(true)}
+          onDelete={() => setIsDeleteCollectionOpen(true)}
+          isUpdateDisabled={selectedCollectionId === ""}
+          isDeleteDisabled={selectedCollectionId === ""}
         />
         <HStack>
           {availableElements.map((el) => (
@@ -145,6 +166,43 @@ export default function SlideToolbar({
             setIsAddCollectionOpen(false);
           }
         }}
+      />
+
+      <AddStyleCollectionModal
+        isOpen={isEditCollectionOpen}
+        onClose={() => setIsEditCollectionOpen(false)}
+        title="Update Style Collection"
+        confirmLabel="Update"
+        initialName={selectedCollection?.name ?? ""}
+        onSave={async (name) => {
+          if (selectedCollectionId === "") return;
+          const { data } = await updateCollection({
+            variables: { data: { id: selectedCollectionId, name } },
+          });
+          if (data?.updateStyleCollection) {
+            onUpdateCollection?.({
+              id: selectedCollectionId,
+              name: data.updateStyleCollection.name,
+            });
+          }
+          setIsEditCollectionOpen(false);
+        }}
+      />
+
+      <ConfirmationModal
+        isOpen={isDeleteCollectionOpen}
+        onClose={() => setIsDeleteCollectionOpen(false)}
+        action="delete collection"
+        bodyText="Are you sure you want to delete this collection?"
+        onConfirm={async () => {
+          if (selectedCollectionId === "") return;
+          await deleteCollection({
+            variables: { data: { id: selectedCollectionId } },
+          });
+          onDeleteCollection?.(selectedCollectionId);
+          setIsDeleteCollectionOpen(false);
+        }}
+        isLoading={deleting}
       />
     </>
   );

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -53,6 +53,21 @@ export const CREATE_STYLE_COLLECTION = gql`
   }
 `;
 
+export const UPDATE_STYLE_COLLECTION = gql`
+  mutation UpdateStyleCollection($data: UpdateStyleCollectionInput!) {
+    updateStyleCollection(data: $data) {
+      id
+      name
+    }
+  }
+`;
+
+export const DELETE_STYLE_COLLECTION = gql`
+  mutation DeleteStyleCollection($data: IdInput!) {
+    deleteStyleCollection(data: $data)
+  }
+`;
+
 export const GET_STYLES_WITH_CONFIG = gql`
   query GetStylesWithConfig($collectionId: String!, $element: String!) {
     getAllStyle(


### PR DESCRIPTION
## Summary
- allow AddStyleCollectionModal to accept initial values
- add update & delete style collection mutations
- support editing and deleting collections from SlideToolbar
- handle collection updates in LessonEditor

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845eb5030bc8326b3b1ce10a2712e4b