### PR TITLE
Add theme & color palette dropdowns

### DIFF
--- a/insight-fe/src/components/dropdowns/ColorPaletteDropdown.tsx
+++ b/insight-fe/src/components/dropdowns/ColorPaletteDropdown.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { ChangeEvent, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+import { GET_COLOR_PALETTES } from "@/graphql/lesson";
+import SimpleDropdown from "./SimpleDropdown";
+
+interface ColorPaletteDropdownProps {
+  collectionId: string | null;
+  value: string | null;
+  onChange: (id: string | null) => void;
+  isDisabled?: boolean;
+}
+
+export default function ColorPaletteDropdown({
+  collectionId,
+  value,
+  onChange,
+  isDisabled = false,
+}: ColorPaletteDropdownProps) {
+  const variables = useMemo(
+    () => (collectionId ? { collectionId: String(collectionId) } : undefined),
+    [collectionId]
+  );
+
+  const { data, loading } = useQuery(GET_COLOR_PALETTES, {
+    variables,
+    skip: !collectionId,
+  });
+
+  const palettes = collectionId ? data?.getAllColorPalette ?? [] : [];
+
+  const options = useMemo(
+    () => palettes.map((p: any) => ({ label: p.name, value: String(p.id) })),
+    [palettes]
+  );
+
+  return (
+    <SimpleDropdown
+      options={options}
+      value={value ?? ""}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+        onChange(e.target.value || null)
+      }
+      isDisabled={isDisabled || !collectionId}
+    />
+  );
+}
+

--- a/insight-fe/src/components/dropdowns/ThemeDropdown.tsx
+++ b/insight-fe/src/components/dropdowns/ThemeDropdown.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ChangeEvent, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+import { GET_ALL_THEMES } from "@/graphql/lesson";
+import SimpleDropdown from "./SimpleDropdown";
+
+interface ThemeDropdownProps {
+  value: string | null;
+  onChange: (id: string | null) => void;
+  isDisabled?: boolean;
+}
+
+export default function ThemeDropdown({
+  value,
+  onChange,
+  isDisabled = false,
+}: ThemeDropdownProps) {
+  const { data, loading } = useQuery(GET_ALL_THEMES);
+
+  const themes = data?.getAllTheme ?? [];
+
+  const options = useMemo(
+    () => themes.map((t: any) => ({ label: t.name, value: String(t.id) })),
+    [themes]
+  );
+
+  return (
+    <SimpleDropdown
+      options={options}
+      value={value ?? ""}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) =>
+        onChange(e.target.value || null)
+      }
+      isDisabled={isDisabled}
+    />
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a dropdown to select themes
- add a dropdown to select color palettes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849dd4f7f0c832691aa8ba9e2752e02