### PR TITLE
Fix GraphQL schema generation error

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/dto/element.dto.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/dto/element.dto.ts
@@ -3,6 +3,7 @@ import { GraphQLJSONObject } from 'graphql-type-json';
 import { PageElementType } from '../../style/page-element-type';
 
 @InputType('LessonElementInput')
+@ObjectType('LessonElement')
 export class ElementInput {
   @Field()
   id: string;
@@ -47,5 +48,4 @@ export class ElementInput {
   animation?: Record<string, any>;
 }
 
-@ObjectType('LessonElement')
-export class ElementDto extends ElementInput {}
+export { ElementInput as ElementDto };


### PR DESCRIPTION
## Summary
- ensure `LessonElement` GraphQL type has fields by decorating `ElementInput` as both input and object type

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684983d3b9c08326b2923182a90be6eb