### PR TITLE
Fix background opacity for semantic tokens

### DIFF
--- a/insight-fe/src/components/lesson/elements/ElementWrapper.test.tsx
+++ b/insight-fe/src/components/lesson/elements/ElementWrapper.test.tsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import ElementWrapper from './ElementWrapper';
+
+const renderWithChakra = (ui: React.ReactElement) => {
+  return render(<ChakraProvider>{ui}</ChakraProvider>);
+};
+
+describe('ElementWrapper background', () => {
+  it('renders hex background with opacity', () => {
+    renderWithChakra(
+      <ElementWrapper
+        data-testid="wrapper"
+        styles={{ bgColor: '#ff0000', bgOpacity: 0.5 }}
+      >
+        Test
+      </ElementWrapper>
+    );
+    expect(screen.getByTestId('wrapper')).toHaveStyle(
+      'background: rgba(255, 0, 0, 0.5)'
+    );
+  });
+
+  it('renders token background with opacity', () => {
+    renderWithChakra(
+      <ElementWrapper
+        data-testid="wrapper"
+        styles={{ bgColor: 'red.500', bgOpacity: 0.5 }}
+      >
+        Test
+      </ElementWrapper>
+    );
+    expect(screen.getByTestId('wrapper')).toHaveStyle(
+      'background: rgba(var(--chakra-colors-red-500), 0.5)'
+    );
+  });
+});

--- a/insight-fe/src/components/lesson/elements/ElementWrapper.tsx
+++ b/insight-fe/src/components/lesson/elements/ElementWrapper.tsx
@@ -36,7 +36,11 @@ export default function ElementWrapper({ styles, children, ...props }: ElementWr
   const background = styles?.gradientFrom && styles?.gradientTo
     ? `linear-gradient(${styles.gradientDirection ?? 0}deg, ${styles.gradientFrom}, ${styles.gradientTo})`
     : styles?.bgColor
-    ? hexToRgba(styles.bgColor, styles.bgOpacity ?? 0)
+    ? styles.bgColor.startsWith('#')
+      ? hexToRgba(styles.bgColor, styles.bgOpacity ?? 0)
+      : `rgba(var(--chakra-colors-${styles.bgColor.replace(/\./g, '-')}), ${
+          styles.bgOpacity ?? 0
+        })`
     : undefined;
 
   return (


### PR DESCRIPTION
## Summary
- handle Chakra semantic tokens in `ElementWrapper`
- add unit tests for hex colors and token colors

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684993413a448326a436f9f859fc22f5