### PR TITLE
Fix palette name input bug

### DIFF
--- a/insight-fe/src/components/lesson/modals/AddColorPaletteModal.test.tsx
+++ b/insight-fe/src/components/lesson/modals/AddColorPaletteModal.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ChakraProvider } from '@chakra-ui/react';
+import AddColorPaletteModal from './AddColorPaletteModal';
+
+describe('AddColorPaletteModal', () => {
+  it('updates palette name when typing', () => {
+    render(
+      <ChakraProvider>
+        <AddColorPaletteModal isOpen={true} onClose={() => {}} collectionId={1} />
+      </ChakraProvider>
+    );
+    const input = screen.getByPlaceholderText('Palette name') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'My Palette' } });
+    expect(input.value).toBe('My Palette');
+  });
+});

--- a/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
@@ -55,6 +55,7 @@ export default function ColorPaletteModal({
     skip: !paletteId || !isOpen,
     fetchPolicy: "network-only",
   });
+  const palette = paletteData?.getColorPalette;
 
   const [createPalette, { loading: creating }] = useMutation(CREATE_COLOR_PALETTE);
   const [updatePalette, { loading: updating }] = useMutation(UPDATE_COLOR_PALETTE);
@@ -65,18 +66,16 @@ export default function ColorPaletteModal({
   useEffect(() => {
     if (!isOpen) return;
 
-    if (paletteId && paletteData?.getColorPalette) {
-      setName(paletteData.getColorPalette.name);
+    if (paletteId && palette) {
+      setName(palette.name);
       setColors(
-        paletteData.getColorPalette.colors.length > 0
-          ? paletteData.getColorPalette.colors
-          : ["#000000"]
+        palette.colors.length > 0 ? palette.colors : ["#000000"]
       );
     } else {
       setName(initialName);
       setColors(initialColors.length > 0 ? initialColors : ["#000000"]);
     }
-  }, [isOpen, initialName, initialColors, paletteId, paletteData]);
+  }, [isOpen, paletteId, palette, initialName, initialColors]);
 
   const handleColorChange = (idx: number, value: string) => {
     setColors((cols) => cols.map((c, i) => (i === idx ? value : c)));


### PR DESCRIPTION
## Summary
- ensure color palette name state doesn't reset when typing
- add regression test for palette name input

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849a64aacc083268a2c540567b366d3