### PR TITLE
Implement findOne queries for variant and palette

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.resolver.ts
@@ -7,6 +7,7 @@ import {
   FindAllColorPaletteInput,
 } from './color-palette.inputs';
 import { RbacPermissionKey } from 'src/modules/rbac/decorators/resolver-permission-key.decorator';
+import { IdInput } from 'src/common/base.inputs';
 import { ColorPaletteService } from './color-palette.service';
 
 const BaseColorPaletteResolver = createBaseResolver<
@@ -16,13 +17,24 @@ const BaseColorPaletteResolver = createBaseResolver<
 >(ColorPaletteEntity, CreateColorPaletteInput, UpdateColorPaletteInput, {
   queryName: 'ColorPalette',
   stableKeyPrefix: 'colorPalette',
-  enabledOperations: ['findAll', 'findOne', 'create', 'update', 'remove'],
+  enabledOperations: ['findAll', 'create', 'update', 'remove'],
 });
 
 @Resolver(() => ColorPaletteEntity)
 export class ColorPaletteResolver extends BaseColorPaletteResolver {
   constructor(private readonly paletteService: ColorPaletteService) {
     super(paletteService);
+  }
+
+  @Query(() => ColorPaletteEntity, {
+    name: 'getColorPalette',
+    description: 'Returns one ColorPalette',
+  })
+  @RbacPermissionKey('colorPalette.getColorPalette')
+  async findOne(
+    @Args('data', { type: () => IdInput }) data: IdInput,
+  ): Promise<ColorPaletteEntity> {
+    return this.paletteService.findOne(data.id);
   }
 
   @Query(() => [ColorPaletteEntity], {

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.service.ts
@@ -48,4 +48,8 @@ export class ColorPaletteService extends BaseService<
     ];
     return super.findAll({ ...rest, filters: finalFilters });
   }
+
+  async findOne(id: number, relations?: string[]): Promise<ColorPaletteEntity> {
+    return super.findOne(id, relations);
+  }
 }

--- a/insight-be/src/modules/timbuktu/administrative/style/component-variant.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/component-variant.resolver.ts
@@ -1,4 +1,4 @@
-import { Resolver } from '@nestjs/graphql';
+import { Args, Query, Resolver } from '@nestjs/graphql';
 import { createBaseResolver } from 'src/common/base.resolver';
 import { ComponentVariantEntity } from './component-variant.entity';
 import {
@@ -6,6 +6,8 @@ import {
   UpdateComponentVariantInput,
 } from './component-variant.inputs';
 import { ComponentVariantService } from './component-variant.service';
+import { IdInput } from 'src/common/base.inputs';
+import { RbacPermissionKey } from 'src/modules/rbac/decorators/resolver-permission-key.decorator';
 
 const BaseComponentVariantResolver = createBaseResolver<
   ComponentVariantEntity,
@@ -16,7 +18,6 @@ const BaseComponentVariantResolver = createBaseResolver<
   stableKeyPrefix: 'componentVariant',
   enabledOperations: [
     'findAll',
-    'findOne',
     'findOneBy',
     'create',
     'update',
@@ -29,5 +30,16 @@ const BaseComponentVariantResolver = createBaseResolver<
 export class ComponentVariantResolver extends BaseComponentVariantResolver {
   constructor(private readonly variantService: ComponentVariantService) {
     super(variantService);
+  }
+
+  @Query(() => ComponentVariantEntity, {
+    name: 'getComponentVariant',
+    description: 'Returns one ComponentVariant',
+  })
+  @RbacPermissionKey('componentVariant.getComponentVariant')
+  async findOne(
+    @Args('data', { type: () => IdInput }) data: IdInput,
+  ): Promise<ComponentVariantEntity> {
+    return this.variantService.findOne(data.id);
   }
 }

--- a/insight-be/src/modules/timbuktu/administrative/style/component-variant.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/component-variant.service.ts
@@ -36,4 +36,8 @@ export class ComponentVariantService extends BaseService<
     ];
     return super.update({ ...rest, relationIds: relations } as any);
   }
+
+  async findOne(id: number, relations?: string[]): Promise<ComponentVariantEntity> {
+    return super.findOne(id, relations);
+  }
 }


### PR DESCRIPTION
## Summary
- enable fetching a single component variant by id
- enable fetching a single color palette by id
- expose these queries through GraphQL API

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684959fab52883268499fd246946abfc