### PR TITLE
Add theme token fields

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, ManyToOne, JoinColumn, RelationId } from 'typeorm';
 import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
 import { ColorPaletteEntity } from '../color-palette/color-palette.entity';
@@ -10,6 +11,14 @@ export class ThemeEntity extends AbstractBaseEntity {
   @Field()
   @Column()
   name: string;
+
+  @Field(() => GraphQLJSONObject)
+  @Column({ type: 'jsonb' })
+  foundationTokens: Record<string, any>;
+
+  @Field(() => GraphQLJSONObject)
+  @Column({ type: 'jsonb' })
+  semanticTokens: Record<string, any>;
 
   @Field(() => StyleCollectionEntity)
   @ManyToOne(() => StyleCollectionEntity, { nullable: false })
@@ -30,5 +39,9 @@ export class ThemeEntity extends AbstractBaseEntity {
   @Column({ name: 'default_palette_id' })
   @RelationId((theme: ThemeEntity) => theme.defaultPalette)
   defaultPaletteId!: number;
+
+  @Field()
+  @Column({ default: 1 })
+  version!: number;
 
 }

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.inputs.ts
@@ -1,10 +1,20 @@
 import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
 import { HasRelationsInput } from 'src/common/base.inputs';
 
 @InputType()
 export class CreateThemeInput extends HasRelationsInput {
   @Field()
   name: string;
+
+  @Field(() => GraphQLJSONObject)
+  foundationTokens: Record<string, any>;
+
+  @Field(() => GraphQLJSONObject)
+  semanticTokens: Record<string, any>;
+
+  @Field({ defaultValue: 1 })
+  version?: number;
 
   @Field(() => ID)
   styleCollectionId: number;


### PR DESCRIPTION
## Summary
- add `foundationTokens`, `semanticTokens`, and `version` to `ThemeEntity`
- expose these fields through `CreateThemeInput` and updates

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849503248808326a68f6e5050bef482