### PR TITLE
Add editable table component

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -1,13 +1,25 @@
 import ElementWrapper, {
   ElementWrapperStyles,
 } from "@/components/lesson/elements/ElementWrapper";
-import { Box, Text, Table, Thead, Tbody, Tr, Th, Td } from "@chakra-ui/react";
+import { Box, Text, Table, Tbody, Tr, Td } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 
 export interface ElementAnimation {
   type: "flyInFade";
   direction: "left" | "right" | "top" | "bottom";
   delay: number;
+}
+
+export interface TableCell {
+  text: string;
+  styles?: {
+    color?: string;
+    fontSize?: string;
+    fontFamily?: string;
+    fontWeight?: string;
+    lineHeight?: string;
+    textAlign?: string;
+  };
 }
 
 export interface SlideElementDnDItemProps {
@@ -42,6 +54,14 @@ export interface SlideElementDnDItemProps {
     options: string[];
     correctAnswer: string;
   }[];
+  /**
+   * Table configuration when type is "table"
+   */
+  table?: {
+    rows: number;
+    cols: number;
+    cells: TableCell[][];
+  };
   styles?: {
     color?: string;
     fontSize?: string;
@@ -129,17 +149,25 @@ export const SlideElementDnDItem = ({
     content = (
       <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Table size="sm">
-          <Thead>
-            <Tr>
-              <Th>Header 1</Th>
-              <Th>Header 2</Th>
-            </Tr>
-          </Thead>
           <Tbody>
-            <Tr>
-              <Td>Cell</Td>
-              <Td>Cell</Td>
-            </Tr>
+            {item.table?.cells.map((row, rIdx) => (
+              <Tr key={rIdx}>
+                {row.map((cell, cIdx) => (
+                  <Td key={cIdx} p={1}>
+                    <Text
+                      color={cell.styles?.color}
+                      fontSize={cell.styles?.fontSize}
+                      fontFamily={cell.styles?.fontFamily}
+                      fontWeight={cell.styles?.fontWeight}
+                      lineHeight={cell.styles?.lineHeight}
+                      textAlign={cell.styles?.textAlign as any}
+                    >
+                      {cell.text}
+                    </Text>
+                  </Td>
+                ))}
+              </Tr>
+            ))}
           </Tbody>
         </Table>
       </ElementWrapper>

--- a/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
@@ -10,6 +10,7 @@ import AnimationSettings from "../attributes/AnimationSettings";
 import ImageAttributes from "../attributes/ImageAttributes";
 import TextAttributes from "../attributes/TextAttributes";
 import VideoAttributes from "../attributes/VideoAttributes";
+import TableAttributes from "../attributes/TableAttributes";
 import WrapperSettings from "../attributes/WrapperSettings";
 import useStyleAttributes from "../hooks/useStyleAttributes";
 
@@ -51,6 +52,15 @@ export default function ElementAttributesPane({
   const [description, setDescription] = useState(element.description || "");
   const [questions, setQuestions] = useState(
     element.questions || ([] as SlideElementDnDItemProps["questions"])
+  );
+  const [table, setTable] = useState(
+    element.table || {
+      rows: 2,
+      cols: 2,
+      cells: Array.from({ length: 2 }, () =>
+        Array.from({ length: 2 }, () => ({ text: "", styles: { color: "#000000" } }))
+      ),
+    }
   );
   const [isQuizModalOpen, setIsQuizModalOpen] = useState(false);
   const styleAttrs = useStyleAttributes({
@@ -111,6 +121,15 @@ export default function ElementAttributesPane({
     setTitle(element.title || "");
     setDescription(element.description || "");
     setQuestions(element.questions || []);
+    setTable(
+      element.table || {
+        rows: 2,
+        cols: 2,
+        cells: Array.from({ length: 2 }, () =>
+          Array.from({ length: 2 }, () => ({ text: "", styles: { color: "#000000" } }))
+        ),
+      }
+    );
     setAnimationEnabled(!!element.animation);
     setAnimationDirection(element.animation?.direction || "left");
     setAnimationDelay(element.animation?.delay ?? 0);
@@ -165,6 +184,9 @@ export default function ElementAttributesPane({
       updated.description = description;
       updated.questions = questions;
     }
+    if (element.type === "table") {
+      updated.table = table;
+    }
     onChange(updated);
   }, [
     color,
@@ -179,6 +201,7 @@ export default function ElementAttributesPane({
     title,
     description,
     questions,
+    table,
     bgColor,
     bgOpacity,
     gradientFrom,
@@ -239,6 +262,14 @@ export default function ElementAttributesPane({
         )}
         {element.type === "video" && (
           <VideoAttributes url={url} setUrl={setUrl} />
+        )}
+        {element.type === "table" && (
+          <TableAttributes
+            table={table}
+            setTable={setTable}
+            colorPalettes={colorPalettes}
+            selectedPaletteId={selectedPaletteId}
+          />
         )}
         {element.type === "quiz" && (
           <QuizAttributes

--- a/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import {
+  AccordionItem,
+  AccordionButton,
+  AccordionPanel,
+  AccordionIcon,
+  Box,
+  FormControl,
+  FormLabel,
+  Input,
+  Stack,
+  SimpleGrid,
+} from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import PaletteColorPicker from "../PaletteColorPicker";
+import { TableCell } from "@/components/DnD/cards/SlideElementDnDCard";
+
+interface TableAttributesProps {
+  table: {
+    rows: number;
+    cols: number;
+    cells: TableCell[][];
+  };
+  setTable: (table: { rows: number; cols: number; cells: TableCell[][] }) => void;
+  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  selectedPaletteId?: number | "";
+}
+
+export default function TableAttributes({
+  table,
+  setTable,
+  colorPalettes,
+  selectedPaletteId,
+}: TableAttributesProps) {
+  const [rows, setRows] = useState(table.rows);
+  const [cols, setCols] = useState(table.cols);
+  const [cells, setCells] = useState<TableCell[][]>(table.cells);
+
+  useEffect(() => {
+    setRows(table.rows);
+    setCols(table.cols);
+    setCells(table.cells);
+  }, [table.rows, table.cols, table.cells]);
+
+  // adjust cell matrix when rows/cols change
+  useEffect(() => {
+    setCells((prev) => {
+      const newRows = Array.from({ length: rows }, (_, r) =>
+        Array.from({ length: cols }, (_, c) => prev[r]?.[c] || { text: "", styles: { color: "#000000" } })
+      );
+      return newRows;
+    });
+  }, [rows, cols]);
+
+  useEffect(() => {
+    setTable({ rows, cols, cells });
+  }, [rows, cols, cells, setTable]);
+
+  const paletteColors =
+    colorPalettes?.find((p) => Number(p.id) === Number(selectedPaletteId))?.colors ?? [];
+
+  const updateCell = (r: number, c: number, cell: TableCell) => {
+    setCells((prev) => {
+      const next = prev.map((row) => row.slice());
+      next[r][c] = cell;
+      return next;
+    });
+  };
+
+  return (
+    <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>
+      <h2>
+        <AccordionButton>
+          <Box flex="1" textAlign="left">Table</Box>
+          <AccordionIcon />
+        </AccordionButton>
+      </h2>
+      <AccordionPanel pb={2}>
+        <Stack spacing={2}>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Rows
+            </FormLabel>
+            <Input
+              size="sm"
+              type="number"
+              w="60px"
+              min={1}
+              value={rows}
+              onChange={(e) => setRows(Math.max(1, parseInt(e.target.value) || 1))}
+            />
+          </FormControl>
+          <FormControl display="flex" alignItems="center">
+            <FormLabel mb="0" fontSize="sm" w="40%">
+              Columns
+            </FormLabel>
+            <Input
+              size="sm"
+              type="number"
+              w="60px"
+              min={1}
+              value={cols}
+              onChange={(e) => setCols(Math.max(1, parseInt(e.target.value) || 1))}
+            />
+          </FormControl>
+          <SimpleGrid columns={cols} spacing={2}>
+            {cells.map((row, rIdx) =>
+              row.map((cell, cIdx) => (
+                <Stack key={`${rIdx}-${cIdx}`} spacing={1}>
+                  <Input
+                    size="sm"
+                    placeholder="Text"
+                    value={cell.text}
+                    onChange={(e) =>
+                      updateCell(rIdx, cIdx, { ...cell, text: e.target.value })
+                    }
+                  />
+                  <PaletteColorPicker
+                    value={cell.styles?.color || "#000000"}
+                    onChange={(color) =>
+                      updateCell(rIdx, cIdx, {
+                        ...cell,
+                        styles: { ...cell.styles, color },
+                      })
+                    }
+                    paletteColors={paletteColors}
+                  />
+                </Stack>
+              ))
+            )}
+          </SimpleGrid>
+        </Stack>
+      </AccordionPanel>
+    </AccordionItem>
+  );
+}

--- a/insight-fe/src/components/lesson/hooks/useDnDHandlers.ts
+++ b/insight-fe/src/components/lesson/hooks/useDnDHandlers.ts
@@ -61,11 +61,31 @@ export default function useDnDHandlers(
                       },
                     }
                   : type === "image"
-                  ? { src: "https://via.placeholder.com/150" }
+                    ? { src: "https://via.placeholder.com/150" }
                   : type === "video"
-                  ? { url: "" }
+                    ? { url: "" }
                   : type === "quiz"
-                  ? { title: "Untitled Quiz", description: "", questions: [] }
+                    ? { title: "Untitled Quiz", description: "", questions: [] }
+                  : type === "table"
+                    ? {
+                        table: {
+                          rows: 2,
+                          cols: 2,
+                          cells: Array.from({ length: 2 }, () =>
+                            Array.from({ length: 2 }, () => ({
+                              text: "Cell",
+                              styles: {
+                                color: options.defaultColor,
+                                fontSize: "14px",
+                                fontFamily: options.defaultFontFamily,
+                                fontWeight: "normal",
+                                lineHeight: "1.2",
+                                textAlign: "left",
+                              },
+                            }))
+                          ),
+                        },
+                      }
                   : {}),
                 wrapperStyles: { ...defaultColumnWrapperStyles },
                 animation: undefined,

--- a/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { Box, Text, Table, Thead, Tbody, Tr, Th, Td } from "@chakra-ui/react";
+import { Box, Text, Table, Tbody, Tr, Td } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
@@ -66,17 +66,25 @@ export default function SlideElementRenderer({
     content = (
       <ElementWrapper styles={item.wrapperStyles} data-testid="table-element">
         <Table size="sm">
-          <Thead>
-            <Tr>
-              <Th>Header 1</Th>
-              <Th>Header 2</Th>
-            </Tr>
-          </Thead>
           <Tbody>
-            <Tr>
-              <Td>Cell</Td>
-              <Td>Cell</Td>
-            </Tr>
+            {item.table?.cells.map((row, rIdx) => (
+              <Tr key={rIdx}>
+                {row.map((cell, cIdx) => (
+                  <Td key={cIdx} p={1}>
+                    <Text
+                      color={cell.styles?.color}
+                      fontSize={cell.styles?.fontSize}
+                      fontFamily={cell.styles?.fontFamily}
+                      fontWeight={cell.styles?.fontWeight}
+                      lineHeight={cell.styles?.lineHeight}
+                      textAlign={cell.styles?.textAlign as any}
+                    >
+                      {cell.text}
+                    </Text>
+                  </Td>
+                ))}
+              </Tr>
+            ))}
           </Tbody>
         </Table>
       </ElementWrapper>


### PR DESCRIPTION
## Summary
- allow table element to hold cell data
- let drag/drop handler initialize tables with default cells
- display table content in editor and preview
- expose table editing controls in attribute pane

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484643a1548326a18781e1871c9783