### PR TITLE
Add Theme module

### DIFF
--- a/insight-be/src/app.module.ts
+++ b/insight-be/src/app.module.ts
@@ -52,6 +52,8 @@ import { StyleCollectionEntity } from './modules/timbuktu/administrative/style-c
 import { StyleEntity } from './modules/timbuktu/administrative/style/style.entity';
 import { StyleGroupEntity } from './modules/timbuktu/administrative/style-group/style-group.entity';
 import { ColorPaletteEntity } from './modules/timbuktu/administrative/color-palette/color-palette.entity';
+import { ThemeModule } from './modules/timbuktu/administrative/theme/theme.module';
+import { ThemeEntity } from './modules/timbuktu/administrative/theme/theme.entity';
 
 @Module({
   imports: [
@@ -95,6 +97,7 @@ import { ColorPaletteEntity } from './modules/timbuktu/administrative/color-pale
         StyleEntity,
         StyleGroupEntity,
         ColorPaletteEntity,
+        ThemeEntity,
       ],
       synchronize: true,
     }),
@@ -118,6 +121,7 @@ import { ColorPaletteEntity } from './modules/timbuktu/administrative/color-pale
     StyleModule,
     StyleGroupModule,
     ColorPaletteModule,
+    ThemeModule,
     ClassModule,
     LessonModule,
     QuizModule,

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
@@ -1,0 +1,34 @@
+import { Column, Entity, ManyToOne, JoinColumn, RelationId } from 'typeorm';
+import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { AbstractBaseEntity } from 'src/common/base.entity';
+import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
+import { ColorPaletteEntity } from '../color-palette/color-palette.entity';
+
+@ObjectType()
+@Entity('themes')
+export class ThemeEntity extends AbstractBaseEntity {
+  @Field()
+  @Column()
+  name: string;
+
+  @Field(() => StyleCollectionEntity)
+  @ManyToOne(() => StyleCollectionEntity, { nullable: false })
+  @JoinColumn({ name: 'collection_id' })
+  styleCollection!: StyleCollectionEntity;
+
+  @Field(() => ID)
+  @Column({ name: 'collection_id' })
+  @RelationId((theme: ThemeEntity) => theme.styleCollection)
+  styleCollectionId!: number;
+
+  @Field(() => ColorPaletteEntity)
+  @ManyToOne(() => ColorPaletteEntity, { nullable: false })
+  @JoinColumn({ name: 'default_palette_id' })
+  defaultPalette!: ColorPaletteEntity;
+
+  @Field(() => ID)
+  @Column({ name: 'default_palette_id' })
+  @RelationId((theme: ThemeEntity) => theme.defaultPalette)
+  defaultPaletteId!: number;
+
+}

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.inputs.ts
@@ -1,0 +1,21 @@
+import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
+import { HasRelationsInput } from 'src/common/base.inputs';
+
+@InputType()
+export class CreateThemeInput extends HasRelationsInput {
+  @Field()
+  name: string;
+
+  @Field(() => ID)
+  styleCollectionId: number;
+
+  @Field(() => ID)
+  defaultPaletteId: number;
+
+}
+
+@InputType()
+export class UpdateThemeInput extends PartialType(CreateThemeInput) {
+  @Field(() => ID)
+  id: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ThemeEntity } from './theme.entity';
+import { ThemeResolver } from './theme.resolver';
+import { ThemeService } from './theme.service';
+import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
+import { ColorPaletteEntity } from '../color-palette/color-palette.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([ThemeEntity, StyleCollectionEntity, ColorPaletteEntity]),
+  ],
+  providers: [ThemeService, ThemeResolver],
+  exports: [ThemeService],
+})
+export class ThemeModule {}

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.resolver.ts
@@ -1,0 +1,30 @@
+import { Resolver } from '@nestjs/graphql';
+import { createBaseResolver } from 'src/common/base.resolver';
+import { ThemeEntity } from './theme.entity';
+import { CreateThemeInput, UpdateThemeInput } from './theme.inputs';
+import { ThemeService } from './theme.service';
+
+const BaseThemeResolver = createBaseResolver<
+  ThemeEntity,
+  CreateThemeInput,
+  UpdateThemeInput
+>(ThemeEntity, CreateThemeInput, UpdateThemeInput, {
+  queryName: 'Theme',
+  stableKeyPrefix: 'theme',
+  enabledOperations: [
+    'findAll',
+    'findOne',
+    'findOneBy',
+    'create',
+    'update',
+    'remove',
+    'search',
+  ],
+});
+
+@Resolver(() => ThemeEntity)
+export class ThemeResolver extends BaseThemeResolver {
+  constructor(private readonly themeService: ThemeService) {
+    super(themeService);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.service.ts
@@ -1,0 +1,49 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BaseService } from 'src/common/base.service';
+import { ThemeEntity } from './theme.entity';
+import { CreateThemeInput, UpdateThemeInput } from './theme.inputs';
+
+@Injectable()
+export class ThemeService extends BaseService<
+  ThemeEntity,
+  CreateThemeInput,
+  UpdateThemeInput
+> {
+  constructor(
+    @InjectRepository(ThemeEntity) themeRepository: Repository<ThemeEntity>,
+    @InjectDataSource() dataSource: DataSource,
+  ) {
+    super(themeRepository, dataSource);
+  }
+
+  async create(data: CreateThemeInput): Promise<ThemeEntity> {
+    const { styleCollectionId, defaultPaletteId, relationIds = [], ...rest } = data;
+    const relations = [
+      ...relationIds,
+      { relation: 'styleCollection', ids: [styleCollectionId] },
+      { relation: 'defaultPalette', ids: [defaultPaletteId] },
+    ];
+    return super.create({ ...rest, relationIds: relations } as any);
+  }
+
+  async update(data: UpdateThemeInput): Promise<ThemeEntity> {
+    const {
+      styleCollectionId,
+      defaultPaletteId,
+      relationIds = [],
+      ...rest
+    } = data;
+    const relations = [
+      ...relationIds,
+      ...(styleCollectionId
+        ? [{ relation: 'styleCollection', ids: [styleCollectionId] }]
+        : []),
+      ...(defaultPaletteId
+        ? [{ relation: 'defaultPalette', ids: [defaultPaletteId] }]
+        : []),
+    ];
+    return super.update({ ...rest, relationIds: relations } as any);
+  }
+}


### PR DESCRIPTION
## Summary
- implement ThemeEntity and CRUD infrastructure
- wire ThemeModule and ThemeEntity into AppModule
- remove unused font fields from `Theme`

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846d8f41fd08326b1cea91678b8fff7