### PR TITLE
Switch wrapper defaults to semantic tokens

### DIFF
--- a/insight-fe/src/components/lesson/defaultStyles.ts
+++ b/insight-fe/src/components/lesson/defaultStyles.ts
@@ -1,7 +1,7 @@
 import type { ElementWrapperStyles } from "./elements/ElementWrapper";
 
 export const defaultColumnWrapperStyles: ElementWrapperStyles = {
-  bgColor: "#ffffff",
+  bgColor: "surface.card",
   bgOpacity: 0,
   gradientFrom: "",
   gradientTo: "",
@@ -11,7 +11,7 @@ export const defaultColumnWrapperStyles: ElementWrapperStyles = {
   paddingY: 0,
   marginX: 0,
   marginY: 0,
-  borderColor: "#000000",
+  borderColor: "border.default",
   borderWidth: 0,
   borderRadius: "none",
 };

--- a/insight-fe/src/components/lesson/hooks/useStyleAttributes.ts
+++ b/insight-fe/src/components/lesson/hooks/useStyleAttributes.ts
@@ -24,7 +24,9 @@ export default function useStyleAttributes({
   onChange,
   defaultBgOpacity = 0,
 }: UseStyleAttributesOptions) {
-  const [bgColor, setBgColor] = useState(wrapperStyles?.bgColor || "#ffffff");
+  const [bgColor, setBgColor] = useState(
+    wrapperStyles?.bgColor || "surface.card"
+  );
   const [bgOpacity, setBgOpacity] = useState(
     wrapperStyles?.bgOpacity ?? defaultBgOpacity
   );
@@ -46,7 +48,7 @@ export default function useStyleAttributes({
   const [marginX, setMarginX] = useState(wrapperStyles?.marginX ?? 0);
   const [marginY, setMarginY] = useState(wrapperStyles?.marginY ?? 0);
   const [borderColor, setBorderColor] = useState(
-    wrapperStyles?.borderColor || "#000000"
+    wrapperStyles?.borderColor || "border.default"
   );
   const [borderWidth, setBorderWidth] = useState(
     wrapperStyles?.borderWidth ?? 0
@@ -58,7 +60,7 @@ export default function useStyleAttributes({
 
   // Reset when dependencies change (new item selected)
   useEffect(() => {
-    setBgColor(wrapperStyles?.bgColor || "#ffffff");
+    setBgColor(wrapperStyles?.bgColor || "surface.card");
     setBgOpacity(wrapperStyles?.bgOpacity ?? defaultBgOpacity);
     setGradientFrom(wrapperStyles?.gradientFrom || "");
     setGradientTo(wrapperStyles?.gradientTo || "");
@@ -73,7 +75,7 @@ export default function useStyleAttributes({
     setPaddingY(wrapperStyles?.paddingY ?? 0);
     setMarginX(wrapperStyles?.marginX ?? 0);
     setMarginY(wrapperStyles?.marginY ?? 0);
-    setBorderColor(wrapperStyles?.borderColor || "#000000");
+    setBorderColor(wrapperStyles?.borderColor || "border.default");
     setBorderWidth(wrapperStyles?.borderWidth ?? 0);
     setBorderRadius(wrapperStyles?.borderRadius || "none");
     setSpacing(initialSpacing);


### PR DESCRIPTION
## Summary
- use token-based defaults in `defaultStyles`
- update `useStyleAttributes` to use token defaults

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684978a5ffe88326b68d9044c1a7253d