### PR TITLE
Fix palette modal loading

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -90,7 +90,12 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
 
   useEffect(() => {
     if (collectionsData?.getAllStyleCollection) {
-      setStyleCollections(collectionsData.getAllStyleCollection);
+      setStyleCollections(
+        collectionsData.getAllStyleCollection.map((c: any) => ({
+          id: Number(c.id),
+          name: c.name,
+        }))
+      );
     }
   }, [collectionsData]);
 
@@ -128,7 +133,12 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
 
   useEffect(() => {
     if (groupsData?.getAllStyleGroup) {
-      setStyleGroups(groupsData.getAllStyleGroup);
+      setStyleGroups(
+        groupsData.getAllStyleGroup.map((g: any) => ({
+          id: Number(g.id),
+          name: g.name,
+        }))
+      );
     } else {
       setStyleGroups([]);
     }
@@ -154,7 +164,13 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
 
   useEffect(() => {
     if (palettesData?.getAllColorPalette) {
-      setColorPalettes(palettesData.getAllColorPalette);
+      setColorPalettes(
+        palettesData.getAllColorPalette.map((p: any) => ({
+          id: Number(p.id),
+          name: p.name,
+          colors: p.colors,
+        }))
+      );
     } else {
       setColorPalettes([]);
     }
@@ -165,7 +181,12 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     name: string;
     colors: string[];
   }) => {
-    setColorPalettes((p) => p.map((pl) => (pl.id === palette.id ? palette : pl)));
+    const normalized = {
+      id: Number(palette.id),
+      name: palette.name,
+      colors: palette.colors,
+    };
+    setColorPalettes((p) => p.map((pl) => (pl.id === normalized.id ? normalized : pl)));
     await fetchPalettes({
       variables: { collectionId: String(selectedCollectionId) },
     });
@@ -176,7 +197,10 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     name: string;
     colors: string[];
   }) => {
-    setColorPalettes((p) => [...p, palette]);
+    setColorPalettes((p) => [
+      ...p,
+      { id: Number(palette.id), name: palette.name, colors: palette.colors },
+    ]);
     await fetchPalettes({
       variables: { collectionId: String(selectedCollectionId) },
     });

--- a/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
@@ -105,7 +105,11 @@ export default function ColorPaletteModal({
                   },
                 });
                 if (data?.updateColorPalette) {
-                  onSave?.(data.updateColorPalette);
+                  onSave?.({
+                    id: Number(data.updateColorPalette.id),
+                    name: data.updateColorPalette.name,
+                    colors: data.updateColorPalette.colors,
+                  });
                 }
               } else {
                 const { data } = await createPalette({
@@ -114,7 +118,11 @@ export default function ColorPaletteModal({
                   },
                 });
                 if (data?.createColorPalette) {
-                  onSave?.(data.createColorPalette);
+                  onSave?.({
+                    id: Number(data.createColorPalette.id),
+                    name: data.createColorPalette.name,
+                    colors: data.createColorPalette.colors,
+                  });
                   setName("");
                   setColors(["#000000"]);
                 }

--- a/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
@@ -245,7 +245,7 @@ export default function SlideToolbar({
           });
           if (data?.createStyleCollection) {
             onAddCollection({
-              id: data.createStyleCollection.id,
+              id: Number(data.createStyleCollection.id),
               name: data.createStyleCollection.name,
             });
           }
@@ -304,7 +304,7 @@ export default function SlideToolbar({
           });
           if (data?.createStyleGroup) {
             onAddGroup({
-              id: data.createStyleGroup.id,
+              id: Number(data.createStyleGroup.id),
               name: data.createStyleGroup.name,
             });
           }


### PR DESCRIPTION
## Summary
- load IDs as numbers when fetching collections, groups, and palettes
- normalize IDs when creating palette/collection/group
- keep palette edits displaying values in update modal

## Testing
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6846b19444b0832697eaa8186dc2227b