### PR TITLE
Fix TS2612 overrides in lesson DTOs

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/dto/column.dto.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/dto/column.dto.ts
@@ -23,5 +23,5 @@ export class ColumnInput {
 @ObjectType('LessonColumn')
 export class ColumnDto extends ColumnInput {
   @Field(() => [ElementDto])
-  override items: ElementDto[];
+  declare override items: ElementDto[];
 }

--- a/insight-be/src/modules/timbuktu/administrative/lesson/dto/slide.dto.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/dto/slide.dto.ts
@@ -16,5 +16,5 @@ export class SlideInput {
 @ObjectType('LessonSlide')
 export class SlideDto extends SlideInput {
   @Field(() => [ColumnDto])
-  override columns: ColumnDto[];
+  declare override columns: ColumnDto[];
 }


### PR DESCRIPTION
## Summary
- fix override usage in `LessonColumn` and `LessonSlide` DTOs

## Testing
- `npm run build` *(fails: `nest` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497d5f68608326a4605557b0aadf5d