### PR TITLE
Add aspect ratio selection in lesson preview

### DIFF
--- a/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
@@ -31,11 +31,13 @@ export default function LessonPreviewModal({
   );
 
   const current = aspectOptions.find((o) => o.value === ratio) ?? aspectOptions[0];
+  const modalWidth = `${current.width + 32}px`;
   return (
     <BaseModal
       isOpen={isOpen}
       onClose={onClose}
-      size="6xl"
+      size="full"
+      contentProps={{ maxW: modalWidth }}
       title="Lesson Preview"
     >
       <Stack spacing={6} py={2}>

--- a/insight-fe/src/components/modals/BaseModal.tsx
+++ b/insight-fe/src/components/modals/BaseModal.tsx
@@ -8,6 +8,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalProps as ChakraModalProps,
+  ModalContentProps,
 } from "@chakra-ui/react";
 
 interface BaseModalProps
@@ -15,6 +16,8 @@ interface BaseModalProps
   title?: string;
   showCloseButton?: boolean;
   footer?: React.ReactNode;
+  /** Additional props forwarded to ModalContent */
+  contentProps?: ModalContentProps;
   children: React.ReactNode;
 }
 
@@ -25,12 +28,13 @@ export const BaseModal: React.FC<BaseModalProps> = ({
   title,
   showCloseButton = true,
   footer,
+  contentProps,
   children,
 }) => {
   return (
     <Modal isOpen={isOpen} onClose={onClose} size={size} isCentered>
       <ModalOverlay />
-      <ModalContent>
+      <ModalContent {...contentProps}>
         {title && <ModalHeader>{title}</ModalHeader>}
         {showCloseButton && <ModalCloseButton />}
         <ModalBody>{children}</ModalBody>


### PR DESCRIPTION
## Summary
- allow choosing aspect ratio in lesson preview modal
- render slide previews inside containers for selected device sizes

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68484b8dd2348326a821a054a458f95c