### PR TITLE
Refactor lesson JSON style fields

### DIFF
--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -12,8 +12,8 @@ export interface ElementAnimation {
 
 export interface TableCell {
   text: string;
-  styles?: {
-    colorIndex?: number;
+  styleOverrides?: {
+    colorToken?: string;
     fontSize?: string;
     fontFamily?: string;
     fontWeight?: string;
@@ -66,8 +66,8 @@ export interface SlideElementDnDItemProps {
     cols: number;
     cells: TableCell[][];
   };
-  styles?: {
-    colorIndex?: number;
+  styleOverrides?: {
+    colorToken?: string;
     fontSize?: string;
     fontFamily?: string;
     fontWeight?: string;
@@ -138,11 +138,11 @@ export const SlideElementDnDItem = ({
     content = (
       <ElementWrapper styles={wrapperStyles} {...baseProps}>
         <Text
-          fontSize={item.styles?.fontSize}
-          fontFamily={item.styles?.fontFamily}
-          fontWeight={item.styles?.fontWeight}
-          lineHeight={item.styles?.lineHeight}
-          textAlign={item.styles?.textAlign as any}
+          fontSize={item.styleOverrides?.fontSize}
+          fontFamily={item.styleOverrides?.fontFamily}
+          fontWeight={item.styleOverrides?.fontWeight}
+          lineHeight={item.styleOverrides?.lineHeight}
+          textAlign={item.styleOverrides?.textAlign as any}
         >
           {item.text || "Sample Text"}
         </Text>
@@ -158,11 +158,11 @@ export const SlideElementDnDItem = ({
                 {row.map((cell, cIdx) => (
                   <Td key={cIdx} p={1}>
                     <Text
-                      fontSize={cell.styles?.fontSize}
-                      fontFamily={cell.styles?.fontFamily}
-                      fontWeight={cell.styles?.fontWeight}
-                      lineHeight={cell.styles?.lineHeight}
-                      textAlign={cell.styles?.textAlign as any}
+                      fontSize={cell.styleOverrides?.fontSize}
+                      fontFamily={cell.styleOverrides?.fontFamily}
+                      fontWeight={cell.styleOverrides?.fontWeight}
+                      lineHeight={cell.styleOverrides?.lineHeight}
+                      textAlign={cell.styleOverrides?.textAlign as any}
                     >
                       {cell.text}
                     </Text>

--- a/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
@@ -33,20 +33,22 @@ export default function ElementAttributesPane({
   variants,
 }: ElementAttributesPaneProps) {
   const [colorToken, setColorToken] = useState(
-    element.styles?.colorToken ?? ""
+    element.styleOverrides?.colorToken ?? ""
   );
-  const [fontSize, setFontSize] = useState(element.styles?.fontSize || "16px");
+  const [fontSize, setFontSize] = useState(
+    element.styleOverrides?.fontSize || "16px"
+  );
   const [fontFamily, setFontFamily] = useState(
-    element.styles?.fontFamily || availableFonts[0].fontFamily
+    element.styleOverrides?.fontFamily || availableFonts[0].fontFamily
   );
   const [fontWeight, setFontWeight] = useState(
-    element.styles?.fontWeight || "normal"
+    element.styleOverrides?.fontWeight || "normal"
   );
   const [lineHeight, setLineHeight] = useState(
-    element.styles?.lineHeight || "1.2"
+    element.styleOverrides?.lineHeight || "1.2"
   );
   const [textAlign, setTextAlign] = useState(
-    element.styles?.textAlign || "left"
+    element.styleOverrides?.textAlign || "left"
   );
   const [text, setText] = useState(element.text || "");
   const [src, setSrc] = useState(element.src || "");
@@ -61,7 +63,7 @@ export default function ElementAttributesPane({
       rows: 2,
       cols: 2,
       cells: Array.from({ length: 2 }, () =>
-        Array.from({ length: 2 }, () => ({ text: "", styles: { colorToken: "" } }))
+        Array.from({ length: 2 }, () => ({ text: "", styleOverrides: { colorToken: "" } }))
       ),
     }
   );
@@ -112,12 +114,14 @@ export default function ElementAttributesPane({
   // using id/type avoids resets when the parent simply updates
   // the same element instance with new references
   useEffect(() => {
-    setColorToken(element.styles?.colorToken ?? "");
-    setFontSize(element.styles?.fontSize || "16px");
-    setFontFamily(element.styles?.fontFamily || availableFonts[0].fontFamily);
-    setFontWeight(element.styles?.fontWeight || "normal");
-    setLineHeight(element.styles?.lineHeight || "1.2");
-    setTextAlign(element.styles?.textAlign || "left");
+    setColorToken(element.styleOverrides?.colorToken ?? "");
+    setFontSize(element.styleOverrides?.fontSize || "16px");
+    setFontFamily(
+      element.styleOverrides?.fontFamily || availableFonts[0].fontFamily
+    );
+    setFontWeight(element.styleOverrides?.fontWeight || "normal");
+    setLineHeight(element.styleOverrides?.lineHeight || "1.2");
+    setTextAlign(element.styleOverrides?.textAlign || "left");
     setText(element.text || "");
     setSrc(element.src || "");
     setUrl(element.url || "");
@@ -129,7 +133,7 @@ export default function ElementAttributesPane({
         rows: 2,
         cols: 2,
         cells: Array.from({ length: 2 }, () =>
-          Array.from({ length: 2 }, () => ({ text: "", styles: { colorToken: "" } }))
+          Array.from({ length: 2 }, () => ({ text: "", styleOverrides: { colorToken: "" } }))
         ),
       }
     );
@@ -166,8 +170,8 @@ export default function ElementAttributesPane({
     };
     if (element.type === "text") {
       updated.text = text;
-      updated.styles = {
-        ...element.styles,
+      updated.styleOverrides = {
+        ...element.styleOverrides,
         colorToken,
         fontSize,
         fontFamily,

--- a/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
@@ -54,7 +54,7 @@ export default function TableAttributes({
     Array.from({ length: newRows }, (_, r) =>
       Array.from(
         { length: newCols },
-        (_, c) => prev[r]?.[c] || { text: "", styles: { colorToken: "" } }
+        (_, c) => prev[r]?.[c] || { text: "", styleOverrides: { colorToken: "" } }
       )
     );
 
@@ -151,11 +151,14 @@ export default function TableAttributes({
                     }
                   />
                   <PaletteColorPicker
-                    value={tokenKeys.indexOf(cell.styles?.colorToken ?? "")}
+                    value={tokenKeys.indexOf(cell.styleOverrides?.colorToken ?? "")}
                     onChange={(idx) =>
                       updateCell(rIdx, cIdx, {
                         ...cell,
-                        styles: { ...cell.styles, colorToken: tokenKeys[idx] },
+                        styleOverrides: {
+                          ...cell.styleOverrides,
+                          colorToken: tokenKeys[idx],
+                        },
                       })
                     }
                     paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}

--- a/insight-fe/src/components/lesson/hooks/useDnDHandlers.ts
+++ b/insight-fe/src/components/lesson/hooks/useDnDHandlers.ts
@@ -51,7 +51,7 @@ export default function useDnDHandlers(
                 ...(type === "text"
                   ? {
                       text: "Sample Text",
-                      styles: {
+                      styleOverrides: {
                         colorToken: options.defaultColorToken,
                         fontSize: "16px",
                         fontFamily: options.defaultFontFamily,
@@ -74,7 +74,7 @@ export default function useDnDHandlers(
                           cells: Array.from({ length: 2 }, () =>
                             Array.from({ length: 2 }, () => ({
                               text: "Cell",
-                              styles: {
+                              styleOverrides: {
                                 colorToken: options.defaultColorToken,
                                 fontSize: "14px",
                                 fontFamily: options.defaultFontFamily,

--- a/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
@@ -57,12 +57,12 @@ export default function SlideElementRenderer({
     content = (
       <ElementWrapper styles={item.wrapperStyles} data-testid="text-element">
         <Text
-          fontSize={item.styles?.fontSize}
-          fontFamily={item.styles?.fontFamily}
-          fontWeight={item.styles?.fontWeight}
-          lineHeight={item.styles?.lineHeight}
-          textAlign={item.styles?.textAlign as any}
-          color={tokenColor(tokens, item.styles?.colorToken)}
+          fontSize={item.styleOverrides?.fontSize}
+          fontFamily={item.styleOverrides?.fontFamily}
+          fontWeight={item.styleOverrides?.fontWeight}
+          lineHeight={item.styleOverrides?.lineHeight}
+          textAlign={item.styleOverrides?.textAlign as any}
+          color={tokenColor(tokens, item.styleOverrides?.colorToken)}
           {...(resolveVariant(variants, item.variantId)?.props ?? {})}
         >
           {item.text || "Sample Text"}
@@ -79,12 +79,12 @@ export default function SlideElementRenderer({
                 {row.map((cell, cIdx) => (
                   <Td key={cIdx} p={1}>
                     <Text
-                      fontSize={cell.styles?.fontSize}
-                      fontFamily={cell.styles?.fontFamily}
-                      fontWeight={cell.styles?.fontWeight}
-                      lineHeight={cell.styles?.lineHeight}
-                      textAlign={cell.styles?.textAlign as any}
-                      color={tokenColor(tokens, cell.styles?.colorToken)}
+                      fontSize={cell.styleOverrides?.fontSize}
+                      fontFamily={cell.styleOverrides?.fontFamily}
+                      fontWeight={cell.styleOverrides?.fontWeight}
+                      lineHeight={cell.styleOverrides?.lineHeight}
+                      textAlign={cell.styleOverrides?.textAlign as any}
+                      color={tokenColor(tokens, cell.styleOverrides?.colorToken)}
                     >
                       {cell.text}
                     </Text>

--- a/insight-fe/src/components/lesson/utils/migrateContent.ts
+++ b/insight-fe/src/components/lesson/utils/migrateContent.ts
@@ -1,0 +1,54 @@
+import { SemanticTokens } from "@/theme/helpers";
+import { Slide } from "../slide/SlideSequencer";
+import { SlideElementDnDItemProps, TableCell } from "@/components/DnD/cards/SlideElementDnDCard";
+
+/**
+ * Convert legacy lesson content using color palette indices to the
+ * current format using semantic token names.
+ */
+export function migrateSlides(slides: Slide[], tokens?: SemanticTokens): Slide[] {
+  const tokenKeys = tokens ? Object.keys(tokens.colors ?? {}) : [];
+
+  const migrateCell = (cell: TableCell): TableCell => {
+    const styles: any = (cell as any).styles;
+    if (styles) {
+      const { colorIndex, ...rest } = styles;
+      const colorToken =
+        typeof colorIndex === "number" ? tokenKeys[colorIndex] : styles.colorToken;
+      (cell as any).styleOverrides = {
+        ...rest,
+        ...(colorToken ? { colorToken } : {}),
+      };
+      delete (cell as any).styles;
+    }
+    return cell;
+  };
+
+  const migrateItem = (item: SlideElementDnDItemProps): SlideElementDnDItemProps => {
+    const styles: any = (item as any).styles;
+    if (styles) {
+      const { colorIndex, ...rest } = styles;
+      const colorToken =
+        typeof colorIndex === "number" ? tokenKeys[colorIndex] : styles.colorToken;
+      (item as any).styleOverrides = {
+        ...rest,
+        ...(colorToken ? { colorToken } : {}),
+      };
+      delete (item as any).styles;
+    }
+    if (item.table?.cells) {
+      item.table.cells = item.table.cells.map((row) => row.map(migrateCell));
+    }
+    return item;
+  };
+
+  return slides.map((slide) => ({
+    ...slide,
+    columnMap: Object.fromEntries(
+      Object.entries(slide.columnMap).map(([id, col]) => [
+        id,
+        { ...col, items: col.items.map(migrateItem) },
+      ])
+    ),
+  }));
+}


### PR DESCRIPTION
## Summary
- update lesson element interfaces to use `styleOverrides`
- migrate existing lesson data from palette colors to token names
- adjust element attribute UI and handlers for new format
- convert loaded lessons via migration logic

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6849731dd6a08326a17e9dbba24920f6