### PR TITLE
Fix LessonService dependency injection

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.module.ts
@@ -3,9 +3,10 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { LessonService } from './lesson.service';
 import { LessonResolver } from './lesson.resolver';
 import { LessonEntity } from './lesson.entity';
+import { ThemeEntity } from '../theme/theme.entity';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([LessonEntity])],
+  imports: [TypeOrmModule.forFeature([LessonEntity, ThemeEntity])],
   providers: [LessonService, LessonResolver],
   exports: [LessonService],
 })


### PR DESCRIPTION
## Summary
- add ThemeEntity to LessonModule's TypeORM feature list so that LessonService can inject ThemeEntityRepository

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68497f38dfc88326ab6ddf0724922b3d