### PR TITLE
Add lesson theme upgrade

### DIFF
--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -325,3 +325,12 @@ export const DELETE_COMPONENT_VARIANT = gql`
     deleteComponentVariant(data: $data)
   }
 `;
+
+export const UPGRADE_LESSON_THEME = gql`
+  mutation UpgradeLessonTheme($data: UpgradeLessonThemeInput!) {
+    upgradeLessonTheme(data: $data) {
+      id
+      themeVersion
+    }
+  }
+`;


### PR DESCRIPTION
## Summary
- add `upgradeLessonTheme` mutation to GraphQL queries
- enable upgrading a lesson's theme via LessonDropdown
- show confirmation dialog and success toast on upgrade

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in insight-be *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68499cd89d5083269e22c496ed94c307