### PR TITLE
Add component variant entity

### DIFF
--- a/insight-be/src/app.module.ts
+++ b/insight-be/src/app.module.ts
@@ -54,6 +54,8 @@ import { StyleGroupEntity } from './modules/timbuktu/administrative/style-group/
 import { ColorPaletteEntity } from './modules/timbuktu/administrative/color-palette/color-palette.entity';
 import { ThemeModule } from './modules/timbuktu/administrative/theme/theme.module';
 import { ThemeEntity } from './modules/timbuktu/administrative/theme/theme.entity';
+import { ComponentVariantModule } from './modules/timbuktu/administrative/style/component-variant.module';
+import { ComponentVariantEntity } from './modules/timbuktu/administrative/style/component-variant.entity';
 
 @Module({
   imports: [
@@ -98,6 +100,7 @@ import { ThemeEntity } from './modules/timbuktu/administrative/theme/theme.entit
         StyleGroupEntity,
         ColorPaletteEntity,
         ThemeEntity,
+        ComponentVariantEntity,
       ],
       synchronize: true,
     }),
@@ -122,6 +125,7 @@ import { ThemeEntity } from './modules/timbuktu/administrative/theme/theme.entit
     StyleGroupModule,
     ColorPaletteModule,
     ThemeModule,
+    ComponentVariantModule,
     ClassModule,
     LessonModule,
     QuizModule,

--- a/insight-be/src/modules/timbuktu/administrative/style/component-variant.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/component-variant.entity.ts
@@ -1,0 +1,37 @@
+import { Column, Entity, ManyToOne, JoinColumn, RelationId } from 'typeorm';
+import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
+import { AbstractBaseEntity } from 'src/common/base.entity';
+import { ThemeEntity } from '../theme/theme.entity';
+
+@ObjectType()
+@Entity('component_variants')
+export class ComponentVariantEntity extends AbstractBaseEntity {
+  @Field()
+  @Column()
+  name: string;
+
+  @Field()
+  @Column()
+  baseComponent: string;
+
+  @Field(() => GraphQLJSONObject)
+  @Column({ type: 'jsonb' })
+  props: Record<string, any>;
+
+  @Field()
+  @Column()
+  accessibleName: string;
+
+  @Field(() => ThemeEntity)
+  @ManyToOne(() => ThemeEntity, (theme) => theme.componentVariants, {
+    nullable: false,
+  })
+  @JoinColumn({ name: 'theme_id' })
+  theme!: ThemeEntity;
+
+  @Field(() => ID)
+  @Column({ name: 'theme_id' })
+  @RelationId((variant: ComponentVariantEntity) => variant.theme)
+  themeId!: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/style/component-variant.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/component-variant.inputs.ts
@@ -1,0 +1,27 @@
+import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
+import { HasRelationsInput } from 'src/common/base.inputs';
+
+@InputType()
+export class CreateComponentVariantInput extends HasRelationsInput {
+  @Field()
+  name: string;
+
+  @Field()
+  baseComponent: string;
+
+  @Field(() => GraphQLJSONObject)
+  props: Record<string, any>;
+
+  @Field()
+  accessibleName: string;
+
+  @Field(() => ID)
+  themeId: number;
+}
+
+@InputType()
+export class UpdateComponentVariantInput extends PartialType(CreateComponentVariantInput) {
+  @Field(() => ID)
+  id: number;
+}

--- a/insight-be/src/modules/timbuktu/administrative/style/component-variant.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/component-variant.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ComponentVariantEntity } from './component-variant.entity';
+import { ComponentVariantResolver } from './component-variant.resolver';
+import { ComponentVariantService } from './component-variant.service';
+import { ThemeEntity } from '../theme/theme.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ComponentVariantEntity, ThemeEntity])],
+  providers: [ComponentVariantService, ComponentVariantResolver],
+  exports: [ComponentVariantService],
+})
+export class ComponentVariantModule {}

--- a/insight-be/src/modules/timbuktu/administrative/style/component-variant.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/component-variant.resolver.ts
@@ -1,0 +1,33 @@
+import { Resolver } from '@nestjs/graphql';
+import { createBaseResolver } from 'src/common/base.resolver';
+import { ComponentVariantEntity } from './component-variant.entity';
+import {
+  CreateComponentVariantInput,
+  UpdateComponentVariantInput,
+} from './component-variant.inputs';
+import { ComponentVariantService } from './component-variant.service';
+
+const BaseComponentVariantResolver = createBaseResolver<
+  ComponentVariantEntity,
+  CreateComponentVariantInput,
+  UpdateComponentVariantInput
+>(ComponentVariantEntity, CreateComponentVariantInput, UpdateComponentVariantInput, {
+  queryName: 'ComponentVariant',
+  stableKeyPrefix: 'componentVariant',
+  enabledOperations: [
+    'findAll',
+    'findOne',
+    'findOneBy',
+    'create',
+    'update',
+    'remove',
+    'search',
+  ],
+});
+
+@Resolver(() => ComponentVariantEntity)
+export class ComponentVariantResolver extends BaseComponentVariantResolver {
+  constructor(private readonly variantService: ComponentVariantService) {
+    super(variantService);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/style/component-variant.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/component-variant.service.ts
@@ -1,0 +1,39 @@
+import { Injectable } from '@nestjs/common';
+import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
+import { DataSource, Repository } from 'typeorm';
+import { BaseService } from 'src/common/base.service';
+import { ComponentVariantEntity } from './component-variant.entity';
+import {
+  CreateComponentVariantInput,
+  UpdateComponentVariantInput,
+} from './component-variant.inputs';
+
+@Injectable()
+export class ComponentVariantService extends BaseService<
+  ComponentVariantEntity,
+  CreateComponentVariantInput,
+  UpdateComponentVariantInput
+> {
+  constructor(
+    @InjectRepository(ComponentVariantEntity)
+    variantRepository: Repository<ComponentVariantEntity>,
+    @InjectDataSource() dataSource: DataSource,
+  ) {
+    super(variantRepository, dataSource);
+  }
+
+  async create(data: CreateComponentVariantInput): Promise<ComponentVariantEntity> {
+    const { themeId, relationIds = [], ...rest } = data;
+    const relations = [...relationIds, { relation: 'theme', ids: [themeId] }];
+    return super.create({ ...rest, relationIds: relations } as any);
+  }
+
+  async update(data: UpdateComponentVariantInput): Promise<ComponentVariantEntity> {
+    const { themeId, relationIds = [], ...rest } = data;
+    const relations = [
+      ...relationIds,
+      ...(themeId ? [{ relation: 'theme', ids: [themeId] }] : []),
+    ];
+    return super.update({ ...rest, relationIds: relations } as any);
+  }
+}

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
@@ -1,9 +1,17 @@
-import { Column, Entity, ManyToOne, JoinColumn, RelationId } from 'typeorm';
+import {
+  Column,
+  Entity,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  RelationId,
+} from 'typeorm';
 import { Field, ObjectType, ID } from '@nestjs/graphql';
 import { GraphQLJSONObject } from 'graphql-type-json';
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
 import { ColorPaletteEntity } from '../color-palette/color-palette.entity';
+import { ComponentVariantEntity } from '../style/component-variant.entity';
 
 @ObjectType()
 @Entity('themes')
@@ -39,6 +47,10 @@ export class ThemeEntity extends AbstractBaseEntity {
   @Column({ name: 'default_palette_id' })
   @RelationId((theme: ThemeEntity) => theme.defaultPalette)
   defaultPaletteId!: number;
+
+  @Field(() => [ComponentVariantEntity], { nullable: true })
+  @OneToMany(() => ComponentVariantEntity, (variant) => variant.theme)
+  componentVariants?: ComponentVariantEntity[];
 
   @Field()
   @Column({ default: 1 })


### PR DESCRIPTION
## Summary
- add `component_variants` entity
- implement GraphQL inputs/service/resolver/module for component variants
- relate themes to component variants
- register component variants in the app module

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684951bef3688326819cc097291a56bd