### PR TITLE
Enable CRUD dropdown for style groups

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -202,6 +202,13 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
           }
           await refetchCollections();
         }}
+        onAddGroup={(group) => setStyleGroups([...styleGroups, group])}
+        onUpdateGroup={(group) =>
+          setStyleGroups((gs) => gs.map((g) => (g.id === group.id ? group : g)))
+        }
+        onDeleteGroup={(id) =>
+          setStyleGroups((gs) => gs.filter((g) => g.id !== id))
+        }
       />
 
       <SlideCanvas

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -202,13 +202,42 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
           }
           await refetchCollections();
         }}
-        onAddGroup={(group) => setStyleGroups([...styleGroups, group])}
-        onUpdateGroup={(group) =>
-          setStyleGroups((gs) => gs.map((g) => (g.id === group.id ? group : g)))
-        }
-        onDeleteGroup={(id) =>
-          setStyleGroups((gs) => gs.filter((g) => g.id !== id))
-        }
+        onAddGroup={async (group) => {
+          setStyleGroups([...styleGroups, group]);
+          if (selectedCollectionId !== "" && selectedElementType) {
+            await fetchGroups({
+              variables: {
+                collectionId: String(selectedCollectionId),
+                element: selectedElementType,
+              },
+            });
+          }
+        }}
+        onUpdateGroup={async (group) => {
+          setStyleGroups((gs) => gs.map((g) => (g.id === group.id ? group : g)));
+          if (selectedCollectionId !== "" && selectedElementType) {
+            await fetchGroups({
+              variables: {
+                collectionId: String(selectedCollectionId),
+                element: selectedElementType,
+              },
+            });
+          }
+        }}
+        onDeleteGroup={async (id) => {
+          setStyleGroups((gs) => gs.filter((g) => g.id !== id));
+          if (selectedCollectionId === id) {
+            setSelectedGroupId("");
+          }
+          if (selectedCollectionId !== "" && selectedElementType) {
+            await fetchGroups({
+              variables: {
+                collectionId: String(selectedCollectionId),
+                element: selectedElementType,
+              },
+            });
+          }
+        }}
       />
 
       <SlideCanvas
@@ -289,7 +318,17 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
           setStyleCollections([...styleCollections, collection]);
           await refetchCollections();
         }}
-        onAddGroup={(group) => setStyleGroups([...styleGroups, group])}
+        onAddGroup={async (group) => {
+          setStyleGroups([...styleGroups, group]);
+          if (selectedCollectionId !== "" && selectedElementType) {
+            await fetchGroups({
+              variables: {
+                collectionId: String(selectedCollectionId),
+                element: selectedElementType,
+              },
+            });
+          }
+        }}
         onAddPalette={(palette) => {
           setColorPalettes((p) => [...p, palette]);
           fetchPalettes({

--- a/insight-fe/src/components/lesson/modals/AddStyleGroupModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddStyleGroupModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { Button, HStack, Input } from "@chakra-ui/react";
 import { BaseModal } from "@/components/modals/BaseModal";
 
@@ -6,21 +6,37 @@ interface AddStyleGroupModalProps {
   isOpen: boolean;
   onSave: (name: string) => void;
   onClose: () => void;
+  /** Pre-populated name when editing an existing group */
+  initialName?: string;
+  /** Modal title, defaults to "Add Style Group" */
+  title?: string;
+  /** Text displayed on the confirmation button */
+  confirmLabel?: string;
 }
 
 export default function AddStyleGroupModal({
   isOpen,
   onSave,
   onClose,
+  initialName = "",
+  title = "Add Style Group",
+  confirmLabel = "Save",
 }: AddStyleGroupModalProps) {
-  const [name, setName] = useState("");
+  const [name, setName] = useState(initialName);
   const [loading, setLoading] = useState(false);
+
+  // Reset name whenever the modal is opened or the initial value changes
+  useEffect(() => {
+    if (isOpen) {
+      setName(initialName);
+    }
+  }, [isOpen, initialName]);
 
   return (
     <BaseModal
       isOpen={isOpen}
       onClose={onClose}
-      title="Add Style Group"
+      title={title}
       footer={
         <HStack>
           <Button
@@ -30,14 +46,16 @@ export default function AddStyleGroupModal({
               setLoading(true);
               try {
                 await onSave(name);
-                setName("");
+                if (initialName === "") {
+                  setName("");
+                }
                 onClose();
               } finally {
                 setLoading(false);
               }
             }}
           >
-            Save
+            {confirmLabel}
           </Button>
           <Button onClick={onClose}>Cancel</Button>
         </HStack>

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -44,6 +44,21 @@ export const CREATE_STYLE_GROUP = gql`
   }
 `;
 
+export const UPDATE_STYLE_GROUP = gql`
+  mutation UpdateStyleGroup($data: UpdateStyleGroupInput!) {
+    updateStyleGroup(data: $data) {
+      id
+      name
+    }
+  }
+`;
+
+export const DELETE_STYLE_GROUP = gql`
+  mutation DeleteStyleGroup($data: IdInput!) {
+    deleteStyleGroup(data: $data)
+  }
+`;
+
 export const CREATE_STYLE_COLLECTION = gql`
   mutation CreateStyleCollection($data: CreateStyleCollectionInput!) {
     createStyleCollection(data: $data) {


### PR DESCRIPTION
## Summary
- add configurable `AddStyleGroupModal`
- expose update/delete style group operations
- convert groups dropdown to `CrudDropdown`
- wire group CRUD handlers in the lesson editor

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run lint` in `insight-be` *(fails: missing eslint dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684600a55f248326831cf1178600c964