### PR TITLE
Fix editor initialization

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -76,13 +76,6 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
   );
   const [selectedGroupId, setSelectedGroupId] = useState<number | "">("");
 
-  // Sync toolbar element type with the currently selected element on the canvas
-  useEffect(() => {
-    if (editor.selectedElement && selectedCollectionId !== "") {
-      setSelectedElementType(editor.selectedElement.type);
-    }
-  }, [editor.selectedElement, selectedCollectionId]);
-
   const [fetchStyles, { data: stylesData }] = useLazyQuery(
     GET_STYLES_WITH_CONFIG_BY_GROUP,
     { fetchPolicy: "network-only" }
@@ -100,6 +93,13 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     defaultColor: selectedPalette?.colors[0] ?? "#000000",
     defaultFontFamily: availableFonts[0].fontFamily,
   });
+
+  // Sync toolbar element type with the currently selected element on the canvas
+  useEffect(() => {
+    if (editor.selectedElement && selectedCollectionId !== "") {
+      setSelectedElementType(editor.selectedElement.type);
+    }
+  }, [editor.selectedElement, selectedCollectionId]);
 
   useImperativeHandle(
     ref,

--- a/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
+++ b/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
@@ -6,7 +6,7 @@ import useBoardColumnHelpers from "./useBoardColumnHelpers";
 import useDnDHandlers from "./useDnDHandlers";
 import { availableFonts } from "@/theme/fonts";
 
-export { LessonEditorHandle } from "./useLessonSelection";
+export type { LessonEditorHandle } from "./useLessonSelection";
 
 export function useLessonEditorState(
   ref?: React.Ref<LessonEditorHandle>,


### PR DESCRIPTION
## Summary
- fix runtime crash from referencing `editor` before it is defined
- correctly re-export `LessonEditorHandle` as a type

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847debabdcc8326b038f9e7cbed9c96