### PR TITLE
Use semantic tokens for lesson styling

### DIFF
--- a/insight-fe/src/components/lesson/attributes-pane/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/BoardAttributesPane.tsx
@@ -4,19 +4,18 @@ import { Accordion } from "@chakra-ui/react";
 import useStyleAttributes from "../hooks/useStyleAttributes";
 import WrapperSettings from "../attributes/WrapperSettings";
 import { BoardRow } from "../slide/SlideElementsContainer";
+import { SemanticTokens } from "@/theme/helpers";
 
 interface BoardAttributesPaneProps {
   board: BoardRow;
   onChange: (updated: BoardRow) => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
-  selectedPaletteId?: number | "";
+  tokens?: SemanticTokens;
 }
 
 export default function BoardAttributesPane({
   board,
   onChange,
-  colorPalettes,
-  selectedPaletteId,
+  tokens,
 }: BoardAttributesPaneProps) {
   const styleAttrs = useStyleAttributes({
     wrapperStyles: board.wrapperStyles,
@@ -29,11 +28,7 @@ export default function BoardAttributesPane({
 
   return (
     <Accordion allowMultiple>
-      <WrapperSettings
-        attrs={styleAttrs}
-        colorPalettes={colorPalettes}
-        selectedPaletteId={selectedPaletteId}
-      />
+      <WrapperSettings attrs={styleAttrs} tokens={tokens} />
     </Accordion>
   );
 }

--- a/insight-fe/src/components/lesson/attributes-pane/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ColumnAttributesPane.tsx
@@ -6,19 +6,18 @@ import { ColumnType } from "@/components/DnD/types";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import WrapperSettings from "../attributes/WrapperSettings";
 import useStyleAttributes from "../hooks/useStyleAttributes";
+import { SemanticTokens } from "@/theme/helpers";
 
 interface ColumnAttributesPaneProps {
   column: ColumnType<SlideElementDnDItemProps>;
   onChange: (updated: ColumnType<SlideElementDnDItemProps>) => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
-  selectedPaletteId?: number | "";
+  tokens?: SemanticTokens;
 }
 
 export default function ColumnAttributesPane({
   column,
   onChange,
-  colorPalettes,
-  selectedPaletteId,
+  tokens,
 }: ColumnAttributesPaneProps) {
   const styleAttrs = useStyleAttributes({
     wrapperStyles: column.wrapperStyles,
@@ -30,11 +29,7 @@ export default function ColumnAttributesPane({
 
   return (
     <Accordion allowMultiple>
-      <WrapperSettings
-        attrs={styleAttrs}
-        colorPalettes={colorPalettes}
-        selectedPaletteId={selectedPaletteId}
-      />
+      <WrapperSettings attrs={styleAttrs} tokens={tokens} />
     </Accordion>
   );
 }

--- a/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
@@ -13,14 +13,15 @@ import VideoAttributes from "../attributes/VideoAttributes";
 import TableAttributes from "../attributes/TableAttributes";
 import WrapperSettings from "../attributes/WrapperSettings";
 import useStyleAttributes from "../hooks/useStyleAttributes";
+import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
 
 interface ElementAttributesPaneProps {
   element: SlideElementDnDItemProps;
   onChange: (updated: SlideElementDnDItemProps) => void;
   onClone?: () => void;
   onDelete?: () => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
-  selectedPaletteId?: number | "";
+  tokens?: SemanticTokens;
+  variants?: ComponentVariant[];
 }
 
 export default function ElementAttributesPane({
@@ -28,11 +29,11 @@ export default function ElementAttributesPane({
   onChange,
   onClone,
   onDelete,
-  colorPalettes,
-  selectedPaletteId,
+  tokens,
+  variants,
 }: ElementAttributesPaneProps) {
-  const [colorIndex, setColorIndex] = useState(
-    element.styles?.colorIndex ?? 0
+  const [colorToken, setColorToken] = useState(
+    element.styles?.colorToken ?? ""
   );
   const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
   const [fontFamily, setFontFamily] = useState(
@@ -60,7 +61,7 @@ export default function ElementAttributesPane({
       rows: 2,
       cols: 2,
       cells: Array.from({ length: 2 }, () =>
-        Array.from({ length: 2 }, () => ({ text: "", styles: { colorIndex: 0 } }))
+        Array.from({ length: 2 }, () => ({ text: "", styles: { colorToken: "" } }))
       ),
     }
   );
@@ -111,7 +112,7 @@ export default function ElementAttributesPane({
   // using id/type avoids resets when the parent simply updates
   // the same element instance with new references
   useEffect(() => {
-    setColorIndex(element.styles?.colorIndex ?? 0);
+    setColorToken(element.styles?.colorToken ?? "");
     setFontSize(element.styles?.fontSize || "16px");
     setFontFamily(element.styles?.fontFamily || availableFonts[0].fontFamily);
     setFontWeight(element.styles?.fontWeight || "normal");
@@ -128,7 +129,7 @@ export default function ElementAttributesPane({
         rows: 2,
         cols: 2,
         cells: Array.from({ length: 2 }, () =>
-          Array.from({ length: 2 }, () => ({ text: "", styles: { colorIndex: 0 } }))
+          Array.from({ length: 2 }, () => ({ text: "", styles: { colorToken: "" } }))
         ),
       }
     );
@@ -167,7 +168,7 @@ export default function ElementAttributesPane({
       updated.text = text;
       updated.styles = {
         ...element.styles,
-        colorIndex,
+        colorToken,
         fontSize,
         fontFamily,
         fontWeight,
@@ -191,7 +192,7 @@ export default function ElementAttributesPane({
     }
     onChange(updated);
   }, [
-        colorIndex,
+        colorToken,
         fontSize,
     fontFamily,
     fontWeight,
@@ -226,11 +227,7 @@ export default function ElementAttributesPane({
   return (
     <>
       <Accordion allowMultiple>
-        <WrapperSettings
-          attrs={styleAttrs}
-          colorPalettes={colorPalettes}
-          selectedPaletteId={selectedPaletteId}
-        />
+        <WrapperSettings attrs={styleAttrs} tokens={tokens} />
         <AnimationSettings
           enabled={animationEnabled}
           setEnabled={setAnimationEnabled}
@@ -243,8 +240,8 @@ export default function ElementAttributesPane({
           <TextAttributes
             text={text}
             setText={setText}
-            colorIndex={colorIndex}
-            setColorIndex={setColorIndex}
+            colorToken={colorToken}
+            setColorToken={setColorToken}
             fontSize={fontSize}
             setFontSize={setFontSize}
             fontFamily={fontFamily}
@@ -255,8 +252,8 @@ export default function ElementAttributesPane({
             setLineHeight={setLineHeight}
             textAlign={textAlign}
             setTextAlign={setTextAlign}
-            colorPalettes={colorPalettes}
-            selectedPaletteId={selectedPaletteId}
+            tokens={tokens}
+            variants={variants}
           />
         )}
         {element.type === "image" && (
@@ -269,8 +266,7 @@ export default function ElementAttributesPane({
           <TableAttributes
             table={table}
             setTable={setTable}
-            colorPalettes={colorPalettes}
-            selectedPaletteId={selectedPaletteId}
+            tokens={tokens}
           />
         )}
         {element.type === "quiz" && (

--- a/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
@@ -15,6 +15,7 @@ import {
 import { useEffect, useState, useRef } from "react";
 import PaletteColorPicker from "../PaletteColorPicker";
 import { TableCell } from "@/components/DnD/cards/SlideElementDnDCard";
+import { SemanticTokens, tokenColor } from "@/theme/helpers";
 
 interface TableAttributesProps {
   table: {
@@ -23,15 +24,13 @@ interface TableAttributesProps {
     cells: TableCell[][];
   };
   setTable: (table: { rows: number; cols: number; cells: TableCell[][] }) => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
-  selectedPaletteId?: number | "";
+  tokens?: SemanticTokens;
 }
 
 export default function TableAttributes({
   table,
   setTable,
-  colorPalettes,
-  selectedPaletteId,
+  tokens,
 }: TableAttributesProps) {
   const [rows, setRows] = useState(table.rows);
   const [cols, setCols] = useState(table.cols);
@@ -55,7 +54,7 @@ export default function TableAttributes({
     Array.from({ length: newRows }, (_, r) =>
       Array.from(
         { length: newCols },
-        (_, c) => prev[r]?.[c] || { text: "", styles: { colorIndex: 0 } }
+        (_, c) => prev[r]?.[c] || { text: "", styles: { colorToken: "" } }
       )
     );
 
@@ -89,8 +88,7 @@ export default function TableAttributes({
     });
   };
 
-  const paletteColors =
-    colorPalettes?.find((p) => Number(p.id) === Number(selectedPaletteId))?.colors ?? [];
+  const tokenKeys = tokens ? Object.keys(tokens.colors ?? {}) : [];
 
   const updateCell = (r: number, c: number, cell: TableCell) => {
     updateTableCells((prev) => {
@@ -153,14 +151,14 @@ export default function TableAttributes({
                     }
                   />
                   <PaletteColorPicker
-                    value={cell.styles?.colorIndex ?? 0}
+                    value={tokenKeys.indexOf(cell.styles?.colorToken ?? "")}
                     onChange={(idx) =>
                       updateCell(rIdx, cIdx, {
                         ...cell,
-                        styles: { ...cell.styles, colorIndex: idx },
+                        styles: { ...cell.styles, colorToken: tokenKeys[idx] },
                       })
                     }
-                    paletteColors={paletteColors}
+                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
                   />
                 </Stack>
               ))

--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -14,12 +14,13 @@ import {
 } from "@chakra-ui/react";
 import { availableFonts } from "@/theme/fonts";
 import PaletteColorPicker from "../PaletteColorPicker";
+import { SemanticTokens, tokenColor, ComponentVariant } from "@/theme/helpers";
 
 interface TextAttributesProps {
   text: string;
   setText: (val: string) => void;
-  colorIndex: number;
-  setColorIndex: (val: number) => void;
+  colorToken: string;
+  setColorToken: (val: string) => void;
   fontSize: string;
   setFontSize: (val: string) => void;
   fontFamily: string;
@@ -30,15 +31,15 @@ interface TextAttributesProps {
   setLineHeight: (val: string) => void;
   textAlign: string;
   setTextAlign: (val: string) => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
-  selectedPaletteId?: number | "";
+  tokens?: SemanticTokens;
+  variants?: ComponentVariant[];
 }
 
 export default function TextAttributes({
   text,
   setText,
-  colorIndex,
-  setColorIndex,
+  colorToken,
+  setColorToken,
   fontSize,
   setFontSize,
   fontFamily,
@@ -49,13 +50,9 @@ export default function TextAttributes({
   setLineHeight,
   textAlign,
   setTextAlign,
-  colorPalettes,
-  selectedPaletteId,
+  tokens,
 }: TextAttributesProps) {
-  const paletteColors =
-    colorPalettes?.find(
-      (p) => Number(p.id) === Number(selectedPaletteId)
-    )?.colors ?? [];
+  const tokenKeys = tokens ? Object.keys(tokens.colors ?? {}) : [];
 
   return (
     <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>
@@ -78,9 +75,9 @@ export default function TextAttributes({
               Color
             </FormLabel>
             <PaletteColorPicker
-              value={colorIndex}
-              onChange={setColorIndex}
-              paletteColors={paletteColors}
+              value={tokenKeys.indexOf(colorToken)}
+              onChange={(idx) => setColorToken(tokenKeys[idx])}
+              paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
             />
           </FormControl>
           <FormControl display="flex" alignItems="center">

--- a/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
@@ -16,18 +16,14 @@ import {
 } from "@chakra-ui/react";
 import type useStyleAttributes from "../hooks/useStyleAttributes";
 import PaletteColorPicker from "../PaletteColorPicker";
+import { SemanticTokens, tokenColor } from "@/theme/helpers";
 
 interface WrapperSettingsProps {
   attrs: ReturnType<typeof useStyleAttributes>;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
-  selectedPaletteId?: number | "";
+  tokens?: SemanticTokens;
 }
 
-export default function WrapperSettings({
-  attrs,
-  colorPalettes,
-  selectedPaletteId,
-}: WrapperSettingsProps) {
+export default function WrapperSettings({ attrs, tokens }: WrapperSettingsProps) {
   const {
     bgColor,
     setBgColor,
@@ -61,10 +57,7 @@ export default function WrapperSettings({
     setSpacing,
   } = attrs;
 
-  const paletteColors =
-    colorPalettes?.find(
-      (p) => Number(p.id) === Number(selectedPaletteId)
-    )?.colors ?? [];
+  const tokenKeys = tokens ? Object.keys(tokens.colors ?? {}) : [];
 
   return (
     <>
@@ -102,12 +95,12 @@ export default function WrapperSettings({
               <FormControl display="flex" alignItems="center">
                 <FormLabel mb="0" fontSize="sm" w="40%">Color</FormLabel>
                 <PaletteColorPicker
-                  value={paletteColors.indexOf(bgColor)}
+                  value={tokenKeys.indexOf(bgColor)}
                   onChange={(idx) => {
-                    setBgColor(paletteColors[idx]);
+                    setBgColor(tokenKeys[idx]);
                     setBgOpacity(1);
                   }}
-                  paletteColors={paletteColors}
+                  paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
                 />
               </FormControl>
             )}
@@ -116,17 +109,17 @@ export default function WrapperSettings({
                 <FormControl display="flex" alignItems="center">
                   <FormLabel mb="0" fontSize="sm" w="40%">Grad. From</FormLabel>
                   <PaletteColorPicker
-                    value={paletteColors.indexOf(gradientFrom)}
-                    onChange={(idx) => setGradientFrom(paletteColors[idx])}
-                    paletteColors={paletteColors}
+                    value={tokenKeys.indexOf(gradientFrom)}
+                    onChange={(idx) => setGradientFrom(tokenKeys[idx])}
+                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
                   />
                 </FormControl>
                 <FormControl display="flex" alignItems="center">
                   <FormLabel mb="0" fontSize="sm" w="40%">Grad. To</FormLabel>
                   <PaletteColorPicker
-                    value={paletteColors.indexOf(gradientTo)}
-                    onChange={(idx) => setGradientTo(paletteColors[idx])}
-                    paletteColors={paletteColors}
+                    value={tokenKeys.indexOf(gradientTo)}
+                    onChange={(idx) => setGradientTo(tokenKeys[idx])}
+                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
                   />
                 </FormControl>
                 <FormControl display="flex" alignItems="center">
@@ -261,9 +254,9 @@ export default function WrapperSettings({
                 Color
               </FormLabel>
               <PaletteColorPicker
-                value={paletteColors.indexOf(borderColor)}
-                onChange={(idx) => setBorderColor(paletteColors[idx])}
-                paletteColors={paletteColors}
+                value={tokenKeys.indexOf(borderColor)}
+                onChange={(idx) => setBorderColor(tokenKeys[idx])}
+                paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
               />
             </FormControl>
             <FormControl display="flex" alignItems="center">

--- a/insight-fe/src/components/lesson/hooks/useDnDHandlers.ts
+++ b/insight-fe/src/components/lesson/hooks/useDnDHandlers.ts
@@ -7,7 +7,7 @@ import { defaultColumnWrapperStyles } from "../defaultStyles";
 import type { LessonState, Action } from "./useLessonSelection";
 
 interface Options {
-  defaultColor: string;
+  defaultColorToken: string;
   defaultFontFamily: string;
 }
 
@@ -52,7 +52,7 @@ export default function useDnDHandlers(
                   ? {
                       text: "Sample Text",
                       styles: {
-                        colorIndex: 0,
+                        colorToken: options.defaultColorToken,
                         fontSize: "16px",
                         fontFamily: options.defaultFontFamily,
                         fontWeight: "normal",
@@ -75,7 +75,7 @@ export default function useDnDHandlers(
                             Array.from({ length: 2 }, () => ({
                               text: "Cell",
                               styles: {
-                                colorIndex: 0,
+                                colorToken: options.defaultColorToken,
                                 fontSize: "14px",
                                 fontFamily: options.defaultFontFamily,
                                 fontWeight: "normal",

--- a/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
+++ b/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
@@ -10,12 +10,12 @@ export type { LessonEditorHandle } from "./useLessonSelection";
 
 export function useLessonEditorState(
   ref?: React.Ref<LessonEditorHandle>,
-  options?: { defaultColor: string; defaultFontFamily: string }
+  options?: { defaultColorToken: string; defaultFontFamily: string }
 ) {
   const selection = useLessonSelection(ref);
   const boardHelpers = useBoardColumnHelpers(selection.state, selection.dispatch);
   const dndHandlers = useDnDHandlers(selection.state, selection.dispatch, {
-    defaultColor: options?.defaultColor ?? "#000000",
+    defaultColorToken: options?.defaultColorToken ?? "",
     defaultFontFamily: options?.defaultFontFamily ?? availableFonts[0].fontFamily,
   });
 

--- a/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
@@ -5,18 +5,13 @@ import { BaseModal } from "../../modals/BaseModal";
 import SlidePreview from "../slide/SlidePreview";
 import { Slide } from "../slide/SlideSequencer";
 import { useQuery } from "@apollo/client";
-import {
-  GET_COLOR_PALETTE,
-  GET_COMPONENT_VARIANTS,
-  GET_THEME,
-} from "@/graphql/lesson";
-import { ColorPalette, ComponentVariant } from "@/theme/helpers";
+import { GET_THEME } from "@/graphql/lesson";
+import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
 
 interface LessonPreviewModalProps {
   isOpen: boolean;
   onClose: () => void;
   slides: Slide[];
-  paletteId?: number;
   themeId?: number;
 }
 
@@ -24,7 +19,6 @@ export default function LessonPreviewModal({
   isOpen,
   onClose,
   slides,
-  paletteId,
   themeId,
 }: LessonPreviewModalProps) {
   const { data: themeData } = useQuery(GET_THEME, {
@@ -32,20 +26,9 @@ export default function LessonPreviewModal({
     skip: !themeId || !isOpen,
   });
 
-  const paletteIdToUse = paletteId ?? themeData?.getTheme?.defaultPaletteId;
-
-  const { data: paletteData } = useQuery(GET_COLOR_PALETTE, {
-    variables: { id: String(paletteIdToUse) },
-    skip: !paletteIdToUse || !isOpen,
-  });
-
-  const { data: variantData } = useQuery(GET_COMPONENT_VARIANTS, {
-    variables: { themeId: String(themeId) },
-    skip: !themeId || !isOpen,
-  });
-
-  const palette: ColorPalette | undefined = paletteData?.getColorPalette;
-  const variants: ComponentVariant[] | undefined = variantData?.getAllComponentVariant;
+  const theme = themeData?.getTheme;
+  const tokens: SemanticTokens | undefined = theme?.semanticTokens;
+  const variants: ComponentVariant[] | undefined = theme?.componentVariants;
 
   return (
     <BaseModal
@@ -64,7 +47,7 @@ export default function LessonPreviewModal({
             <SlidePreview
               columnMap={slide.columnMap}
               boards={slide.boards}
-              palette={palette}
+              tokens={tokens}
               variants={variants}
             />
           </Box>

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -9,6 +9,7 @@ import ColumnAttributesPane from "../attributes-pane/ColumnAttributesPane";
 import ElementAttributesPane from "../attributes-pane/ElementAttributesPane";
 import SlideElementsContainer, { BoardRow } from "./SlideElementsContainer";
 import SlideSequencer, { Slide } from "./SlideSequencer";
+import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
 
 interface SlideCanvasProps {
   slides: Slide[];
@@ -32,9 +33,9 @@ interface SlideCanvasProps {
   handleDropElement: (e: React.DragEvent<HTMLDivElement>) => void;
   openSaveStyle: () => void;
   openLoadStyle: () => void;
-  colorPalettes: { id: number; name: string; colors: string[] }[];
-  selectedPaletteId: number | "";
-} 
+  tokens?: SemanticTokens;
+  variants?: ComponentVariant[];
+}
 
 export default function SlideCanvas({
   slides,
@@ -58,8 +59,8 @@ export default function SlideCanvas({
   handleDropElement,
   openSaveStyle,
   openLoadStyle,
-  colorPalettes,
-  selectedPaletteId,
+  tokens,
+  variants,
 }: SlideCanvasProps) {
   return (
     <Flex gap={6} alignItems="flex-start">
@@ -100,6 +101,8 @@ export default function SlideCanvas({
               onSelectColumn={(id) => selectColumn(id)}
               selectedBoardId={selectedBoard ? selectedBoard.id : null}
               onSelectBoard={(id) => selectBoard(id)}
+              tokens={tokens}
+              variants={variants}
             />
           </Box>
           <Box p={4} borderWidth="1px" borderRadius="md" minW="200px">
@@ -121,24 +124,22 @@ export default function SlideCanvas({
                 onChange={updateElement}
                 onClone={cloneElement}
                 onDelete={deleteElement}
-                colorPalettes={colorPalettes}
-                selectedPaletteId={selectedPaletteId}
+                tokens={tokens}
+                variants={variants}
               />
             )}
             {selectedColumn && (
               <ColumnAttributesPane
                 column={selectedColumn}
                 onChange={updateColumn}
-                colorPalettes={colorPalettes}
-                selectedPaletteId={selectedPaletteId}
+                tokens={tokens}
               />
             )}
             {selectedBoard && (
               <BoardAttributesPane
                 board={selectedBoard}
                 onChange={updateBoard}
-                colorPalettes={colorPalettes}
-                selectedPaletteId={selectedPaletteId}
+                tokens={tokens}
               />
             )}
           </Box>

--- a/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
@@ -10,17 +10,17 @@ import ImageElement from "../elements/ImageElement";
 import QuizElement from "../elements/QuizElement";
 import VideoElement from "../elements/VideoElement";
 
-import { ComponentVariant, ColorPalette, resolveVariant, paletteColor } from "@/theme/helpers";
+import { ComponentVariant, SemanticTokens, resolveVariant, tokenColor } from "@/theme/helpers";
 
 interface SlideElementRendererProps {
   item: SlideElementDnDItemProps;
-  palette?: ColorPalette;
+  tokens?: SemanticTokens;
   variants?: ComponentVariant[];
 }
 
 export default function SlideElementRenderer({
   item,
-  palette,
+  tokens,
   variants,
 }: SlideElementRendererProps) {
   const MotionBox = motion(Box);
@@ -62,7 +62,7 @@ export default function SlideElementRenderer({
           fontWeight={item.styles?.fontWeight}
           lineHeight={item.styles?.lineHeight}
           textAlign={item.styles?.textAlign as any}
-          color={paletteColor(palette, item.styles?.colorIndex ?? 0)}
+          color={tokenColor(tokens, item.styles?.colorToken)}
           {...(resolveVariant(variants, item.variantId)?.props ?? {})}
         >
           {item.text || "Sample Text"}
@@ -84,7 +84,7 @@ export default function SlideElementRenderer({
                       fontWeight={cell.styles?.fontWeight}
                       lineHeight={cell.styles?.lineHeight}
                       textAlign={cell.styles?.textAlign as any}
-                      color={paletteColor(palette, cell.styles?.colorIndex ?? 0)}
+                      color={tokenColor(tokens, cell.styles?.colorToken)}
                     >
                       {cell.text}
                     </Text>

--- a/insight-fe/src/components/lesson/slide/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementsContainer.tsx
@@ -13,6 +13,7 @@ import {
   defaultColumnWrapperStyles,
   defaultBoardWrapperStyles,
 } from "../defaultStyles";
+import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
 import { ElementWrapperStyles } from "../elements/ElementWrapper";
 
 export interface BoardRow {
@@ -36,6 +37,8 @@ interface SlideElementsContainerProps {
   onSelectColumn?: (id: string) => void;
   selectedBoardId?: string | null;
   onSelectBoard?: (id: string) => void;
+  tokens?: SemanticTokens;
+  variants?: ComponentVariant[];
 }
 
 const COLUMN_COLORS = [
@@ -58,6 +61,8 @@ export default function SlideElementsContainer({
   onSelectColumn,
   selectedBoardId,
   onSelectBoard,
+  tokens,
+  variants,
 }: SlideElementsContainerProps) {
   const instanceId = useRef(Symbol("slide-container"));
   const boardInstanceId = useRef(Symbol("board-container"));

--- a/insight-fe/src/components/lesson/slide/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/slide/SlidePreview.tsx
@@ -7,19 +7,19 @@ import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnD
 import SlideElementRenderer from "./SlideElementRenderer";
 import { BoardRow } from "./SlideElementsContainer";
 import ElementWrapper from "../elements/ElementWrapper";
-import { ColorPalette, ComponentVariant } from "@/theme/helpers";
+import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
 
 interface SlidePreviewProps {
   columnMap: ColumnMap<SlideElementDnDItemProps>;
   boards: BoardRow[];
-  palette?: ColorPalette;
+  tokens?: SemanticTokens;
   variants?: ComponentVariant[];
 }
 
 export default function SlidePreview({
   columnMap,
   boards,
-  palette,
+  tokens,
   variants,
 }: SlidePreviewProps) {
   return (
@@ -49,7 +49,7 @@ export default function SlidePreview({
                       <Box key={item.id} mb={2} data-card-id={item.id}>
                         <SlideElementRenderer
                           item={item}
-                          palette={palette}
+                          tokens={tokens}
                           variants={variants}
                         />
                       </Box>

--- a/insight-fe/src/theme/helpers.ts
+++ b/insight-fe/src/theme/helpers.ts
@@ -25,3 +25,14 @@ export function paletteColor(
   if (!palette) return undefined;
   return palette.colors[index];
 }
+
+export type SemanticTokens = Record<string, Record<string, string>>;
+
+export function tokenColor(
+  tokens: SemanticTokens | undefined,
+  path: string | undefined,
+): string | undefined {
+  if (!tokens || !path) return undefined;
+  const [category, key] = path.split(".");
+  return tokens[category]?.[key];
+}


### PR DESCRIPTION
## Summary
- add semantic token helpers
- migrate LessonEditor and Slide rendering to semantic tokens
- update attribute panes to handle token-based styling
- build Chakra theme from selected theme tokens

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68496f26bfa083268d3fcfa21f7db0f7