### PR TITLE
Refactor lesson content to typed slides

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/dto/column.dto.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/dto/column.dto.ts
@@ -1,0 +1,27 @@
+import { Field, ObjectType, InputType } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
+import { ElementDto, ElementInput } from './element.dto';
+
+@InputType('LessonColumnInput')
+export class ColumnInput {
+  @Field()
+  columnId: string;
+
+  @Field({ nullable: true })
+  title?: string;
+
+  @Field(() => [ElementInput])
+  items: ElementInput[];
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  wrapperStyles?: Record<string, any>;
+
+  @Field({ nullable: true })
+  spacing?: number;
+}
+
+@ObjectType('LessonColumn')
+export class ColumnDto extends ColumnInput {
+  @Field(() => [ElementDto])
+  override items: ElementDto[];
+}

--- a/insight-be/src/modules/timbuktu/administrative/lesson/dto/element.dto.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/dto/element.dto.ts
@@ -1,0 +1,51 @@
+import { Field, ObjectType, InputType, ID } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
+import { PageElementType } from '../../style/page-element-type';
+
+@InputType('LessonElementInput')
+export class ElementInput {
+  @Field()
+  id: string;
+
+  @Field(() => ID, { nullable: true })
+  styleId?: number;
+
+  @Field(() => ID, { nullable: true })
+  variantId?: number;
+
+  @Field(() => PageElementType)
+  type: PageElementType;
+
+  @Field({ nullable: true })
+  text?: string;
+
+  @Field({ nullable: true })
+  url?: string;
+
+  @Field({ nullable: true })
+  src?: string;
+
+  @Field({ nullable: true })
+  title?: string;
+
+  @Field({ nullable: true })
+  description?: string;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  questions?: Record<string, any>;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  table?: Record<string, any>;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  styleOverrides?: Record<string, any>;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  wrapperStyles?: Record<string, any>;
+
+  @Field(() => GraphQLJSONObject, { nullable: true })
+  animation?: Record<string, any>;
+}
+
+@ObjectType('LessonElement')
+export class ElementDto extends ElementInput {}

--- a/insight-be/src/modules/timbuktu/administrative/lesson/dto/slide.dto.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/dto/slide.dto.ts
@@ -1,0 +1,20 @@
+import { Field, ObjectType, InputType } from '@nestjs/graphql';
+import { ColumnDto, ColumnInput } from './column.dto';
+
+@InputType('LessonSlideInput')
+export class SlideInput {
+  @Field()
+  id: string;
+
+  @Field()
+  title: string;
+
+  @Field(() => [ColumnInput])
+  columns: ColumnInput[];
+}
+
+@ObjectType('LessonSlide')
+export class SlideDto extends SlideInput {
+  @Field(() => [ColumnDto])
+  override columns: ColumnDto[];
+}

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
@@ -11,6 +11,7 @@ import {
 } from 'typeorm';
 import { ObjectType, Field, ID } from '@nestjs/graphql';
 import { GraphQLJSONObject } from 'graphql-type-json';
+import { SlideDto } from './dto/slide.dto';
 
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { EducatorProfileEntity } from '../../user-profiles/educator-profile/educator-profile.entity';
@@ -33,9 +34,9 @@ export class LessonEntity extends AbstractBaseEntity {
   @Column({ type: 'text', nullable: true })
   description?: string;
 
-  @Field(() => GraphQLJSONObject, { nullable: true })
+  @Field(() => [SlideDto], { nullable: true })
   @Column({ type: 'jsonb', nullable: true })
-  content?: Record<string, any>;
+  content?: SlideDto[];
 
   /* ---------- theme ---------- */
 

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
@@ -1,6 +1,6 @@
 import { PartialType, InputType, Field, ID } from '@nestjs/graphql';
-import { GraphQLJSONObject } from 'graphql-type-json';
 import { HasRelationsInput } from 'src/common/base.inputs';
+import { SlideInput } from './dto/slide.dto';
 
 @InputType()
 export class CreateLessonInput extends HasRelationsInput {
@@ -10,8 +10,8 @@ export class CreateLessonInput extends HasRelationsInput {
   @Field({ nullable: true })
   description?: string;
 
-  @Field(() => GraphQLJSONObject, { nullable: true })
-  content?: Record<string, any>;
+  @Field(() => [SlideInput], { nullable: true })
+  content?: SlideInput[];
 
   @Field(() => ID)
   themeId: number;


### PR DESCRIPTION
## Summary
- add Element, Column and Slide DTOs
- use these DTOs for lesson content

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_6849798b6e7083268c361d6692925a5f