### PR TITLE
Enable dynamic palette switching

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -18,6 +18,7 @@ export const LessonBuilderPageClient = () => {
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [previewSlides, setPreviewSlides] = useState<Slide[]>([]);
   const [previewThemeId, setPreviewThemeId] = useState<number | undefined>();
+  const [previewPaletteId, setPreviewPaletteId] = useState<number | undefined>();
   const editorRef = useRef<LessonEditorHandle>(null);
 
   const [createLesson, { loading: saving }] = useMutation(CREATE_LESSON, {
@@ -32,6 +33,8 @@ export const LessonBuilderPageClient = () => {
     setPreviewSlides(slides);
     const themeId = editorRef.current?.getThemeId();
     setPreviewThemeId(themeId === "" ? undefined : (themeId as number));
+    const paletteId = editorRef.current?.getPaletteId?.();
+    setPreviewPaletteId(paletteId === "" ? undefined : (paletteId as number));
     setIsPreviewOpen(true);
   };
 
@@ -130,6 +133,7 @@ export const LessonBuilderPageClient = () => {
           onClose={() => setIsPreviewOpen(false)}
           slides={previewSlides}
           themeId={previewThemeId}
+          paletteId={previewPaletteId}
         />
       )}
     </Flex>

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -10,6 +10,7 @@ import {
   GET_STYLES_WITH_CONFIG_BY_GROUP,
   GET_STYLE_GROUPS,
   GET_COLOR_PALETTES,
+  GET_COLOR_PALETTE,
   GET_THEMES,
 } from "@/graphql/lesson";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
@@ -86,6 +87,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
   const [fetchGroups, { data: groupsData }] = useLazyQuery(GET_STYLE_GROUPS);
   const [fetchPalettes, { data: palettesData }] = useLazyQuery(GET_COLOR_PALETTES);
   const [fetchThemes, { data: themesData }] = useLazyQuery(GET_THEMES);
+  const [fetchPalette, { data: paletteData }] = useLazyQuery(GET_COLOR_PALETTE);
 
   const selectedPalette =
     selectedPaletteId !== ""
@@ -242,15 +244,37 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
       const theme = themes.find((t) => t.id === selectedThemeId);
       if (theme) {
         setSelectedPaletteId(theme.defaultPaletteId);
-        setChakraTheme(
-          extendTheme(baseTheme, {
-            ...theme.foundationTokens,
-            semanticTokens: theme.semanticTokens,
-          })
-        );
       }
     }
   }, [selectedThemeId, themes]);
+
+  useEffect(() => {
+    if (selectedPaletteId !== "") {
+      fetchPalette({ variables: { id: String(selectedPaletteId) } });
+    }
+  }, [selectedPaletteId]);
+
+  useEffect(() => {
+    if (!selectedTheme) return;
+    const foundation = JSON.parse(
+      JSON.stringify(selectedTheme.foundationTokens || {}),
+    );
+    if (foundation.colors && paletteData?.getColorPalette?.colors) {
+      const keys = Object.keys(foundation.colors);
+      const merged: Record<string, string> = {};
+      keys.forEach((key, idx) => {
+        merged[key] =
+          paletteData.getColorPalette.colors[idx] ?? foundation.colors[key];
+      });
+      foundation.colors = merged;
+    }
+    setChakraTheme(
+      extendTheme(baseTheme, {
+        ...foundation,
+        semanticTokens: selectedTheme.semanticTokens,
+      }),
+    );
+  }, [selectedTheme, paletteData]);
 
   const handleUpdatePalette = async (palette: {
     id: number;

--- a/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { Box, Stack, Text } from "@chakra-ui/react";
+import { Box, Stack, Text, ChakraProvider, extendTheme } from "@chakra-ui/react";
 import { BaseModal } from "../../modals/BaseModal";
 import SlidePreview from "../slide/SlidePreview";
 import { Slide } from "../slide/SlideSequencer";
 import { useQuery } from "@apollo/client";
-import { GET_THEME } from "@/graphql/lesson";
+import { GET_THEME, GET_COLOR_PALETTE } from "@/graphql/lesson";
 import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
+import baseTheme from "@/theme/theme";
 
 interface LessonPreviewModalProps {
   isOpen: boolean;
   onClose: () => void;
   slides: Slide[];
   themeId?: number;
+  paletteId?: number;
 }
 
 export default function LessonPreviewModal({
@@ -20,15 +22,37 @@ export default function LessonPreviewModal({
   onClose,
   slides,
   themeId,
+  paletteId,
 }: LessonPreviewModalProps) {
   const { data: themeData } = useQuery(GET_THEME, {
     variables: { id: String(themeId) },
     skip: !themeId || !isOpen,
   });
 
+  const { data: paletteData } = useQuery(GET_COLOR_PALETTE, {
+    variables: { id: String(paletteId) },
+    skip: !paletteId || !isOpen,
+  });
+
   const theme = themeData?.getTheme;
   const tokens: SemanticTokens | undefined = theme?.semanticTokens;
   const variants: ComponentVariant[] | undefined = theme?.componentVariants;
+
+  const foundation = theme ? { ...(theme.foundationTokens as any) } : undefined;
+  if (foundation?.colors && paletteData?.getColorPalette?.colors) {
+    const keys = Object.keys(foundation.colors);
+    const merged: Record<string, string> = {};
+    keys.forEach((k, idx) => {
+      merged[k] = paletteData.getColorPalette.colors[idx] ?? foundation.colors[k];
+    });
+    foundation.colors = merged;
+  }
+  const chakraTheme = theme
+    ? extendTheme(baseTheme, {
+        ...(foundation || {}),
+        semanticTokens: theme.semanticTokens,
+      })
+    : baseTheme;
 
   return (
     <BaseModal
@@ -37,7 +61,8 @@ export default function LessonPreviewModal({
       size="6xl"
       title="Lesson Preview"
     >
-      <Stack spacing={6} py={2}>
+      <ChakraProvider theme={chakraTheme}>
+        <Stack spacing={6} py={2}>
         {slides.length === 0 && <Text>No slides available</Text>}
         {slides.map((slide) => (
           <Box key={slide.id}>
@@ -52,7 +77,8 @@ export default function LessonPreviewModal({
             />
           </Box>
         ))}
-      </Stack>
+        </Stack>
+      </ChakraProvider>
     </BaseModal>
   );
 }


### PR DESCRIPTION
## Summary
- fetch palette colors when switching palettes
- merge palette colors with foundation tokens and extend Chakra theme
- pass palette info to preview modal and wrap preview in ChakraProvider

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498a6bc4dc832681eb192352502673