### PR TITLE
Update lesson theme requirements

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
@@ -39,15 +39,19 @@ export class LessonEntity extends AbstractBaseEntity {
 
   /* ---------- theme ---------- */
 
-  @Field(() => ThemeEntity, { nullable: true })
-  @ManyToOne(() => ThemeEntity, { nullable: true })
+  @Field(() => ThemeEntity)
+  @ManyToOne(() => ThemeEntity, { nullable: false })
   @JoinColumn({ name: 'theme_id' })
-  theme?: ThemeEntity;
+  theme!: ThemeEntity;
 
-  @Field(() => ID, { nullable: true })
-  @Column({ name: 'theme_id', nullable: true })
+  @Field(() => ID)
+  @Column({ name: 'theme_id' })
   @RelationId((lesson: LessonEntity) => lesson.theme)
-  themeId?: number;
+  themeId!: number;
+
+  @Field(() => Date, { nullable: true })
+  @Column({ name: 'last_theme_upgrade', type: 'timestamptz', nullable: true })
+  lastThemeUpgrade?: Date;
 
   /* ---------- relationships ---------- */
 

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
@@ -13,8 +13,8 @@ export class CreateLessonInput extends HasRelationsInput {
   @Field(() => GraphQLJSONObject, { nullable: true })
   content?: Record<string, any>;
 
-  @Field(() => ID, { nullable: true })
-  themeId?: number;
+  @Field(() => ID)
+  themeId: number;
 
   @Field(() => [ID], { nullable: 'itemsAndList' })
   recommendedYearGroupIds?: number[];

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.service.ts
@@ -18,4 +18,19 @@ export class LessonService extends BaseService<
   ) {
     super(lessonRepository, dataSource);
   }
+
+  async create(data: CreateLessonInput): Promise<LessonEntity> {
+    const { themeId, relationIds = [], ...rest } = data as any;
+    const relations = [...relationIds, { relation: 'theme', ids: [themeId] }];
+    return super.create({ ...rest, relationIds: relations } as any);
+  }
+
+  async update(data: UpdateLessonInput): Promise<LessonEntity> {
+    const { themeId, relationIds = [], ...rest } = data as any;
+    const relations = [
+      ...relationIds,
+      ...(themeId ? [{ relation: 'theme', ids: [themeId] }] : []),
+    ];
+    return super.update({ ...rest, relationIds: relations } as any);
+  }
 }


### PR DESCRIPTION
## Summary
- require a theme when creating a lesson
- add last theme upgrade timestamp to lessons
- connect theme relation when creating or updating lessons

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_684952f3a36c8326bc5256fdd51ceafa