### PR TITLE
Restrict lesson style overrides

### DIFF
--- a/insight-be/src/validators/theme/style-overrides.validator.spec.ts
+++ b/insight-be/src/validators/theme/style-overrides.validator.spec.ts
@@ -1,0 +1,46 @@
+import { BadRequestException } from '@nestjs/common';
+import { validateStyleOverrides } from './style-overrides.validator';
+
+describe('validateStyleOverrides', () => {
+  const allowedTokens = ['primary', 'secondary'];
+
+  it('allows valid overrides', () => {
+    const content = {
+      styleOverrides: { colorToken: 'colors.primary', fontSize: '16px' },
+    };
+    expect(() =>
+      validateStyleOverrides(content, allowedTokens),
+    ).not.toThrow();
+  });
+
+  it('rejects invalid token', () => {
+    const content = {
+      styleOverrides: { colorToken: 'colors.danger' },
+    };
+    expect(() => validateStyleOverrides(content, allowedTokens)).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('rejects unknown field', () => {
+    const content = {
+      styleOverrides: { colorToken: 'colors.primary', foo: 'bar' },
+    };
+    expect(() => validateStyleOverrides(content, allowedTokens)).toThrow(
+      BadRequestException,
+    );
+  });
+
+  it('validates nested objects', () => {
+    const content = {
+      slides: [
+        {
+          items: [{ styleOverrides: { colorToken: 'colors.secondary' } }],
+        },
+      ],
+    };
+    expect(() =>
+      validateStyleOverrides(content, allowedTokens),
+    ).not.toThrow();
+  });
+});

--- a/insight-be/src/validators/theme/style-overrides.validator.ts
+++ b/insight-be/src/validators/theme/style-overrides.validator.ts
@@ -1,10 +1,21 @@
 import { BadRequestException } from '@nestjs/common';
 
+const DEFAULT_ALLOWED_FIELDS = [
+  'colorToken',
+  'fontSize',
+  'fontFamily',
+  'fontWeight',
+  'lineHeight',
+  'textAlign',
+];
+
 export function validateStyleOverrides(
   content: any,
   allowedTokens: string[],
+  allowedFields: string[] = DEFAULT_ALLOWED_FIELDS,
 ): void {
   const allowed = new Set(allowedTokens);
+  const allowedFieldsSet = new Set(allowedFields);
 
   function walk(val: any): void {
     if (!val || typeof val !== 'object') return;
@@ -12,13 +23,24 @@ export function validateStyleOverrides(
       val.forEach(walk);
       return;
     }
-    if (val.styleOverrides?.colorToken) {
-      const tokenPath = val.styleOverrides.colorToken as string;
-      const key = tokenPath.split('.').pop() as string;
-      if (!allowed.has(key)) {
-        throw new BadRequestException(
-          `Style override token "${tokenPath}" is not permitted`,
-        );
+    if (val.styleOverrides) {
+      const overrides = val.styleOverrides as Record<string, any>;
+      for (const key of Object.keys(overrides)) {
+        if (!allowedFieldsSet.has(key)) {
+          throw new BadRequestException(
+            `Style override field "${key}" is not permitted`,
+          );
+        }
+      }
+
+      if (overrides.colorToken) {
+        const tokenPath = overrides.colorToken as string;
+        const tokenKey = tokenPath.split('.').pop() as string;
+        if (!allowed.has(tokenKey)) {
+          throw new BadRequestException(
+            `Style override token "${tokenPath}" is not permitted`,
+          );
+        }
       }
     }
     Object.values(val).forEach(walk);

--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -84,13 +84,17 @@ export default function TextAttributes({
             <FormLabel mb="0" fontSize="sm" w="40%">
               Size
             </FormLabel>
-            <Input
+            <Select
               size="sm"
-              type="number"
-              w="60px"
-              value={parseInt(fontSize)}
-              onChange={(e) => setFontSize(e.target.value + "px")}
-            />
+              value={fontSize}
+              onChange={(e) => setFontSize(e.target.value)}
+            >
+              {['12px','14px','16px','18px','20px','24px','28px','32px'].map((s) => (
+                <option key={s} value={s}>
+                  {s}
+                </option>
+              ))}
+            </Select>
           </FormControl>
           <FormControl display="flex" alignItems="center">
             <FormLabel mb="0" fontSize="sm" w="40%">
@@ -128,13 +132,17 @@ export default function TextAttributes({
             <FormLabel mb="0" fontSize="sm" w="40%">
               Line Height
             </FormLabel>
-            <Input
+            <Select
               size="sm"
-              type="number"
-              w="60px"
-              value={parseFloat(lineHeight)}
+              value={lineHeight}
               onChange={(e) => setLineHeight(e.target.value)}
-            />
+            >
+              {['1','1.2','1.4','1.6','1.8'].map((lh) => (
+                <option key={lh} value={lh}>
+                  {lh}
+                </option>
+              ))}
+            </Select>
           </FormControl>
           <FormControl display="flex" alignItems="center">
             <FormLabel mb="0" fontSize="sm" w="40%">


### PR DESCRIPTION
## Summary
- validate lesson style override fields and token names
- add tests for style override validator
- restrict text attribute inputs to preset font size and line height options

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68498e6407fc832683f39f212f5ffde5