### PR TITLE
Fix palette edit modal

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -348,14 +348,16 @@ export default function ThemeBuilderPageClient() {
         />
       )}
 
-      {isEditPaletteOpen && selectedPalette && (
+      {isEditPaletteOpen && (
         <AddColorPaletteModal
           isOpen={isEditPaletteOpen}
           onClose={() => setIsEditPaletteOpen(false)}
           collectionId={selectedCollectionId as number}
-          paletteId={selectedPaletteId as number}
-          initialName={selectedPalette.name}
-          initialColors={selectedPalette.colors}
+          paletteId={
+            selectedPaletteId === "" ? undefined : (selectedPaletteId as number)
+          }
+          initialName={selectedPalette?.name ?? ""}
+          initialColors={selectedPalette?.colors ?? []}
           title="Update Color Palette"
           confirmLabel="Update"
           onSave={(palette) => {


### PR DESCRIPTION
## Summary
- allow palette edit modal to open even if selected palette data isn't immediately available

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684836107d108326ae99625aedc108e0