### PR TITLE
Add theme selection for lesson builder

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
@@ -5,6 +5,7 @@ import {
   ManyToOne,
   ManyToMany,
   JoinTable,
+  JoinColumn,
   RelationId,
   OneToMany,
 } from 'typeorm';
@@ -19,6 +20,7 @@ import { SubjectEntity } from '../subject/subject.entity';
 import { EducatorProfileDto } from '../../user-profiles/educator-profile/dto/educator-profile.dto';
 import { MultipleChoiceQuestionEntity } from '../multiple-choice-question/multiple-choice-question.entity';
 import { QuizEntity } from '../quiz/quiz.entity';
+import { ThemeEntity } from '../theme/theme.entity';
 
 @ObjectType()
 @Entity('lessons')
@@ -34,6 +36,18 @@ export class LessonEntity extends AbstractBaseEntity {
   @Field(() => GraphQLJSONObject, { nullable: true })
   @Column({ type: 'jsonb', nullable: true })
   content?: Record<string, any>;
+
+  /* ---------- theme ---------- */
+
+  @Field(() => ThemeEntity, { nullable: true })
+  @ManyToOne(() => ThemeEntity, { nullable: true })
+  @JoinColumn({ name: 'theme_id' })
+  theme?: ThemeEntity;
+
+  @Field(() => ID, { nullable: true })
+  @Column({ name: 'theme_id', nullable: true })
+  @RelationId((lesson: LessonEntity) => lesson.theme)
+  themeId?: number;
 
   /* ---------- relationships ---------- */
 

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
@@ -13,6 +13,9 @@ export class CreateLessonInput extends HasRelationsInput {
   @Field(() => GraphQLJSONObject, { nullable: true })
   content?: Record<string, any>;
 
+  @Field(() => ID, { nullable: true })
+  themeId?: number;
+
   @Field(() => [ID], { nullable: 'itemsAndList' })
   recommendedYearGroupIds?: number[];
 

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -45,12 +45,14 @@ export const LessonBuilderPageClient = () => {
   }) => {
     if (!yearGroupId || !subjectId || !topicId) return;
     const content = editorRef.current?.getContent() ?? { slides: [] };
+    const themeId = editorRef.current?.getThemeId() ?? null;
     await createLesson({
       variables: {
         data: {
           title,
           description: description.length > 0 ? description : null,
           content,
+          themeId: themeId ? Number(themeId) : undefined,
           recommendedYearGroupIds: [Number(yearGroupId)],
           relationIds: [
             { relation: "subject", ids: [Number(subjectId)] },

--- a/insight-fe/src/components/lesson/hooks/useDnDHandlers.ts
+++ b/insight-fe/src/components/lesson/hooks/useDnDHandlers.ts
@@ -6,9 +6,15 @@ import { availableFonts } from "@/theme/fonts";
 import { defaultColumnWrapperStyles } from "../defaultStyles";
 import type { LessonState, Action } from "./useLessonSelection";
 
+interface Options {
+  defaultColor: string;
+  defaultFontFamily: string;
+}
+
 export default function useDnDHandlers(
   state: LessonState,
-  dispatch: React.Dispatch<Action>
+  dispatch: React.Dispatch<Action>,
+  options: Options
 ) {
   const handleDropElement = useCallback(
     (e: React.DragEvent<HTMLDivElement>) => {
@@ -46,9 +52,9 @@ export default function useDnDHandlers(
                   ? {
                       text: "Sample Text",
                       styles: {
-                        color: "#000000",
+                        color: options.defaultColor,
                         fontSize: "16px",
-                        fontFamily: availableFonts[0].fontFamily,
+                        fontFamily: options.defaultFontFamily,
                         fontWeight: "normal",
                         lineHeight: "1.2",
                         textAlign: "left",
@@ -103,7 +109,7 @@ export default function useDnDHandlers(
       });
       dispatch({ type: "setDropIndicator", indicator: null });
     },
-    [state.selectedSlideId, dispatch]
+    [state.selectedSlideId, dispatch, options.defaultColor, options.defaultFontFamily]
   );
 
   const handleDragOver = useCallback(

--- a/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
+++ b/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
@@ -4,13 +4,20 @@ import type { LessonEditorHandle } from "./useLessonSelection";
 import { useLessonSelection } from "./useLessonSelection";
 import useBoardColumnHelpers from "./useBoardColumnHelpers";
 import useDnDHandlers from "./useDnDHandlers";
+import { availableFonts } from "@/theme/fonts";
 
 export { LessonEditorHandle } from "./useLessonSelection";
 
-export function useLessonEditorState(ref?: React.Ref<LessonEditorHandle>) {
+export function useLessonEditorState(
+  ref?: React.Ref<LessonEditorHandle>,
+  options?: { defaultColor: string; defaultFontFamily: string }
+) {
   const selection = useLessonSelection(ref);
   const boardHelpers = useBoardColumnHelpers(selection.state, selection.dispatch);
-  const dndHandlers = useDnDHandlers(selection.state, selection.dispatch);
+  const dndHandlers = useDnDHandlers(selection.state, selection.dispatch, {
+    defaultColor: options?.defaultColor ?? "#000000",
+    defaultFontFamily: options?.defaultFontFamily ?? availableFonts[0].fontFamily,
+  });
 
   return {
     state: selection.state,

--- a/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
@@ -37,8 +37,11 @@ interface SlideToolbarProps {
   styleCollections: { id: number; name: string }[];
   styleGroups: { id: number; name: string }[];
   colorPalettes: { id: number; name: string; colors: string[] }[];
+  themes: { id: number; name: string }[];
   selectedCollectionId: number | "";
   onSelectCollection: (id: number | "") => void;
+  selectedThemeId: number | "";
+  onSelectTheme: (id: number | "") => void;
   selectedPaletteId: number | "";
   onSelectPalette: (id: number | "") => void;
   selectedElementType: string | null;
@@ -60,10 +63,13 @@ interface SlideToolbarProps {
 export default function SlideToolbar({
   availableElements,
   styleCollections,
+  themes,
   styleGroups,
   colorPalettes,
   selectedCollectionId,
   onSelectCollection,
+  selectedThemeId,
+  onSelectTheme,
   selectedPaletteId,
   onSelectPalette,
   selectedElementType,
@@ -132,6 +138,12 @@ export default function SlideToolbar({
     () => colorPalettes.map((p) => ({ label: p.name, value: String(p.id) })),
     [colorPalettes]
   );
+  const selectedTheme =
+    selectedThemeId !== "" ? themes.find((t) => t.id === selectedThemeId) : undefined;
+  const themeOptions = useMemo(
+    () => themes.map((t) => ({ label: t.name, value: String(t.id) })),
+    [themes]
+  );
   return (
     <>
       <Box p={4} borderWidth="1px" borderRadius="md">
@@ -166,6 +178,16 @@ export default function SlideToolbar({
             onDelete={() => setIsDeleteCollectionOpen(true)}
             isUpdateDisabled={selectedCollectionId === ""}
             isDeleteDisabled={selectedCollectionId === ""}
+          />
+          <CrudDropdown
+            options={themeOptions}
+            value={selectedThemeId}
+            onChange={(e) =>
+              onSelectTheme(
+                e.target.value === "" ? "" : parseInt(e.target.value, 10)
+              )
+            }
+            isDisabled={selectedCollectionId === ""}
           />
           <CrudDropdown
             options={paletteOptions}


### PR DESCRIPTION
## Summary
- support persisting a lesson's theme
- allow selecting a theme when editing
- apply theme palette colour to new elements

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in insight-fe *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6846f587e2408326adc6f4402a712869