### PR TITLE
Update ColorPaletteModal

### DIFF
--- a/insight-fe/src/components/lesson/StyleModals.tsx
+++ b/insight-fe/src/components/lesson/StyleModals.tsx
@@ -2,7 +2,7 @@
 
 import LoadStyleModal from "./modals/LoadStyleModal";
 import SaveStyleModal from "./modals/SaveStyleModal";
-import AddColorPaletteModal from "./modals/AddColorPaletteModal";
+import ColorPaletteModal from "./modals/AddColorPaletteModal";
 
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
@@ -62,7 +62,7 @@ export default function StyleModals({
         onLoad={onLoad}
       />
       {selectedCollectionId !== "" && (
-        <AddColorPaletteModal
+        <ColorPaletteModal
           isOpen={isPaletteOpen}
           onClose={closePalette}
           collectionId={selectedCollectionId as number}


### PR DESCRIPTION
## Summary
- extend modal to allow editing color palettes
- reset fields on open
- switch between create and update mutation
- rename exported component to `ColorPaletteModal`
- update usages

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684690995bf08326b4a3a741bd8d9393