### PR TITLE
Remove palette dropdown from theme builder pane

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -187,25 +187,6 @@ export default function ThemeBuilderPageClient() {
             isDeleteDisabled={selectedCollectionId === ""}
           />
         </FormControl>
-        <FormControl flex={1} isDisabled={selectedCollectionId === ""}>
-          <FormLabel>Default Palette</FormLabel>
-          <CrudDropdown
-            options={paletteOptions}
-            value={selectedPaletteId}
-            onChange={(e) =>
-              setSelectedPaletteId(
-                e.target.value === "" ? "" : parseInt(e.target.value, 10),
-              )
-            }
-            onCreate={() => setIsAddPaletteOpen(true)}
-            onUpdate={() => setIsEditPaletteOpen(true)}
-            onDelete={() => setIsDeletePaletteOpen(true)}
-            isDisabled={selectedCollectionId === ""}
-            isCreateDisabled={selectedCollectionId === ""}
-            isUpdateDisabled={selectedPaletteId === ""}
-            isDeleteDisabled={selectedPaletteId === ""}
-          />
-        </FormControl>
       </HStack>
 
       <Accordion allowMultiple>


### PR DESCRIPTION
## Summary
- remove the default palette dropdown from the Theme Builder attribute panel

## Testing
- `npm test` *(fails: Missing script)*
- `npm test` in `insight-be` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68483ce705508326985e193a2fd2e61e