### PR TITLE
Add theme helpers and preview data fetching

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -16,6 +16,7 @@ export const LessonBuilderPageClient = () => {
   const [isLoadOpen, setIsLoadOpen] = useState(false);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [previewSlides, setPreviewSlides] = useState<Slide[]>([]);
+  const [previewThemeId, setPreviewThemeId] = useState<number | undefined>();
   const editorRef = useRef<LessonEditorHandle>(null);
 
   const [createLesson, { loading: saving }] = useMutation(CREATE_LESSON, {
@@ -28,6 +29,8 @@ export const LessonBuilderPageClient = () => {
   const openPreview = () => {
     const slides = editorRef.current?.getContent().slides ?? [];
     setPreviewSlides(slides);
+    const themeId = editorRef.current?.getThemeId();
+    setPreviewThemeId(themeId === "" ? undefined : (themeId as number));
     setIsPreviewOpen(true);
   };
 
@@ -119,6 +122,7 @@ export const LessonBuilderPageClient = () => {
           isOpen={isPreviewOpen}
           onClose={() => setIsPreviewOpen(false)}
           slides={previewSlides}
+          themeId={previewThemeId}
         />
       )}
     </Flex>

--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -26,6 +26,8 @@ export interface SlideElementDnDItemProps {
   id: string;
   /** Style reference id when the element originates from the style library */
   styleId?: number;
+  /** Component variant identifier */
+  variantId?: number;
   type: string;
   /**
    * Text content for text elements

--- a/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
@@ -4,18 +4,49 @@ import { Box, Stack, Text } from "@chakra-ui/react";
 import { BaseModal } from "../../modals/BaseModal";
 import SlidePreview from "../slide/SlidePreview";
 import { Slide } from "../slide/SlideSequencer";
+import { useQuery } from "@apollo/client";
+import {
+  GET_COLOR_PALETTE,
+  GET_COMPONENT_VARIANTS,
+  GET_THEME,
+} from "@/graphql/lesson";
+import { ColorPalette, ComponentVariant } from "@/theme/helpers";
 
 interface LessonPreviewModalProps {
   isOpen: boolean;
   onClose: () => void;
   slides: Slide[];
+  paletteId?: number;
+  themeId?: number;
 }
 
 export default function LessonPreviewModal({
   isOpen,
   onClose,
   slides,
+  paletteId,
+  themeId,
 }: LessonPreviewModalProps) {
+  const { data: themeData } = useQuery(GET_THEME, {
+    variables: { id: String(themeId) },
+    skip: !themeId || !isOpen,
+  });
+
+  const paletteIdToUse = paletteId ?? themeData?.getTheme?.defaultPaletteId;
+
+  const { data: paletteData } = useQuery(GET_COLOR_PALETTE, {
+    variables: { id: String(paletteIdToUse) },
+    skip: !paletteIdToUse || !isOpen,
+  });
+
+  const { data: variantData } = useQuery(GET_COMPONENT_VARIANTS, {
+    variables: { themeId: String(themeId) },
+    skip: !themeId || !isOpen,
+  });
+
+  const palette: ColorPalette | undefined = paletteData?.getColorPalette;
+  const variants: ComponentVariant[] | undefined = variantData?.getAllComponentVariant;
+
   return (
     <BaseModal
       isOpen={isOpen}
@@ -30,7 +61,12 @@ export default function LessonPreviewModal({
             <Text mb={2} fontWeight="bold">
               {slide.title}
             </Text>
-            <SlidePreview columnMap={slide.columnMap} boards={slide.boards} />
+            <SlidePreview
+              columnMap={slide.columnMap}
+              boards={slide.boards}
+              palette={palette}
+              variants={variants}
+            />
           </Box>
         ))}
       </Stack>

--- a/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
@@ -10,12 +10,18 @@ import ImageElement from "../elements/ImageElement";
 import QuizElement from "../elements/QuizElement";
 import VideoElement from "../elements/VideoElement";
 
+import { ComponentVariant, ColorPalette, resolveVariant, paletteColor } from "@/theme/helpers";
+
 interface SlideElementRendererProps {
   item: SlideElementDnDItemProps;
+  palette?: ColorPalette;
+  variants?: ComponentVariant[];
 }
 
 export default function SlideElementRenderer({
   item,
+  palette,
+  variants,
 }: SlideElementRendererProps) {
   const MotionBox = motion(Box);
   const animationProps = item.animation
@@ -56,6 +62,8 @@ export default function SlideElementRenderer({
           fontWeight={item.styles?.fontWeight}
           lineHeight={item.styles?.lineHeight}
           textAlign={item.styles?.textAlign as any}
+          color={paletteColor(palette, item.styles?.colorIndex ?? 0)}
+          {...(resolveVariant(variants, item.variantId)?.props ?? {})}
         >
           {item.text || "Sample Text"}
         </Text>
@@ -76,6 +84,7 @@ export default function SlideElementRenderer({
                       fontWeight={cell.styles?.fontWeight}
                       lineHeight={cell.styles?.lineHeight}
                       textAlign={cell.styles?.textAlign as any}
+                      color={paletteColor(palette, cell.styles?.colorIndex ?? 0)}
                     >
                       {cell.text}
                     </Text>

--- a/insight-fe/src/components/lesson/slide/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/slide/SlidePreview.tsx
@@ -7,13 +7,21 @@ import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnD
 import SlideElementRenderer from "./SlideElementRenderer";
 import { BoardRow } from "./SlideElementsContainer";
 import ElementWrapper from "../elements/ElementWrapper";
+import { ColorPalette, ComponentVariant } from "@/theme/helpers";
 
 interface SlidePreviewProps {
   columnMap: ColumnMap<SlideElementDnDItemProps>;
   boards: BoardRow[];
+  palette?: ColorPalette;
+  variants?: ComponentVariant[];
 }
 
-export default function SlidePreview({ columnMap, boards }: SlidePreviewProps) {
+export default function SlidePreview({
+  columnMap,
+  boards,
+  palette,
+  variants,
+}: SlidePreviewProps) {
   return (
     <Stack gap={4}>
       {boards.map((board) => (
@@ -39,7 +47,11 @@ export default function SlidePreview({ columnMap, boards }: SlidePreviewProps) {
                   <Stack gap={column.spacing ?? 2}>
                     {column.items.map((item) => (
                       <Box key={item.id} mb={2} data-card-id={item.id}>
-                        <SlideElementRenderer item={item} />
+                        <SlideElementRenderer
+                          item={item}
+                          palette={palette}
+                          variants={variants}
+                        />
                       </Box>
                     ))}
                   </Stack>

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -245,3 +245,31 @@ export const DELETE_THEME = gql`
     deleteTheme(data: $data)
   }
 `;
+
+export const GET_COMPONENT_VARIANTS = gql`
+  query GetComponentVariants($themeId: String!) {
+    getAllComponentVariant(
+      data: { all: true, filters: [{ column: "themeId", value: $themeId }] }
+    ) {
+      id
+      name
+      baseComponent
+      props
+      accessibleName
+      themeId
+    }
+  }
+`;
+
+export const GET_COMPONENT_VARIANT = gql`
+  query GetComponentVariant($id: String!) {
+    getComponentVariant(data: { id: $id }) {
+      id
+      name
+      baseComponent
+      props
+      accessibleName
+      themeId
+    }
+  }
+`;

--- a/insight-fe/src/theme/helpers.ts
+++ b/insight-fe/src/theme/helpers.ts
@@ -1,0 +1,27 @@
+export interface ComponentVariant {
+  id: number;
+  baseComponent: string;
+  props: Record<string, any>;
+}
+
+export interface ColorPalette {
+  id: number;
+  name: string;
+  colors: string[];
+}
+
+export function resolveVariant(
+  variants: ComponentVariant[] | undefined,
+  variantId?: number,
+): ComponentVariant | undefined {
+  if (!variants || typeof variantId === 'undefined') return undefined;
+  return variants.find((v) => Number(v.id) === Number(variantId));
+}
+
+export function paletteColor(
+  palette: ColorPalette | undefined,
+  index: number,
+): string | undefined {
+  if (!palette) return undefined;
+  return palette.colors[index];
+}


### PR DESCRIPTION
## Summary
- implement `resolveVariant` and `paletteColor` helpers
- fetch component variants and color palettes via new GraphQL queries
- use helpers when rendering slide preview components
- include theme data when opening lesson preview

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849560dbcf08326ac4da44519f908a9