### PR TITLE
Load palette details in update modal

### DIFF
--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -154,6 +154,16 @@ export const GET_COLOR_PALETTES = gql`
   }
 `;
 
+export const GET_COLOR_PALETTE = gql`
+  query GetColorPalette($id: String!) {
+    getColorPalette(data: { id: $id }) {
+      id
+      name
+      colors
+    }
+  }
+`;
+
 export const CREATE_COLOR_PALETTE = gql`
   mutation CreateColorPalette($data: CreateColorPaletteInput!) {
     createColorPalette(data: $data) {


### PR DESCRIPTION
## Summary
- fetch a color palette by id
- preload palette values when editing

## Testing
- `npm --prefix insight-fe run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846ae6b7df08326af8ffe71c192b526