### PR TITLE
Fix palette color resolution

### DIFF
--- a/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
@@ -165,7 +165,7 @@ export default function TableAttributes({
                         },
                       })
                     }
-                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
+                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, k) || "")}
                   />
                 </Stack>
               ))

--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -81,7 +81,7 @@ export default function TextAttributes({
             <PaletteColorPicker
               value={tokenKeys.indexOf(colorToken)}
               onChange={(idx) => setColorToken(tokenKeys[idx])}
-              paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
+              paletteColors={tokenKeys.map((k) => tokenColor(tokens, k) || "")}
             />
           </FormControl>
           <FormControl display="flex" alignItems="center">

--- a/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
@@ -104,7 +104,7 @@ export default function WrapperSettings({ attrs, tokens }: WrapperSettingsProps)
                     setBgColor(tokenKeys[idx]);
                     setBgOpacity(1);
                   }}
-                  paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
+                  paletteColors={tokenKeys.map((k) => tokenColor(tokens, k) || "")}
                 />
               </FormControl>
             )}
@@ -115,7 +115,7 @@ export default function WrapperSettings({ attrs, tokens }: WrapperSettingsProps)
                   <PaletteColorPicker
                     value={tokenKeys.indexOf(gradientFrom)}
                     onChange={(idx) => setGradientFrom(tokenKeys[idx])}
-                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
+                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, k) || "")}
                   />
                 </FormControl>
                 <FormControl display="flex" alignItems="center">
@@ -123,7 +123,7 @@ export default function WrapperSettings({ attrs, tokens }: WrapperSettingsProps)
                   <PaletteColorPicker
                     value={tokenKeys.indexOf(gradientTo)}
                     onChange={(idx) => setGradientTo(tokenKeys[idx])}
-                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
+                    paletteColors={tokenKeys.map((k) => tokenColor(tokens, k) || "")}
                   />
                 </FormControl>
                 <FormControl display="flex" alignItems="center">
@@ -260,7 +260,7 @@ export default function WrapperSettings({ attrs, tokens }: WrapperSettingsProps)
               <PaletteColorPicker
                 value={tokenKeys.indexOf(borderColor)}
                 onChange={(idx) => setBorderColor(tokenKeys[idx])}
-                paletteColors={tokenKeys.map((k) => tokenColor(tokens, `colors.${k}`) || "")}
+                paletteColors={tokenKeys.map((k) => tokenColor(tokens, k) || "")}
               />
             </FormControl>
             <FormControl display="flex" alignItems="center">


### PR DESCRIPTION
## Summary
- improve `tokenColor` to handle bare token names and return hex values
- resolve palette colors in TextAttributes
- resolve palette colors in WrapperSettings
- resolve palette colors in TableAttributes

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849940b6b4c832682c6cb1b3db3a81b