### PR TITLE
Add theme GQL operations

### DIFF
--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -189,3 +189,58 @@ export const DELETE_COLOR_PALETTE = gql`
     deleteColorPalette(data: $data)
   }
 `;
+
+export const GET_THEMES = gql`
+  query GetThemes($collectionId: String!) {
+    getAllTheme(
+      data: {
+        all: true
+        filters: [{ column: "styleCollectionId", value: $collectionId }]
+      }
+    ) {
+      id
+      name
+      styleCollectionId
+      defaultPaletteId
+    }
+  }
+`;
+
+export const GET_THEME = gql`
+  query GetTheme($id: String!) {
+    getTheme(data: { id: $id }) {
+      id
+      name
+      styleCollectionId
+      defaultPaletteId
+    }
+  }
+`;
+
+export const CREATE_THEME = gql`
+  mutation CreateTheme($data: CreateThemeInput!) {
+    createTheme(data: $data) {
+      id
+      name
+      styleCollectionId
+      defaultPaletteId
+    }
+  }
+`;
+
+export const UPDATE_THEME = gql`
+  mutation UpdateTheme($data: UpdateThemeInput!) {
+    updateTheme(data: $data) {
+      id
+      name
+      styleCollectionId
+      defaultPaletteId
+    }
+  }
+`;
+
+export const DELETE_THEME = gql`
+  mutation DeleteTheme($data: IdInput!) {
+    deleteTheme(data: $data)
+  }
+`;


### PR DESCRIPTION
## Summary
- extend `lesson.ts` with CRUD gql operations for themes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` in `insight-fe` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846dc76ed288326944564090ce0ed34