### PR TITLE
Add accessible labels to variants

### DIFF
--- a/insight-fe/jest.config.js
+++ b/insight-fe/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  testEnvironment: 'jsdom',
+  transform: {
+    '^.+\\.(t|j)sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  testRegex: '.*\\.test\\.(t|j)sx?$',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/insight-fe/jest.setup.ts
+++ b/insight-fe/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/insight-fe/package.json
+++ b/insight-fe/package.json
@@ -9,7 +9,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@apollo/client": "3.12",
@@ -48,6 +49,11 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.24",
     "graphql-zeus": "^7.0.5",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@types/jest": "^29.5.14",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@testing-library/react": "^14.1.2",
+    "@testing-library/jest-dom": "^6.1.5"
   }
 }

--- a/insight-fe/src/components/lesson/elements/ImageElement.tsx
+++ b/insight-fe/src/components/lesson/elements/ImageElement.tsx
@@ -5,18 +5,21 @@ import ElementWrapper, { ElementWrapperStyles } from "./ElementWrapper";
 
 interface ImageElementProps {
   src: string;
+  /** Accessible alternative text */
+  alt?: string;
   wrapperStyles?: ElementWrapperStyles;
 }
 
 export default function ImageElement({
   src,
+  alt,
   wrapperStyles,
 }: ImageElementProps) {
   return (
     <ElementWrapper styles={wrapperStyles} data-testid="image-element">
       <Image
         src={src}
-        alt="lesson image"
+        alt={alt || "lesson image"}
         objectFit="contain"
         draggable={false}
       />

--- a/insight-fe/src/components/lesson/slide/SlideElementRenderer.test.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementRenderer.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import SlideElementRenderer from './SlideElementRenderer';
+import { SlideElementDnDItemProps } from '@/components/DnD/cards/SlideElementDnDCard';
+import { ComponentVariant } from '@/theme/helpers';
+
+describe('SlideElementRenderer', () => {
+  it('applies accessible label from variant', () => {
+    const item: SlideElementDnDItemProps = {
+      id: '1',
+      type: 'text',
+      text: 'Hello',
+      variantId: 1,
+    } as any;
+
+    const variants: ComponentVariant[] = [
+      {
+        id: 1,
+        baseComponent: 'Text',
+        accessibleName: 'Greeting text',
+        props: {},
+      },
+    ];
+
+    render(<SlideElementRenderer item={item} variants={variants} />);
+
+    expect(screen.getByLabelText('Greeting text')).toBeInTheDocument();
+  });
+});

--- a/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
@@ -24,6 +24,10 @@ export default function SlideElementRenderer({
   variants,
 }: SlideElementRendererProps) {
   const MotionBox = motion(Box);
+  const variant = resolveVariant(variants, item.variantId);
+  const ariaProps = variant?.accessibleName
+    ? { "aria-label": variant.accessibleName }
+    : {};
   const animationProps = item.animation
     ? {
         initial: {
@@ -98,7 +102,11 @@ export default function SlideElementRenderer({
     );
   } else if (item.type === "image") {
     content = (
-      <ImageElement src={item.src || ""} wrapperStyles={item.wrapperStyles} />
+      <ImageElement
+        src={item.src || ""}
+        alt={variant?.accessibleName}
+        wrapperStyles={item.wrapperStyles}
+      />
     );
   } else if (item.type === "video") {
     content = (
@@ -115,5 +123,9 @@ export default function SlideElementRenderer({
     );
   }
 
-  return <MotionBox {...animationProps}>{content}</MotionBox>;
+  return (
+    <MotionBox {...animationProps} {...ariaProps}>
+      {content}
+    </MotionBox>
+  );
 }

--- a/insight-fe/src/theme/helpers.ts
+++ b/insight-fe/src/theme/helpers.ts
@@ -1,6 +1,8 @@
 export interface ComponentVariant {
   id: number;
   baseComponent: string;
+  /** Human readable name for screen readers */
+  accessibleName?: string;
   props: Record<string, any>;
 }
 


### PR DESCRIPTION
## Summary
- extend ComponentVariant with `accessibleName`
- add aria-label logic in `SlideElementRenderer`
- allow `ImageElement` to accept `alt` text
- configure Jest for `insight-fe` and add unit test for accessibility

## Testing
- `npm test` in `insight-fe` *(fails: jest not found)*
- `npm test` in `insight-be` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498cf899088326a9cf8d9c3b395326