### PR TITLE
Fix missing Accordion context

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -12,6 +12,7 @@ import {
   Select,
   Stack,
   Text,
+  Accordion,
 } from "@chakra-ui/react";
 import { useQuery, useLazyQuery, useMutation } from "@apollo/client";
 
@@ -156,29 +157,31 @@ export default function ThemeBuilderPageClient() {
         Add Palette
       </Button>
 
-      <WrapperSettings
-        attrs={wrapperAttrs}
-        colorPalettes={colorPalettes}
-        selectedPaletteId={selectedPaletteId}
-      />
-      <TextAttributes
-        text={text}
-        setText={setText}
-        color={color}
-        setColor={setColor}
-        fontSize={fontSize}
-        setFontSize={setFontSize}
-        fontFamily={fontFamily}
-        setFontFamily={setFontFamily}
-        fontWeight={fontWeight}
-        setFontWeight={setFontWeight}
-        lineHeight={lineHeight}
-        setLineHeight={setLineHeight}
-        textAlign={textAlign}
-        setTextAlign={setTextAlign}
-        colorPalettes={colorPalettes}
-        selectedPaletteId={selectedPaletteId}
-      />
+      <Accordion allowMultiple>
+        <WrapperSettings
+          attrs={wrapperAttrs}
+          colorPalettes={colorPalettes}
+          selectedPaletteId={selectedPaletteId}
+        />
+        <TextAttributes
+          text={text}
+          setText={setText}
+          color={color}
+          setColor={setColor}
+          fontSize={fontSize}
+          setFontSize={setFontSize}
+          fontFamily={fontFamily}
+          setFontFamily={setFontFamily}
+          fontWeight={fontWeight}
+          setFontWeight={setFontWeight}
+          lineHeight={lineHeight}
+          setLineHeight={setLineHeight}
+          textAlign={textAlign}
+          setTextAlign={setTextAlign}
+          colorPalettes={colorPalettes}
+          selectedPaletteId={selectedPaletteId}
+        />
+      </Accordion>
 
       <Box>
         <Text mb={2}>Preview</Text>


### PR DESCRIPTION
## Summary
- wrap theme builder settings with `<Accordion>` so nested accordion items receive context

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6847e0bcbce88326b5846d0c3f158c4f