### PR TITLE
Resolve semantic tokens to final colors

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -434,7 +434,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
             handleDropElement={editor.handleDropElement}
             openSaveStyle={() => setIsSaveStyleOpen(true)}
             openLoadStyle={() => setIsLoadStyleOpen(true)}
-            tokens={selectedTheme?.semanticTokens}
+            tokens={chakraTheme}
             variants={selectedTheme?.componentVariants}
           />
 

--- a/insight-fe/src/components/lesson/attributes-pane/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/BoardAttributesPane.tsx
@@ -4,12 +4,12 @@ import { Accordion } from "@chakra-ui/react";
 import useStyleAttributes from "../hooks/useStyleAttributes";
 import WrapperSettings from "../attributes/WrapperSettings";
 import { BoardRow } from "../slide/SlideElementsContainer";
-import { SemanticTokens } from "@/theme/helpers";
+import { SemanticTokens, ThemeTokens } from "@/theme/helpers";
 
 interface BoardAttributesPaneProps {
   board: BoardRow;
   onChange: (updated: BoardRow) => void;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
 }
 
 export default function BoardAttributesPane({

--- a/insight-fe/src/components/lesson/attributes-pane/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ColumnAttributesPane.tsx
@@ -6,12 +6,12 @@ import { ColumnType } from "@/components/DnD/types";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import WrapperSettings from "../attributes/WrapperSettings";
 import useStyleAttributes from "../hooks/useStyleAttributes";
-import { SemanticTokens } from "@/theme/helpers";
+import { SemanticTokens, ThemeTokens } from "@/theme/helpers";
 
 interface ColumnAttributesPaneProps {
   column: ColumnType<SlideElementDnDItemProps>;
   onChange: (updated: ColumnType<SlideElementDnDItemProps>) => void;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
 }
 
 export default function ColumnAttributesPane({

--- a/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
@@ -13,14 +13,14 @@ import VideoAttributes from "../attributes/VideoAttributes";
 import TableAttributes from "../attributes/TableAttributes";
 import WrapperSettings from "../attributes/WrapperSettings";
 import useStyleAttributes from "../hooks/useStyleAttributes";
-import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
+import { ComponentVariant, SemanticTokens, ThemeTokens } from "@/theme/helpers";
 
 interface ElementAttributesPaneProps {
   element: SlideElementDnDItemProps;
   onChange: (updated: SlideElementDnDItemProps) => void;
   onClone?: () => void;
   onDelete?: () => void;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
   variants?: ComponentVariant[];
 }
 

--- a/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
@@ -15,7 +15,7 @@ import {
 import { useEffect, useState, useRef } from "react";
 import PaletteColorPicker from "../PaletteColorPicker";
 import { TableCell } from "@/components/DnD/cards/SlideElementDnDCard";
-import { SemanticTokens, tokenColor } from "@/theme/helpers";
+import { SemanticTokens, ThemeTokens, tokenColor } from "@/theme/helpers";
 
 interface TableAttributesProps {
   table: {
@@ -24,7 +24,7 @@ interface TableAttributesProps {
     cells: TableCell[][];
   };
   setTable: (table: { rows: number; cols: number; cells: TableCell[][] }) => void;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
 }
 
 export default function TableAttributes({
@@ -88,7 +88,11 @@ export default function TableAttributes({
     });
   };
 
-  const tokenKeys = tokens ? Object.keys(tokens.colors ?? {}) : [];
+  const tokenKeys = tokens
+    ? 'semanticTokens' in tokens
+      ? Object.keys(tokens.semanticTokens?.colors ?? {})
+      : Object.keys((tokens as any).colors ?? {})
+    : [];
 
   const updateCell = (r: number, c: number, cell: TableCell) => {
     updateTableCells((prev) => {

--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -14,7 +14,7 @@ import {
 } from "@chakra-ui/react";
 import { availableFonts } from "@/theme/fonts";
 import PaletteColorPicker from "../PaletteColorPicker";
-import { SemanticTokens, tokenColor, ComponentVariant } from "@/theme/helpers";
+import { SemanticTokens, ThemeTokens, tokenColor, ComponentVariant } from "@/theme/helpers";
 
 interface TextAttributesProps {
   text: string;
@@ -31,7 +31,7 @@ interface TextAttributesProps {
   setLineHeight: (val: string) => void;
   textAlign: string;
   setTextAlign: (val: string) => void;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
   variants?: ComponentVariant[];
 }
 
@@ -52,7 +52,11 @@ export default function TextAttributes({
   setTextAlign,
   tokens,
 }: TextAttributesProps) {
-  const tokenKeys = tokens ? Object.keys(tokens.colors ?? {}) : [];
+  const tokenKeys = tokens
+    ? 'semanticTokens' in tokens
+      ? Object.keys(tokens.semanticTokens?.colors ?? {})
+      : Object.keys((tokens as any).colors ?? {})
+    : [];
 
   return (
     <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>

--- a/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
@@ -16,11 +16,11 @@ import {
 } from "@chakra-ui/react";
 import type useStyleAttributes from "../hooks/useStyleAttributes";
 import PaletteColorPicker from "../PaletteColorPicker";
-import { SemanticTokens, tokenColor } from "@/theme/helpers";
+import { SemanticTokens, ThemeTokens, tokenColor } from "@/theme/helpers";
 
 interface WrapperSettingsProps {
   attrs: ReturnType<typeof useStyleAttributes>;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
 }
 
 export default function WrapperSettings({ attrs, tokens }: WrapperSettingsProps) {
@@ -57,7 +57,11 @@ export default function WrapperSettings({ attrs, tokens }: WrapperSettingsProps)
     setSpacing,
   } = attrs;
 
-  const tokenKeys = tokens ? Object.keys(tokens.colors ?? {}) : [];
+  const tokenKeys = tokens
+    ? 'semanticTokens' in tokens
+      ? Object.keys(tokens.semanticTokens?.colors ?? {})
+      : Object.keys((tokens as any).colors ?? {})
+    : [];
 
   return (
     <>

--- a/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
@@ -35,7 +35,6 @@ export default function LessonPreviewModal({
   });
 
   const theme = themeData?.getTheme;
-  const tokens: SemanticTokens | undefined = theme?.semanticTokens;
   const variants: ComponentVariant[] | undefined = theme?.componentVariants;
 
   const foundation = theme ? { ...(theme.foundationTokens as any) } : undefined;
@@ -72,7 +71,7 @@ export default function LessonPreviewModal({
             <SlidePreview
               columnMap={slide.columnMap}
               boards={slide.boards}
-              tokens={tokens}
+              tokens={chakraTheme}
               variants={variants}
             />
           </Box>

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -9,7 +9,7 @@ import ColumnAttributesPane from "../attributes-pane/ColumnAttributesPane";
 import ElementAttributesPane from "../attributes-pane/ElementAttributesPane";
 import SlideElementsContainer, { BoardRow } from "./SlideElementsContainer";
 import SlideSequencer, { Slide } from "./SlideSequencer";
-import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
+import { ComponentVariant, SemanticTokens, ThemeTokens } from "@/theme/helpers";
 
 interface SlideCanvasProps {
   slides: Slide[];
@@ -33,7 +33,7 @@ interface SlideCanvasProps {
   handleDropElement: (e: React.DragEvent<HTMLDivElement>) => void;
   openSaveStyle: () => void;
   openLoadStyle: () => void;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
   variants?: ComponentVariant[];
 }
 

--- a/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementRenderer.tsx
@@ -10,11 +10,11 @@ import ImageElement from "../elements/ImageElement";
 import QuizElement from "../elements/QuizElement";
 import VideoElement from "../elements/VideoElement";
 
-import { ComponentVariant, SemanticTokens, resolveVariant, tokenColor } from "@/theme/helpers";
+import { ComponentVariant, SemanticTokens, ThemeTokens, resolveVariant, tokenColor } from "@/theme/helpers";
 
 interface SlideElementRendererProps {
   item: SlideElementDnDItemProps;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
   variants?: ComponentVariant[];
 }
 

--- a/insight-fe/src/components/lesson/slide/SlideElementsContainer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementsContainer.tsx
@@ -13,7 +13,7 @@ import {
   defaultColumnWrapperStyles,
   defaultBoardWrapperStyles,
 } from "../defaultStyles";
-import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
+import { ComponentVariant, SemanticTokens, ThemeTokens } from "@/theme/helpers";
 import { ElementWrapperStyles } from "../elements/ElementWrapper";
 
 export interface BoardRow {
@@ -37,7 +37,7 @@ interface SlideElementsContainerProps {
   onSelectColumn?: (id: string) => void;
   selectedBoardId?: string | null;
   onSelectBoard?: (id: string) => void;
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
   variants?: ComponentVariant[];
 }
 

--- a/insight-fe/src/components/lesson/slide/SlidePreview.tsx
+++ b/insight-fe/src/components/lesson/slide/SlidePreview.tsx
@@ -7,12 +7,12 @@ import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnD
 import SlideElementRenderer from "./SlideElementRenderer";
 import { BoardRow } from "./SlideElementsContainer";
 import ElementWrapper from "../elements/ElementWrapper";
-import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
+import { ComponentVariant, SemanticTokens, ThemeTokens } from "@/theme/helpers";
 
 interface SlidePreviewProps {
   columnMap: ColumnMap<SlideElementDnDItemProps>;
   boards: BoardRow[];
-  tokens?: SemanticTokens;
+  tokens?: ThemeTokens;
   variants?: ComponentVariant[];
 }
 

--- a/insight-fe/src/theme/helpers.test.ts
+++ b/insight-fe/src/theme/helpers.test.ts
@@ -1,0 +1,15 @@
+import { tokenColor } from './helpers';
+
+describe('tokenColor', () => {
+  it('resolves semantic token to foundation color hex', () => {
+    const theme = {
+      semanticTokens: {
+        colors: {
+          brand: { primary: 'colors.blue.500' },
+        },
+      },
+      colors: { blue: { '500': '#3182CE' } },
+    };
+    expect(tokenColor(theme as any, 'colors.brand.primary')).toBe('#3182CE');
+  });
+});

--- a/insight-fe/src/theme/helpers.ts
+++ b/insight-fe/src/theme/helpers.ts
@@ -30,11 +30,45 @@ export function paletteColor(
 
 export type SemanticTokens = Record<string, Record<string, string>>;
 
-export function tokenColor(
-  tokens: SemanticTokens | undefined,
-  path: string | undefined,
-): string | undefined {
+export type ThemeTokens =
+  | SemanticTokens
+  | {
+      semanticTokens?: SemanticTokens;
+      foundationTokens?: { colors?: Record<string, any> };
+      colors?: Record<string, any>;
+    };
+
+function resolvePath(obj: any, path: string): any {
+  if (!obj) return undefined;
+  const parts = path.split('.');
+  let cur: any = obj;
+  for (let i = 0; i < parts.length; i++) {
+    if (cur == null) return undefined;
+    if (Object.prototype.hasOwnProperty.call(cur, parts[i])) {
+      cur = cur[parts[i]];
+    } else {
+      const remaining = parts.slice(i).join('.');
+      if (Object.prototype.hasOwnProperty.call(cur, remaining)) {
+        return cur[remaining];
+      }
+      return undefined;
+    }
+  }
+  return cur;
+}
+
+export function tokenColor(tokens: ThemeTokens | undefined, path: string | undefined): string | undefined {
   if (!tokens || !path) return undefined;
-  const [category, key] = path.split(".");
-  return tokens[category]?.[key];
+
+  const semRoot = 'semanticTokens' in tokens ? tokens.semanticTokens : tokens;
+  const semValue = resolvePath(semRoot, path);
+  if (typeof semValue !== 'string') return undefined;
+  if (semValue.startsWith('#')) return semValue;
+
+  const foundationPath = semValue.startsWith('colors.') ? semValue.slice(7) : semValue;
+  const foundationRoot =
+    ('colors' in tokens ? (tokens as any).colors : undefined) ??
+    (tokens as any).foundationTokens?.colors;
+  const color = resolvePath(foundationRoot, foundationPath);
+  return typeof color === 'string' ? color : semValue;
 }


### PR DESCRIPTION
## Summary
- update `tokenColor` to resolve semantic tokens to foundation color hex codes
- refactor components to pass the theme object to `tokenColor`
- cover color resolution with unit tests

## Testing
- `npm test` *(fails: jest missing)*

------
https://chatgpt.com/codex/tasks/task_e_684990f6044c8326ad6d26e5bf2a95dd