### PR TITLE
Enable slide-level styling in lesson builder

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -37,311 +37,319 @@ const ELEMENT_TYPE_TO_ENUM: Record<string, string> = {
   quiz: "Quiz",
 };
 
-const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
-  _,
-  ref
-) {
-  const editor = useLessonEditorState(ref);
+const LessonEditor = forwardRef<LessonEditorHandle>(
+  function LessonEditor(_, ref) {
+    const editor = useLessonEditorState(ref);
 
-  const [styleCollections, setStyleCollections] = useState<
-    { id: number; name: string }[]
-  >([]);
-  const [styleGroups, setStyleGroups] = useState<{
-    id: number;
-    name: string;
-  }[]>([]);
-  const [colorPalettes, setColorPalettes] = useState<{
-    id: number;
-    name: string;
-    colors: string[];
-  }[]>([]);
-  const [selectedCollectionId, setSelectedCollectionId] = useState<number | "">(
-    ""
-  );
-  const [selectedPaletteId, setSelectedPaletteId] = useState<number | "">("");
-  const [isSaveStyleOpen, setIsSaveStyleOpen] = useState(false);
-  const [isLoadStyleOpen, setIsLoadStyleOpen] = useState(false);
-  const [isPaletteOpen, setIsPaletteOpen] = useState(false);
-  const [styleItems, setStyleItems] = useState<SlideElementDnDItemProps[]>([]);
-  const [selectedElementType, setSelectedElementType] = useState<string | null>(
-    null
-  );
-  const [selectedGroupId, setSelectedGroupId] = useState<number | "">("");
+    const [styleCollections, setStyleCollections] = useState<
+      { id: number; name: string }[]
+    >([]);
+    const [styleGroups, setStyleGroups] = useState<
+      {
+        id: number;
+        name: string;
+      }[]
+    >([]);
+    const [colorPalettes, setColorPalettes] = useState<
+      {
+        id: number;
+        name: string;
+        colors: string[];
+      }[]
+    >([]);
+    const [selectedCollectionId, setSelectedCollectionId] = useState<
+      number | ""
+    >("");
+    const [selectedPaletteId, setSelectedPaletteId] = useState<number | "">("");
+    const [isSaveStyleOpen, setIsSaveStyleOpen] = useState(false);
+    const [isLoadStyleOpen, setIsLoadStyleOpen] = useState(false);
+    const [isPaletteOpen, setIsPaletteOpen] = useState(false);
+    const [styleItems, setStyleItems] = useState<SlideElementDnDItemProps[]>(
+      [],
+    );
+    const [selectedElementType, setSelectedElementType] = useState<
+      string | null
+    >(null);
+    const [selectedGroupId, setSelectedGroupId] = useState<number | "">("");
 
-  // Sync toolbar element type with the currently selected element on the canvas
-  useEffect(() => {
-    if (editor.selectedElement && selectedCollectionId !== "") {
-      setSelectedElementType(editor.selectedElement.type);
-    }
-  }, [editor.selectedElement, selectedCollectionId]);
+    // Sync toolbar element type with the currently selected element on the canvas
+    useEffect(() => {
+      if (editor.selectedElement && selectedCollectionId !== "") {
+        setSelectedElementType(editor.selectedElement.type);
+      }
+    }, [editor.selectedElement, selectedCollectionId]);
 
-  const [fetchStyles, { data: stylesData }] = useLazyQuery(
-    GET_STYLES_WITH_CONFIG_BY_GROUP,
-    { fetchPolicy: "network-only" }
-  );
-  const [fetchGroups, { data: groupsData }] = useLazyQuery(GET_STYLE_GROUPS);
-  const [fetchPalettes, { data: palettesData }] = useLazyQuery(GET_COLOR_PALETTES);
+    const [fetchStyles, { data: stylesData }] = useLazyQuery(
+      GET_STYLES_WITH_CONFIG_BY_GROUP,
+      { fetchPolicy: "network-only" },
+    );
+    const [fetchGroups, { data: groupsData }] = useLazyQuery(GET_STYLE_GROUPS);
+    const [fetchPalettes, { data: palettesData }] =
+      useLazyQuery(GET_COLOR_PALETTES);
 
-  const {
-    data: collectionsData,
-    refetch: refetchCollections,
-  } = useQuery(GET_STYLE_COLLECTIONS);
-  const [createStyle] = useMutation(CREATE_STYLE);
+    const { data: collectionsData, refetch: refetchCollections } = useQuery(
+      GET_STYLE_COLLECTIONS,
+    );
+    const [createStyle] = useMutation(CREATE_STYLE);
 
-  useEffect(() => {
-    if (collectionsData?.getAllStyleCollection) {
-      setStyleCollections(collectionsData.getAllStyleCollection);
-    }
-  }, [collectionsData]);
+    useEffect(() => {
+      if (collectionsData?.getAllStyleCollection) {
+        setStyleCollections(collectionsData.getAllStyleCollection);
+      }
+    }, [collectionsData]);
 
-  useEffect(() => {
-    if (selectedCollectionId === "") {
-      setStyleItems([]);
-      setSelectedElementType(null);
+    useEffect(() => {
+      if (selectedCollectionId === "") {
+        setStyleItems([]);
+        setSelectedElementType(null);
+        setSelectedGroupId("");
+        setColorPalettes([]);
+        setSelectedPaletteId("");
+      }
+    }, [selectedCollectionId]);
+
+    useEffect(() => {
+      if (selectedCollectionId !== "") {
+        fetchPalettes({
+          variables: { collectionId: String(selectedCollectionId) },
+        });
+      }
+    }, [selectedCollectionId]);
+
+    useEffect(() => {
+      if (selectedCollectionId !== "" && selectedElementType) {
+        fetchGroups({
+          variables: {
+            collectionId: String(selectedCollectionId),
+            element: selectedElementType,
+          },
+        });
+      } else {
+        setStyleGroups([]);
+      }
       setSelectedGroupId("");
-      setColorPalettes([]);
-      setSelectedPaletteId("");
-    }
-  }, [selectedCollectionId]);
+    }, [selectedCollectionId, selectedElementType]);
 
-  useEffect(() => {
-    if (selectedCollectionId !== "") {
-      fetchPalettes({
-        variables: { collectionId: String(selectedCollectionId) },
-      });
-    }
-  }, [selectedCollectionId]);
+    useEffect(() => {
+      if (groupsData?.getAllStyleGroup) {
+        setStyleGroups(groupsData.getAllStyleGroup);
+      } else {
+        setStyleGroups([]);
+      }
+    }, [groupsData]);
 
-  useEffect(() => {
-    if (selectedCollectionId !== "" && selectedElementType) {
-      fetchGroups({
-        variables: {
-          collectionId: String(selectedCollectionId),
-          element: selectedElementType,
-        },
-      });
-    } else {
-      setStyleGroups([]);
-    }
-    setSelectedGroupId("");
-  }, [selectedCollectionId, selectedElementType]);
+    useEffect(() => {
+      if (
+        selectedCollectionId !== "" &&
+        selectedElementType &&
+        selectedGroupId !== ""
+      ) {
+        fetchStyles({
+          variables: {
+            collectionId: String(selectedCollectionId),
+            element: selectedElementType,
+            groupId: String(selectedGroupId),
+          },
+        });
+      } else {
+        setStyleItems([]);
+      }
+    }, [selectedCollectionId, selectedElementType, selectedGroupId]);
 
-  useEffect(() => {
-    if (groupsData?.getAllStyleGroup) {
-      setStyleGroups(groupsData.getAllStyleGroup);
-    } else {
-      setStyleGroups([]);
-    }
-  }, [groupsData]);
+    useEffect(() => {
+      if (palettesData?.getAllColorPalette) {
+        setColorPalettes(palettesData.getAllColorPalette);
+      } else {
+        setColorPalettes([]);
+      }
+    }, [palettesData]);
 
-  useEffect(() => {
-    if (
-      selectedCollectionId !== "" &&
-      selectedElementType &&
-      selectedGroupId !== ""
-    ) {
-      fetchStyles({
-        variables: {
-          collectionId: String(selectedCollectionId),
-          element: selectedElementType,
-          groupId: String(selectedGroupId),
-        },
-      });
-    } else {
-      setStyleItems([]);
-    }
-  }, [selectedCollectionId, selectedElementType, selectedGroupId]);
+    useEffect(() => {
+      if (stylesData?.getAllStyle) {
+        const items = stylesData.getAllStyle.map((s: any) => ({
+          ...(s.config as SlideElementDnDItemProps),
+          id: crypto.randomUUID(),
+        }));
+        setStyleItems(items);
+      } else {
+        setStyleItems([]);
+      }
+    }, [stylesData]);
 
-  useEffect(() => {
-    if (palettesData?.getAllColorPalette) {
-      setColorPalettes(palettesData.getAllColorPalette);
-    } else {
-      setColorPalettes([]);
-    }
-  }, [palettesData]);
+    return (
+      <Box>
+        <SlideToolbar
+          availableElements={AVAILABLE_ELEMENTS}
+          styleCollections={styleCollections}
+          styleGroups={styleGroups}
+          selectedCollectionId={selectedCollectionId}
+          onSelectCollection={setSelectedCollectionId}
+          selectedElementType={selectedElementType}
+          onSelectElement={setSelectedElementType}
+          selectedGroupId={selectedGroupId}
+          onSelectGroup={setSelectedGroupId}
+          styleItems={styleItems}
+          onAddCollection={async (collection) => {
+            setStyleCollections([...styleCollections, collection]);
+            await refetchCollections();
+          }}
+          onUpdateCollection={async (collection) => {
+            setStyleCollections((cols) =>
+              cols.map((c) => (c.id === collection.id ? collection : c)),
+            );
+            await refetchCollections();
+          }}
+          onDeleteCollection={async (id) => {
+            setStyleCollections((cols) => cols.filter((c) => c.id !== id));
+            if (selectedCollectionId === id) {
+              setSelectedCollectionId("");
+            }
+            await refetchCollections();
+          }}
+          onAddGroup={async (group) => {
+            setStyleGroups([...styleGroups, group]);
+            if (selectedCollectionId !== "" && selectedElementType) {
+              await fetchGroups({
+                variables: {
+                  collectionId: String(selectedCollectionId),
+                  element: selectedElementType,
+                },
+              });
+            }
+          }}
+          onUpdateGroup={async (group) => {
+            setStyleGroups((gs) =>
+              gs.map((g) => (g.id === group.id ? group : g)),
+            );
+            if (selectedCollectionId !== "" && selectedElementType) {
+              await fetchGroups({
+                variables: {
+                  collectionId: String(selectedCollectionId),
+                  element: selectedElementType,
+                },
+              });
+            }
+          }}
+          onDeleteGroup={async (id) => {
+            setStyleGroups((gs) => gs.filter((g) => g.id !== id));
+            if (selectedCollectionId === id) {
+              setSelectedGroupId("");
+            }
+            if (selectedCollectionId !== "" && selectedElementType) {
+              await fetchGroups({
+                variables: {
+                  collectionId: String(selectedCollectionId),
+                  element: selectedElementType,
+                },
+              });
+            }
+          }}
+        />
 
-  useEffect(() => {
-    if (stylesData?.getAllStyle) {
-      const items = stylesData.getAllStyle.map((s: any) => ({
-        ...(s.config as SlideElementDnDItemProps),
-        id: crypto.randomUUID(),
-      }));
-      setStyleItems(items);
-    } else {
-      setStyleItems([]);
-    }
-  }, [stylesData]);
+        <SlideCanvas
+          slides={editor.state.slides}
+          setSlides={editor.setSlides as any}
+          selectedSlideId={editor.state.selectedSlideId}
+          selectSlide={(id) => editor.selectSlide(id)}
+          selectedSlide={editor.selectedSlide}
+          selectedElement={editor.selectedElement}
+          selectedColumn={editor.selectedColumn}
+          selectedBoard={editor.selectedBoard}
+          dropIndicator={editor.state.dropIndicator}
+          selectElement={(id) => editor.selectElement(id)}
+          selectColumn={(id) => editor.selectColumn(id)}
+          selectBoard={(id) => editor.selectBoard(id)}
+          updateElement={editor.updateElement}
+          cloneElement={editor.cloneElement}
+          deleteElement={editor.deleteElement}
+          updateColumn={editor.updateColumn}
+          updateBoard={editor.updateBoard}
+          updateSlide={editor.updateSlide}
+          handleDragOver={editor.handleDragOver}
+          handleDropElement={editor.handleDropElement}
+          openSaveStyle={() => setIsSaveStyleOpen(true)}
+          openLoadStyle={() => setIsLoadStyleOpen(true)}
+          openAddPalette={() => {
+            if (selectedCollectionId !== "") {
+              setIsPaletteOpen(true);
+            }
+          }}
+          isAddPaletteDisabled={selectedCollectionId === ""}
+          colorPalettes={colorPalettes}
+          selectedPaletteId={selectedPaletteId}
+          onSelectPalette={setSelectedPaletteId}
+        />
 
-  return (
-    <Box>
-      <SlideToolbar
-        availableElements={AVAILABLE_ELEMENTS}
-        styleCollections={styleCollections}
-        styleGroups={styleGroups}
-        selectedCollectionId={selectedCollectionId}
-        onSelectCollection={setSelectedCollectionId}
-        selectedElementType={selectedElementType}
-        onSelectElement={setSelectedElementType}
-        selectedGroupId={selectedGroupId}
-        onSelectGroup={setSelectedGroupId}
-        styleItems={styleItems}
-        onAddCollection={async (collection) => {
-          setStyleCollections([...styleCollections, collection]);
-          await refetchCollections();
-        }}
-        onUpdateCollection={async (collection) => {
-          setStyleCollections((cols) =>
-            cols.map((c) => (c.id === collection.id ? collection : c))
-          );
-          await refetchCollections();
-        }}
-        onDeleteCollection={async (id) => {
-          setStyleCollections((cols) => cols.filter((c) => c.id !== id));
-          if (selectedCollectionId === id) {
-            setSelectedCollectionId("");
-          }
-          await refetchCollections();
-        }}
-        onAddGroup={async (group) => {
-          setStyleGroups([...styleGroups, group]);
-          if (selectedCollectionId !== "" && selectedElementType) {
-            await fetchGroups({
+        <StyleModals
+          isSaveOpen={isSaveStyleOpen}
+          isLoadOpen={isLoadStyleOpen}
+          isPaletteOpen={isPaletteOpen}
+          closeSave={() => setIsSaveStyleOpen(false)}
+          closeLoad={() => setIsLoadStyleOpen(false)}
+          closePalette={() => setIsPaletteOpen(false)}
+          styleCollections={styleCollections}
+          styleGroups={styleGroups}
+          selectedCollectionId={selectedCollectionId}
+          selectedElement={editor.selectedElement}
+          onSave={async ({ name, collectionId, groupId }) => {
+            if (!editor.selectedElement) return;
+            await createStyle({
               variables: {
-                collectionId: String(selectedCollectionId),
-                element: selectedElementType,
+                data: {
+                  name,
+                  collectionId,
+                  groupId: groupId ?? undefined,
+                  element: ELEMENT_TYPE_TO_ENUM[editor.selectedElement.type],
+                  config: editor.selectedElement,
+                },
               },
             });
-          }
-        }}
-        onUpdateGroup={async (group) => {
-          setStyleGroups((gs) => gs.map((g) => (g.id === group.id ? group : g)));
-          if (selectedCollectionId !== "" && selectedElementType) {
-            await fetchGroups({
-              variables: {
-                collectionId: String(selectedCollectionId),
-                element: selectedElementType,
-              },
-            });
-          }
-        }}
-        onDeleteGroup={async (id) => {
-          setStyleGroups((gs) => gs.filter((g) => g.id !== id));
-          if (selectedCollectionId === id) {
-            setSelectedGroupId("");
-          }
-          if (selectedCollectionId !== "" && selectedElementType) {
-            await fetchGroups({
-              variables: {
-                collectionId: String(selectedCollectionId),
-                element: selectedElementType,
-              },
-            });
-          }
-        }}
-      />
 
-      <SlideCanvas
-        slides={editor.state.slides}
-        setSlides={editor.setSlides as any}
-        selectedSlideId={editor.state.selectedSlideId}
-        selectSlide={(id) => editor.selectSlide(id)}
-        selectedSlide={editor.selectedSlide}
-        selectedElement={editor.selectedElement}
-        selectedColumn={editor.selectedColumn}
-        selectedBoard={editor.selectedBoard}
-        dropIndicator={editor.state.dropIndicator}
-        selectElement={(id) => editor.selectElement(id)}
-        selectColumn={(id) => editor.selectColumn(id)}
-        selectBoard={(id) => editor.selectBoard(id)}
-        updateElement={editor.updateElement}
-        cloneElement={editor.cloneElement}
-        deleteElement={editor.deleteElement}
-        updateColumn={editor.updateColumn}
-        updateBoard={editor.updateBoard}
-        handleDragOver={editor.handleDragOver}
-        handleDropElement={editor.handleDropElement}
-        openSaveStyle={() => setIsSaveStyleOpen(true)}
-        openLoadStyle={() => setIsLoadStyleOpen(true)}
-        openAddPalette={() => {
-          if (selectedCollectionId !== "") {
-            setIsPaletteOpen(true);
-          }
-        }}
-        isAddPaletteDisabled={selectedCollectionId === ""}
-        colorPalettes={colorPalettes}
-        selectedPaletteId={selectedPaletteId}
-        onSelectPalette={setSelectedPaletteId}
-      />
-
-      <StyleModals
-        isSaveOpen={isSaveStyleOpen}
-        isLoadOpen={isLoadStyleOpen}
-        isPaletteOpen={isPaletteOpen}
-        closeSave={() => setIsSaveStyleOpen(false)}
-        closeLoad={() => setIsLoadStyleOpen(false)}
-        closePalette={() => setIsPaletteOpen(false)}
-        styleCollections={styleCollections}
-        styleGroups={styleGroups}
-        selectedCollectionId={selectedCollectionId}
-        selectedElement={editor.selectedElement}
-        onSave={async ({ name, collectionId, groupId }) => {
-          if (!editor.selectedElement) return;
-          await createStyle({
-            variables: {
-              data: {
-                name,
-                collectionId,
-                groupId: groupId ?? undefined,
-                element: ELEMENT_TYPE_TO_ENUM[editor.selectedElement.type],
-                config: editor.selectedElement,
-              },
-            },
-          });
-
-          if (
-            selectedCollectionId !== "" &&
-            collectionId === selectedCollectionId &&
-            selectedElementType === editor.selectedElement.type &&
-            selectedGroupId !== "" &&
-            groupId === selectedGroupId
-          ) {
-            await fetchStyles({
-              variables: {
-                collectionId: String(selectedCollectionId),
-                element: selectedElementType,
-                groupId: String(selectedGroupId),
-              },
+            if (
+              selectedCollectionId !== "" &&
+              collectionId === selectedCollectionId &&
+              selectedElementType === editor.selectedElement.type &&
+              selectedGroupId !== "" &&
+              groupId === selectedGroupId
+            ) {
+              await fetchStyles({
+                variables: {
+                  collectionId: String(selectedCollectionId),
+                  element: selectedElementType,
+                  groupId: String(selectedGroupId),
+                },
+              });
+            }
+          }}
+          onAddCollection={async (collection) => {
+            setStyleCollections([...styleCollections, collection]);
+            await refetchCollections();
+          }}
+          onAddGroup={async (group) => {
+            setStyleGroups([...styleGroups, group]);
+            if (selectedCollectionId !== "" && selectedElementType) {
+              await fetchGroups({
+                variables: {
+                  collectionId: String(selectedCollectionId),
+                  element: selectedElementType,
+                },
+              });
+            }
+          }}
+          onAddPalette={(palette) => {
+            setColorPalettes((p) => [...p, palette]);
+            fetchPalettes({
+              variables: { collectionId: String(selectedCollectionId) },
             });
-          }
-        }}
-        onAddCollection={async (collection) => {
-          setStyleCollections([...styleCollections, collection]);
-          await refetchCollections();
-        }}
-        onAddGroup={async (group) => {
-          setStyleGroups([...styleGroups, group]);
-          if (selectedCollectionId !== "" && selectedElementType) {
-            await fetchGroups({
-              variables: {
-                collectionId: String(selectedCollectionId),
-                element: selectedElementType,
-              },
-            });
-          }
-        }}
-        onAddPalette={(palette) => {
-          setColorPalettes((p) => [...p, palette]);
-          fetchPalettes({
-            variables: { collectionId: String(selectedCollectionId) },
-          });
-        }}
-        onLoad={(styleId) => {
-          if (!editor.selectedElement) return;
-          console.log("load style", { styleId });
-        }}
-      />
-    </Box>
-  );
-});
+          }}
+          onLoad={(styleId) => {
+            if (!editor.selectedElement) return;
+            console.log("load style", { styleId });
+          }}
+        />
+      </Box>
+    );
+  },
+);
 
 export default LessonEditor;

--- a/insight-fe/src/components/lesson/attributes-pane/SlideAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/SlideAttributesPane.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Accordion } from "@chakra-ui/react";
+import useStyleAttributes from "../hooks/useStyleAttributes";
+import WrapperSettings from "../attributes/WrapperSettings";
+import { Slide } from "../slide/SlideSequencer";
+
+interface SlideAttributesPaneProps {
+  slide: Slide;
+  onChange: (updated: Slide) => void;
+  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  selectedPaletteId?: number | "";
+}
+
+export default function SlideAttributesPane({
+  slide,
+  onChange,
+  colorPalettes,
+  selectedPaletteId,
+}: SlideAttributesPaneProps) {
+  const styleAttrs = useStyleAttributes({
+    wrapperStyles: slide.wrapperStyles,
+    spacing: slide.spacing,
+    deps: [slide.id],
+    defaultBgOpacity: 1,
+    onChange: ({ wrapperStyles, spacing }) =>
+      onChange({ ...slide, wrapperStyles, spacing }),
+  });
+
+  return (
+    <Accordion allowMultiple>
+      <WrapperSettings
+        attrs={styleAttrs}
+        colorPalettes={colorPalettes}
+        selectedPaletteId={selectedPaletteId}
+      />
+    </Accordion>
+  );
+}

--- a/insight-fe/src/components/lesson/defaultStyles.ts
+++ b/insight-fe/src/components/lesson/defaultStyles.ts
@@ -20,3 +20,8 @@ export const defaultBoardWrapperStyles: ElementWrapperStyles = {
   ...defaultColumnWrapperStyles,
   bgOpacity: 1,
 };
+
+export const defaultSlideWrapperStyles: ElementWrapperStyles = {
+  ...defaultColumnWrapperStyles,
+  bgOpacity: 1,
+};

--- a/insight-fe/src/components/lesson/hooks/useBoardColumnHelpers.ts
+++ b/insight-fe/src/components/lesson/hooks/useBoardColumnHelpers.ts
@@ -5,10 +5,11 @@ import { BoardRow } from "../SlideElementsContainer";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnType } from "@/components/DnD/types";
 import type { LessonState, Action } from "./useLessonSelection";
+import type { Slide } from "../slide/SlideSequencer";
 
 export default function useBoardColumnHelpers(
   state: LessonState,
-  dispatch: React.Dispatch<Action>
+  dispatch: React.Dispatch<Action>,
 ) {
   const updateElement = useCallback(
     (updated: SlideElementDnDItemProps) => {
@@ -39,7 +40,7 @@ export default function useBoardColumnHelpers(
         },
       });
     },
-    [state.selectedSlideId, dispatch]
+    [state.selectedSlideId, dispatch],
   );
 
   const updateColumn = useCallback(
@@ -54,7 +55,7 @@ export default function useBoardColumnHelpers(
         }),
       });
     },
-    [state.selectedSlideId, dispatch]
+    [state.selectedSlideId, dispatch],
   );
 
   const updateBoard = useCallback(
@@ -67,7 +68,7 @@ export default function useBoardColumnHelpers(
         updater: () => updated,
       });
     },
-    [state.selectedSlideId, dispatch]
+    [state.selectedSlideId, dispatch],
   );
 
   const cloneElement = useCallback(() => {
@@ -80,7 +81,9 @@ export default function useBoardColumnHelpers(
         for (const board of slide.boards) {
           for (const colId of board.orderedColumnIds) {
             const col = newMap[colId];
-            const idx = col.items.findIndex((i) => i.id === state.selectedElementId);
+            const idx = col.items.findIndex(
+              (i) => i.id === state.selectedElementId,
+            );
             if (idx !== -1) {
               const orig = col.items[idx];
               const copy = { ...orig, id: crypto.randomUUID() };
@@ -111,7 +114,9 @@ export default function useBoardColumnHelpers(
         for (const board of slide.boards) {
           for (const colId of board.orderedColumnIds) {
             const col = newMap[colId];
-            const idx = col.items.findIndex((i) => i.id === state.selectedElementId);
+            const idx = col.items.findIndex(
+              (i) => i.id === state.selectedElementId,
+            );
             if (idx !== -1) {
               newMap[colId] = {
                 ...col,
@@ -136,5 +141,13 @@ export default function useBoardColumnHelpers(
     updateBoard,
     cloneElement,
     deleteElement,
+    updateSlide: (updater: (slide: Slide) => Slide) => {
+      if (!state.selectedSlideId) return;
+      dispatch({
+        type: "updateSlide",
+        slideId: state.selectedSlideId,
+        updater,
+      });
+    },
   };
 }

--- a/insight-fe/src/components/lesson/hooks/useLessonSelection.ts
+++ b/insight-fe/src/components/lesson/hooks/useLessonSelection.ts
@@ -3,6 +3,7 @@
 import { useCallback, useReducer, useMemo, useImperativeHandle } from "react";
 import { BoardRow } from "../slide/SlideElementsContainer";
 import { Slide, createInitialBoard } from "../slide/SlideSequencer";
+import { defaultSlideWrapperStyles } from "../defaultStyles";
 
 export interface LessonEditorHandle {
   getContent: () => { slides: Slide[] };
@@ -80,7 +81,7 @@ function reducer(state: LessonState, action: Action): LessonState {
       return {
         ...state,
         slides: state.slides.map((s) =>
-          s.id === action.slideId ? action.updater(s) : s
+          s.id === action.slideId ? action.updater(s) : s,
         ),
       };
     case "updateBoard":
@@ -91,10 +92,10 @@ function reducer(state: LessonState, action: Action): LessonState {
             ? {
                 ...s,
                 boards: s.boards.map((b) =>
-                  b.id === action.boardId ? action.updater(b) : b
+                  b.id === action.boardId ? action.updater(b) : b,
                 ),
               }
-            : s
+            : s,
         ),
       };
     default:
@@ -106,6 +107,8 @@ export function useLessonSelection(ref?: React.Ref<LessonEditorHandle>) {
   const initialSlide = {
     id: crypto.randomUUID(),
     title: "Slide 1",
+    wrapperStyles: { ...defaultSlideWrapperStyles },
+    spacing: 4,
     ...createInitialBoard(),
   };
   const [state, dispatch] = useReducer(reducer, {
@@ -126,35 +129,35 @@ export function useLessonSelection(ref?: React.Ref<LessonEditorHandle>) {
         dispatch({ type: "selectSlide", id: slides[0]?.id ?? null });
       },
     }),
-    [state.slides, dispatch]
+    [state.slides, dispatch],
   );
 
   const setSlides = useCallback(
     (updater: React.SetStateAction<Slide[]>) =>
       dispatch({ type: "setSlides", updater }),
-    [dispatch]
+    [dispatch],
   );
 
   const selectSlide = useCallback(
     (id: string | null) => dispatch({ type: "selectSlide", id }),
-    [dispatch]
+    [dispatch],
   );
   const selectElement = useCallback(
     (id: string | null) => dispatch({ type: "selectElement", id }),
-    [dispatch]
+    [dispatch],
   );
   const selectColumn = useCallback(
     (id: string | null) => dispatch({ type: "selectColumn", id }),
-    [dispatch]
+    [dispatch],
   );
   const selectBoard = useCallback(
     (id: string | null) => dispatch({ type: "selectBoard", id }),
-    [dispatch]
+    [dispatch],
   );
 
   const selectedSlide = useMemo(
     () => state.slides.find((s) => s.id === state.selectedSlideId) || null,
-    [state.slides, state.selectedSlideId]
+    [state.slides, state.selectedSlideId],
   );
 
   const selectedElement = useMemo(() => {

--- a/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
@@ -30,7 +30,7 @@ export default function LessonPreviewModal({
             <Text mb={2} fontWeight="bold">
               {slide.title}
             </Text>
-            <SlidePreview columnMap={slide.columnMap} boards={slide.boards} />
+            <SlidePreview slide={slide} />
           </Box>
         ))}
       </Stack>

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -1,14 +1,24 @@
 "use client";
 
-import { Flex, Grid, Box, Text, HStack, Button, Select } from "@chakra-ui/react";
+import {
+  Flex,
+  Grid,
+  Box,
+  Text,
+  HStack,
+  Button,
+  Select,
+} from "@chakra-ui/react";
 
 import BoardAttributesPane from "../attributes-pane/BoardAttributesPane";
+import SlideAttributesPane from "../attributes-pane/SlideAttributesPane";
 import { ColumnType } from "@/components/DnD/types";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import ColumnAttributesPane from "../attributes-pane/ColumnAttributesPane";
 import ElementAttributesPane from "../attributes-pane/ElementAttributesPane";
 import SlideElementsContainer, { BoardRow } from "./SlideElementsContainer";
 import SlideSequencer, { Slide } from "./SlideSequencer";
+import ElementWrapper from "../elements/ElementWrapper";
 
 interface SlideCanvasProps {
   slides: Slide[];
@@ -28,6 +38,7 @@ interface SlideCanvasProps {
   deleteElement: () => void;
   updateColumn: (col: ColumnType<SlideElementDnDItemProps>) => void;
   updateBoard: (board: BoardRow) => void;
+  updateSlide: (updater: (slide: Slide) => Slide) => void;
   handleDragOver: (e: React.DragEvent<HTMLDivElement>) => void;
   handleDropElement: (e: React.DragEvent<HTMLDivElement>) => void;
   openSaveStyle: () => void;
@@ -57,6 +68,7 @@ export default function SlideCanvas({
   deleteElement,
   updateColumn,
   updateBoard,
+  updateSlide,
   handleDragOver,
   handleDropElement,
   openSaveStyle,
@@ -87,26 +99,25 @@ export default function SlideCanvas({
             onDrop={handleDropElement}
           >
             <Text mb={2}>Slide Elements</Text>
-            <SlideElementsContainer
-              columnMap={selectedSlide.columnMap}
-              boards={selectedSlide.boards}
-              onChange={(columnMap, boards) =>
-                setSlides((s) =>
-                  s.map((sl) =>
-                    sl.id === selectedSlideId
-                      ? { ...sl, columnMap, boards }
-                      : sl
-                  )
-                )
-              }
-              selectedElementId={selectedElement ? selectedElement.id : null}
-              onSelectElement={(id) => selectElement(id)}
-              dropIndicator={dropIndicator}
-              selectedColumnId={selectedColumn ? selectedColumn.columnId : null}
-              onSelectColumn={(id) => selectColumn(id)}
-              selectedBoardId={selectedBoard ? selectedBoard.id : null}
-              onSelectBoard={(id) => selectBoard(id)}
-            />
+            <ElementWrapper styles={selectedSlide.wrapperStyles}>
+              <SlideElementsContainer
+                columnMap={selectedSlide.columnMap}
+                boards={selectedSlide.boards}
+                spacing={selectedSlide.spacing}
+                onChange={(columnMap, boards) =>
+                  updateSlide((sl) => ({ ...sl, columnMap, boards }))
+                }
+                selectedElementId={selectedElement ? selectedElement.id : null}
+                onSelectElement={(id) => selectElement(id)}
+                dropIndicator={dropIndicator}
+                selectedColumnId={
+                  selectedColumn ? selectedColumn.columnId : null
+                }
+                onSelectColumn={(id) => selectColumn(id)}
+                selectedBoardId={selectedBoard ? selectedBoard.id : null}
+                onSelectBoard={(id) => selectBoard(id)}
+              />
+            </ElementWrapper>
           </Box>
           <Box p={4} borderWidth="1px" borderRadius="md" minW="200px">
             <HStack justify="space-between" mb={2}>
@@ -124,7 +135,7 @@ export default function SlideCanvas({
                   value={selectedPaletteId}
                   onChange={(e) =>
                     onSelectPalette(
-                      e.target.value === "" ? "" : parseInt(e.target.value, 10)
+                      e.target.value === "" ? "" : parseInt(e.target.value, 10),
                     )
                   }
                   maxW="120px"
@@ -166,6 +177,14 @@ export default function SlideCanvas({
               <BoardAttributesPane
                 board={selectedBoard}
                 onChange={updateBoard}
+                colorPalettes={colorPalettes}
+                selectedPaletteId={selectedPaletteId}
+              />
+            )}
+            {!selectedElement && !selectedColumn && !selectedBoard && (
+              <SlideAttributesPane
+                slide={selectedSlide}
+                onChange={(s) => updateSlide(() => s)}
                 colorPalettes={colorPalettes}
                 selectedPaletteId={selectedPaletteId}
               />

--- a/insight-fe/src/components/lesson/slide/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementsContainer.tsx
@@ -25,9 +25,10 @@ export interface BoardRow {
 interface SlideElementsContainerProps {
   columnMap: ColumnMap<SlideElementDnDItemProps>;
   boards: BoardRow[];
+  spacing?: number;
   onChange: (
     columnMap: ColumnMap<SlideElementDnDItemProps>,
-    boards: BoardRow[]
+    boards: BoardRow[],
   ) => void;
   selectedElementId?: string | null;
   onSelectElement?: (id: string) => void;
@@ -50,6 +51,7 @@ const COLUMN_COLORS = [
 export default function SlideElementsContainer({
   columnMap,
   boards,
+  spacing = 0,
   onChange,
   selectedElementId,
   onSelectElement,
@@ -96,13 +98,13 @@ export default function SlideElementsContainer({
   const updateBoard = (
     boardId: string,
     map: ColumnMap<SlideElementDnDItemProps>,
-    ids: string[]
+    ids: string[],
   ) => {
     onChange(
       map,
       boards.map((b) =>
-        b.id === boardId ? { ...b, orderedColumnIds: ids } : b
-      )
+        b.id === boardId ? { ...b, orderedColumnIds: ids } : b,
+      ),
     );
   };
 
@@ -115,7 +117,7 @@ export default function SlideElementsContainer({
     }
     onChange(
       newMap,
-      boards.filter((b) => b.id !== boardId)
+      boards.filter((b) => b.id !== boardId),
     );
   };
 
@@ -124,7 +126,7 @@ export default function SlideElementsContainer({
     const board = boards.find((b) => b.id === boardId);
     if (!board) return;
     const hasContent = board.orderedColumnIds.some(
-      (id) => columnMap[id]?.items.length > 0
+      (id) => columnMap[id]?.items.length > 0,
     );
     if (hasContent) {
       setBoardIdToDelete(boardId);
@@ -146,11 +148,11 @@ export default function SlideElementsContainer({
     columnMap,
     onChange,
     boardInstanceId,
-    instanceId
+    instanceId,
   );
 
   return (
-    <Stack ref={containerRef} spacing={0}>
+    <Stack ref={containerRef} spacing={spacing}>
       <Button
         size="sm"
         colorScheme="teal"

--- a/insight-fe/src/components/lesson/slide/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/slide/SlidePreview.tsx
@@ -2,53 +2,54 @@
 
 import { Box, Stack } from "@chakra-ui/react";
 
-import { ColumnMap } from "@/components/DnD/types";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import SlideElementRenderer from "./SlideElementRenderer";
-import { BoardRow } from "./SlideElementsContainer";
 import ElementWrapper from "../elements/ElementWrapper";
+import { Slide } from "./SlideSequencer";
 
 interface SlidePreviewProps {
-  columnMap: ColumnMap<SlideElementDnDItemProps>;
-  boards: BoardRow[];
+  slide: Slide;
 }
 
-export default function SlidePreview({ columnMap, boards }: SlidePreviewProps) {
+export default function SlidePreview({ slide }: SlidePreviewProps) {
+  const { columnMap, boards, wrapperStyles, spacing } = slide;
   return (
-    <Stack gap={4}>
-      {boards.map((board) => (
-        <ElementWrapper
-          key={board.id}
-          styles={board.wrapperStyles}
-          data-board-id={board.id}
-        >
-          <Box
-            display="grid"
-            gridTemplateColumns={`repeat(${board.orderedColumnIds.length}, 1fr)`}
-            gap={board.spacing ?? 0}
+    <ElementWrapper styles={wrapperStyles}>
+      <Stack gap={spacing ?? 4}>
+        {boards.map((board) => (
+          <ElementWrapper
+            key={board.id}
+            styles={board.wrapperStyles}
+            data-board-id={board.id}
           >
-            {board.orderedColumnIds.map((colId) => {
-              const column = columnMap[colId];
-              if (!column) return null;
-              return (
-                <ElementWrapper
-                  key={colId}
-                  styles={column.wrapperStyles}
-                  data-column-id={colId}
-                >
-                  <Stack gap={column.spacing ?? 2}>
-                    {column.items.map((item) => (
-                      <Box key={item.id} mb={2} data-card-id={item.id}>
-                        <SlideElementRenderer item={item} />
-                      </Box>
-                    ))}
-                  </Stack>
-                </ElementWrapper>
-              );
-            })}
-          </Box>
-        </ElementWrapper>
-      ))}
-    </Stack>
+            <Box
+              display="grid"
+              gridTemplateColumns={`repeat(${board.orderedColumnIds.length}, 1fr)`}
+              gap={board.spacing ?? 0}
+            >
+              {board.orderedColumnIds.map((colId) => {
+                const column = columnMap[colId];
+                if (!column) return null;
+                return (
+                  <ElementWrapper
+                    key={colId}
+                    styles={column.wrapperStyles}
+                    data-column-id={colId}
+                  >
+                    <Stack gap={column.spacing ?? 2}>
+                      {column.items.map((item) => (
+                        <Box key={item.id} mb={2} data-card-id={item.id}>
+                          <SlideElementRenderer item={item} />
+                        </Box>
+                      ))}
+                    </Stack>
+                  </ElementWrapper>
+                );
+              })}
+            </Box>
+          </ElementWrapper>
+        ))}
+      </Stack>
+    </ElementWrapper>
   );
 }

--- a/insight-fe/src/components/lesson/slide/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideSequencer.tsx
@@ -21,6 +21,7 @@ import { useSlideDnD } from "@/hooks/useSlideDnD";
 import {
   defaultColumnWrapperStyles,
   defaultBoardWrapperStyles,
+  defaultSlideWrapperStyles,
 } from "../defaultStyles";
 import { ElementWrapperStyles } from "../elements/ElementWrapper";
 
@@ -33,6 +34,8 @@ export interface SlideBoard {
 export interface Slide {
   id: string;
   title: string;
+  wrapperStyles?: ElementWrapperStyles;
+  spacing?: number;
   columnMap: ColumnMap<SlideElementDnDItemProps>;
   boards: SlideBoard[];
 }
@@ -106,14 +109,14 @@ function SlideItem({
               input,
               element,
               allowedEdges: ["top", "bottom"],
-            }
+            },
           ),
         onDragEnter: (args) =>
           setClosestEdge(extractClosestEdge(args.self.data)),
         onDrag: (args) => setClosestEdge(extractClosestEdge(args.self.data)),
         onDragLeave: () => setClosestEdge(null),
         onDrop: () => setClosestEdge(null),
-      })
+      }),
     );
   }, [instanceId, slide.id]);
 
@@ -161,6 +164,8 @@ export default function SlideSequencer({
         {
           id,
           title: `Slide ${s.length + 1}`,
+          wrapperStyles: { ...defaultSlideWrapperStyles },
+          spacing: 4,
           columnMap: initial.columnMap,
           boards: initial.boards,
         },


### PR DESCRIPTION
## Summary
- add `defaultSlideWrapperStyles`
- support slide wrapper styles and spacing in lesson editor
- add `SlideAttributesPane` to edit slide styles
- update preview, canvases, and state hooks to handle slide styling

## Testing
- `npm run build` *(fails: `next` not found)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846906c8f4083268732747e641b59c2