### PR TITLE
Load lesson theme on builder page

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -110,6 +110,11 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         editor.selectSlide(slides[0]?.id ?? null);
       },
       getThemeId: () => selectedThemeId,
+      setTheme: (theme: { id: number; styleCollectionId: number; defaultPaletteId: number }) => {
+        setSelectedCollectionId(theme.styleCollectionId);
+        setSelectedThemeId(theme.id);
+        setSelectedPaletteId(theme.defaultPaletteId);
+      },
     }),
     [editor.state.slides, selectedThemeId, editor.setSlides, editor.selectSlide],
   );

--- a/insight-fe/src/components/lesson/hooks/useLessonSelection.ts
+++ b/insight-fe/src/components/lesson/hooks/useLessonSelection.ts
@@ -7,6 +7,8 @@ import { Slide, createInitialBoard } from "../slide/SlideSequencer";
 export interface LessonEditorHandle {
   getContent: () => { slides: Slide[] };
   setContent: (slides: Slide[]) => void;
+  setTheme?: (theme: { id: number; styleCollectionId: number; defaultPaletteId: number }) => void;
+  getThemeId?: () => number | "";
 }
 
 export interface LessonState {

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -137,6 +137,7 @@ export const GET_LESSON = gql`
     getLesson(data: $data) {
       id
       title
+      themeId
       content
     }
   }


### PR DESCRIPTION
## Summary
- load theme info when fetching a lesson
- expose `setTheme` through `LessonEditor` ref
- update GraphQL query to include theme id

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846f92280e883269f4766f929b2e21b