### PR TITLE
Add theme version tracking for lessons

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.entity.ts
@@ -50,6 +50,10 @@ export class LessonEntity extends AbstractBaseEntity {
   @RelationId((lesson: LessonEntity) => lesson.theme)
   themeId!: number;
 
+  @Field()
+  @Column({ name: 'theme_version', default: 1 })
+  themeVersion!: number;
+
   @Field(() => Date, { nullable: true })
   @Column({ name: 'last_theme_upgrade', type: 'timestamptz', nullable: true })
   lastThemeUpgrade?: Date;

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.inputs.ts
@@ -16,6 +16,9 @@ export class CreateLessonInput extends HasRelationsInput {
   @Field(() => ID)
   themeId: number;
 
+  @Field({ nullable: true })
+  themeVersion?: number;
+
   @Field(() => [ID], { nullable: 'itemsAndList' })
   recommendedYearGroupIds?: number[];
 
@@ -33,7 +36,4 @@ export class UpdateLessonInput extends PartialType(CreateLessonInput) {
 export class UpgradeLessonThemeInput {
   @Field(() => ID)
   lessonId: number;
-
-  @Field()
-  version: number;
 }

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.resolver.ts
@@ -35,6 +35,6 @@ export class LessonResolver extends BaseLessonResolver {
   async upgradeLessonTheme(
     @Args('data', { type: () => UpgradeLessonThemeInput }) data: UpgradeLessonThemeInput,
   ): Promise<LessonEntity> {
-    return this.lessonService.upgradeThemeVersion(data.lessonId, data.version);
+    return this.lessonService.upgradeThemeVersion(data.lessonId);
   }
 }


### PR DESCRIPTION
## Summary
- add `themeVersion` column in `LessonEntity`
- expose `themeVersion` in lesson inputs
- set lesson's `themeVersion` to the referenced theme version on create/update
- update lesson theme upgrades to copy version to the lesson

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684988e61e888326855532bdfb56c71a