### PR TITLE
Replace CRUD dropdowns in slide toolbar

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -333,77 +333,18 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     <Box>
       <SlideToolbar
         availableElements={AVAILABLE_ELEMENTS}
-        styleCollections={styleCollections}
-        themes={themes}
         styleGroups={styleGroups}
         selectedCollectionId={selectedCollectionId}
         onSelectCollection={setSelectedCollectionId}
         selectedThemeId={selectedThemeId}
         onSelectTheme={setSelectedThemeId}
+        selectedPaletteId={selectedPaletteId}
+        onSelectPalette={setSelectedPaletteId}
         selectedElementType={selectedElementType}
         onSelectElement={setSelectedElementType}
         selectedGroupId={selectedGroupId}
         onSelectGroup={setSelectedGroupId}
         styleItems={styleItems}
-        onAddCollection={async (collection) => {
-          setStyleCollections([...styleCollections, collection]);
-          await refetchCollections();
-        }}
-        onUpdateCollection={async (collection) => {
-          setStyleCollections((cols) =>
-            cols.map((c) => (c.id === collection.id ? collection : c))
-          );
-          await refetchCollections();
-        }}
-        onDeleteCollection={async (id) => {
-          setStyleCollections((cols) => cols.filter((c) => c.id !== id));
-          if (selectedCollectionId === id) {
-            setSelectedCollectionId("");
-          }
-          await refetchCollections();
-        }}
-        onAddGroup={async (group) => {
-          setStyleGroups([...styleGroups, group]);
-          if (selectedCollectionId !== "" && selectedElementType) {
-            await fetchGroups({
-              variables: {
-                collectionId: String(selectedCollectionId),
-                element: selectedElementType,
-              },
-            });
-          }
-        }}
-        onUpdateGroup={async (group) => {
-          setStyleGroups((gs) => gs.map((g) => (g.id === group.id ? group : g)));
-          if (selectedCollectionId !== "" && selectedElementType) {
-            await fetchGroups({
-              variables: {
-                collectionId: String(selectedCollectionId),
-                element: selectedElementType,
-              },
-            });
-          }
-        }}
-        onDeleteGroup={async (id) => {
-          setStyleGroups((gs) => gs.filter((g) => g.id !== id));
-          if (selectedCollectionId === id) {
-            setSelectedGroupId("");
-          }
-          if (selectedCollectionId !== "" && selectedElementType) {
-            await fetchGroups({
-              variables: {
-                collectionId: String(selectedCollectionId),
-                element: selectedElementType,
-              },
-            });
-          }
-        }}
-        colorPalettes={colorPalettes}
-        selectedPaletteId={selectedPaletteId}
-        onSelectPalette={setSelectedPaletteId}
-        onAddPalette={handleAddPalette}
-        onUpdatePalette={handleUpdatePalette}
-        onDeletePalette={handleDeletePalette}
       />
 
       {selectedThemeId === "" ? (

--- a/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
@@ -1,43 +1,19 @@
 "use client";
 
 import { Box, HStack, VStack, Button } from "@chakra-ui/react";
-import { useState, useMemo } from "react";
-import { useMutation } from "@apollo/client";
+import { useMemo } from "react";
 import {
   SlideElementDnDItemProps,
   SlideElementDnDItem,
 } from "@/components/DnD/cards/SlideElementDnDCard";
-import CrudDropdown from "@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown";
-import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
-import AddStyleCollectionModal from "../modals/AddStyleCollectionModal";
-import AddStyleGroupModal from "../modals/AddStyleGroupModal";
-import ColorPaletteModal from "../modals/AddColorPaletteModal";
-import {
-  CREATE_STYLE_COLLECTION,
-  UPDATE_STYLE_COLLECTION,
-  DELETE_STYLE_COLLECTION,
-  CREATE_STYLE_GROUP,
-  UPDATE_STYLE_GROUP,
-  DELETE_STYLE_GROUP,
-  CREATE_COLOR_PALETTE,
-  UPDATE_COLOR_PALETTE,
-  DELETE_COLOR_PALETTE,
-} from "@/graphql/lesson";
+import ThemeDropdown from "@/components/dropdowns/ThemeDropdown";
+import ColorPaletteDropdown from "@/components/dropdowns/ColorPaletteDropdown";
+import SimpleDropdown from "@/components/dropdowns/SimpleDropdown";
 
-const ELEMENT_TYPE_TO_ENUM: Record<string, string> = {
-  text: "Text",
-  table: "Table",
-  image: "Image",
-  video: "Video",
-  quiz: "Quiz",
-};
 
 interface SlideToolbarProps {
   availableElements: { type: string; label: string }[];
-  styleCollections: { id: number; name: string }[];
   styleGroups: { id: number; name: string }[];
-  colorPalettes: { id: number; name: string; colors: string[] }[];
-  themes: { id: number; name: string }[];
   selectedCollectionId: number | "";
   onSelectCollection: (id: number | "") => void;
   selectedThemeId: number | "";
@@ -49,23 +25,11 @@ interface SlideToolbarProps {
   selectedGroupId: number | "";
   onSelectGroup: (id: number | "") => void;
   styleItems: SlideElementDnDItemProps[];
-  onAddCollection: (collection: { id: number; name: string }) => void;
-  onUpdateCollection?: (collection: { id: number; name: string }) => void;
-  onDeleteCollection?: (id: number) => void;
-  onAddGroup: (group: { id: number; name: string }) => void;
-  onUpdateGroup?: (group: { id: number; name: string }) => void;
-  onDeleteGroup?: (id: number) => void;
-  onAddPalette: (palette: { id: number; name: string; colors: string[] }) => void;
-  onUpdatePalette?: (palette: { id: number; name: string; colors: string[] }) => void;
-  onDeletePalette?: (id: number) => void;
 }
 
 export default function SlideToolbar({
   availableElements,
-  styleCollections,
-  themes,
   styleGroups,
-  colorPalettes,
   selectedCollectionId,
   onSelectCollection,
   selectedThemeId,
@@ -77,73 +41,12 @@ export default function SlideToolbar({
   selectedGroupId,
   onSelectGroup,
   styleItems,
-  onAddCollection,
-  onUpdateCollection,
-  onDeleteCollection,
-  onAddGroup,
-  onUpdateGroup,
-  onDeleteGroup,
-  onAddPalette,
-  onUpdatePalette,
-  onDeletePalette,
 }: SlideToolbarProps) {
-  const [isAddCollectionOpen, setIsAddCollectionOpen] = useState(false);
-  const [isEditCollectionOpen, setIsEditCollectionOpen] = useState(false);
-  const [isDeleteCollectionOpen, setIsDeleteCollectionOpen] = useState(false);
-  const [isAddGroupOpen, setIsAddGroupOpen] = useState(false);
-  const [isEditGroupOpen, setIsEditGroupOpen] = useState(false);
-  const [isDeleteGroupOpen, setIsDeleteGroupOpen] = useState(false);
-  const [isAddPaletteOpen, setIsAddPaletteOpen] = useState(false);
-  const [isEditPaletteOpen, setIsEditPaletteOpen] = useState(false);
-  const [isDeletePaletteOpen, setIsDeletePaletteOpen] = useState(false);
-
-  const [createCollection] = useMutation(CREATE_STYLE_COLLECTION);
-  const [updateCollection] = useMutation(UPDATE_STYLE_COLLECTION);
-  const [deleteCollection, { loading: deleting }] = useMutation(
-    DELETE_STYLE_COLLECTION,
-  );
-  const [createGroup] = useMutation(CREATE_STYLE_GROUP);
-  const [updateGroup] = useMutation(UPDATE_STYLE_GROUP);
-  const [deleteGroup, { loading: deletingGroup }] = useMutation(
-    DELETE_STYLE_GROUP,
-  );
-  const [createPalette] = useMutation(CREATE_COLOR_PALETTE);
-  const [updatePalette] = useMutation(UPDATE_COLOR_PALETTE);
-  const [deletePalette, { loading: deletingPalette }] = useMutation(
-    DELETE_COLOR_PALETTE,
-  );
-
-  const selectedCollection =
-    selectedCollectionId !== ""
-      ? styleCollections.find((c) => c.id === selectedCollectionId)
-      : undefined;
-  const collectionOptions = useMemo(
-    () =>
-      styleCollections.map((c) => ({ label: c.name, value: String(c.id) })),
-    [styleCollections]
-  );
-  const selectedGroup =
-    selectedGroupId !== ""
-      ? styleGroups.find((g) => g.id === selectedGroupId)
-      : undefined;
   const groupOptions = useMemo(
     () => styleGroups.map((g) => ({ label: g.name, value: String(g.id) })),
-    [styleGroups]
+    [styleGroups],
   );
-  const selectedPalette =
-    selectedPaletteId !== ""
-      ? colorPalettes.find((p) => p.id === selectedPaletteId)
-      : undefined;
-  const paletteOptions = useMemo(
-    () => colorPalettes.map((p) => ({ label: p.name, value: String(p.id) })),
-    [colorPalettes]
-  );
-  const selectedTheme =
-    selectedThemeId !== "" ? themes.find((t) => t.id === selectedThemeId) : undefined;
-  const themeOptions = useMemo(
-    () => themes.map((t) => ({ label: t.name, value: String(t.id) })),
-    [themes]
-  );
+
   return (
     <>
       <Box p={4} borderWidth="1px" borderRadius="md">
@@ -165,60 +68,31 @@ export default function SlideToolbar({
       </Box>
       <VStack mt={2} alignItems="flex-start">
         <HStack w="full">
-          <CrudDropdown
-            options={collectionOptions}
-            value={selectedCollectionId}
-            onChange={(e) =>
-              onSelectCollection(
-                e.target.value === "" ? "" : parseInt(e.target.value, 10)
-              )
-            }
-            onCreate={() => setIsAddCollectionOpen(true)}
-            onUpdate={() => setIsEditCollectionOpen(true)}
-            onDelete={() => setIsDeleteCollectionOpen(true)}
-            isUpdateDisabled={selectedCollectionId === ""}
-            isDeleteDisabled={selectedCollectionId === ""}
-          />
-          <CrudDropdown
-            options={themeOptions}
-            value={selectedThemeId}
-            onChange={(e) =>
-              onSelectTheme(
-                e.target.value === "" ? "" : parseInt(e.target.value, 10)
-              )
-            }
+          <ThemeDropdown
+            value={selectedThemeId === "" ? null : String(selectedThemeId)}
+            onChange={(id) => onSelectTheme(id === null ? "" : parseInt(id, 10))}
             isDisabled={selectedCollectionId === ""}
           />
-          <CrudDropdown
-            options={paletteOptions}
-            value={selectedPaletteId}
-            onChange={(e) =>
-              onSelectPalette(
-                e.target.value === "" ? "" : parseInt(e.target.value, 10)
-              )
+          <ColorPaletteDropdown
+            collectionId={
+              selectedCollectionId === "" ? null : String(selectedCollectionId)
             }
-            onCreate={() => setIsAddPaletteOpen(true)}
-            onUpdate={() => setIsEditPaletteOpen(true)}
-            onDelete={() => setIsDeletePaletteOpen(true)}
+            value={selectedPaletteId === "" ? null : String(selectedPaletteId)}
+            onChange={(id) =>
+              onSelectPalette(id === null ? "" : parseInt(id, 10))
+            }
             isDisabled={selectedCollectionId === ""}
-            isCreateDisabled={selectedCollectionId === ""}
-            isUpdateDisabled={selectedPaletteId === ""}
-            isDeleteDisabled={selectedPaletteId === ""}
           />
         </HStack>
         <HStack>
           {availableElements.map((el) => (
-            <Button
-              key={el.type}
-              size="sm"
-              onClick={() => onSelectElement(el.type)}
-            >
+            <Button key={el.type} size="sm" onClick={() => onSelectElement(el.type)}>
               {el.label}
             </Button>
           ))}
         </HStack>
         {selectedElementType && (
-          <CrudDropdown
+          <SimpleDropdown
             options={groupOptions}
             value={selectedGroupId}
             onChange={(e) =>
@@ -226,13 +100,7 @@ export default function SlideToolbar({
                 e.target.value === "" ? "" : parseInt(e.target.value, 10)
               )
             }
-            onCreate={() => setIsAddGroupOpen(true)}
-            onUpdate={() => setIsEditGroupOpen(true)}
-            onDelete={() => setIsDeleteGroupOpen(true)}
             isDisabled={selectedCollectionId === ""}
-            isCreateDisabled={selectedCollectionId === "" || !selectedElementType}
-            isUpdateDisabled={selectedGroupId === ""}
-            isDeleteDisabled={selectedGroupId === ""}
           />
         )}
       </VStack>
@@ -258,165 +126,6 @@ export default function SlideToolbar({
           ))}
         </HStack>
       )}
-      <AddStyleCollectionModal
-        isOpen={isAddCollectionOpen}
-        onClose={() => setIsAddCollectionOpen(false)}
-        onSave={async (name) => {
-          const { data } = await createCollection({
-            variables: { data: { name } },
-          });
-          if (data?.createStyleCollection) {
-            onAddCollection({
-              id: Number(data.createStyleCollection.id),
-              name: data.createStyleCollection.name,
-            });
-          }
-        }}
-      />
-
-      <AddStyleCollectionModal
-        isOpen={isEditCollectionOpen}
-        onClose={() => setIsEditCollectionOpen(false)}
-        title="Update Style Collection"
-        confirmLabel="Update"
-        initialName={selectedCollection?.name ?? ""}
-        onSave={async (name) => {
-          if (selectedCollectionId === "") return;
-          const { data } = await updateCollection({
-            variables: { data: { id: selectedCollectionId, name } },
-          });
-          if (data?.updateStyleCollection) {
-            onUpdateCollection?.({
-              id: selectedCollectionId,
-              name: data.updateStyleCollection.name,
-            });
-          }
-        }}
-      />
-
-      <ConfirmationModal
-        isOpen={isDeleteCollectionOpen}
-        onClose={() => setIsDeleteCollectionOpen(false)}
-        action="delete collection"
-        bodyText="Are you sure you want to delete this collection?"
-        onConfirm={async () => {
-          if (selectedCollectionId === "") return;
-          await deleteCollection({
-            variables: { data: { id: selectedCollectionId } },
-          });
-          onDeleteCollection?.(selectedCollectionId);
-          setIsDeleteCollectionOpen(false);
-        }}
-        isLoading={deleting}
-      />
-
-      <AddStyleGroupModal
-        isOpen={isAddGroupOpen}
-        onClose={() => setIsAddGroupOpen(false)}
-        onSave={async (name) => {
-          if (selectedCollectionId === "" || !selectedElementType) return;
-          const { data } = await createGroup({
-            variables: {
-              data: {
-                name,
-                collectionId: selectedCollectionId,
-                element: ELEMENT_TYPE_TO_ENUM[selectedElementType],
-              },
-            },
-          });
-          if (data?.createStyleGroup) {
-            onAddGroup({
-              id: Number(data.createStyleGroup.id),
-              name: data.createStyleGroup.name,
-            });
-          }
-        }}
-      />
-
-      <AddStyleGroupModal
-        isOpen={isEditGroupOpen}
-        onClose={() => setIsEditGroupOpen(false)}
-        title="Update Style Group"
-        confirmLabel="Update"
-        initialName={selectedGroup?.name ?? ""}
-        onSave={async (name) => {
-          if (
-            selectedGroupId === "" ||
-            selectedCollectionId === "" ||
-            !selectedElementType
-          )
-            return;
-          const { data } = await updateGroup({
-            variables: {
-              data: {
-                id: selectedGroupId,
-                name,
-                collectionId: selectedCollectionId,
-                element: ELEMENT_TYPE_TO_ENUM[selectedElementType],
-              },
-            },
-          });
-          if (data?.updateStyleGroup) {
-            onUpdateGroup?.({
-              id: selectedGroupId,
-              name: data.updateStyleGroup.name,
-            });
-          }
-        }}
-      />
-
-      <ConfirmationModal
-        isOpen={isDeleteGroupOpen}
-        onClose={() => setIsDeleteGroupOpen(false)}
-        action="delete group"
-        bodyText="Are you sure you want to delete this group?"
-        onConfirm={async () => {
-          if (selectedGroupId === "") return;
-          await deleteGroup({ variables: { data: { id: selectedGroupId } } });
-          onDeleteGroup?.(selectedGroupId);
-          setIsDeleteGroupOpen(false);
-        }}
-        isLoading={deletingGroup}
-      />
-
-      <ColorPaletteModal
-        key="add-palette"
-        isOpen={isAddPaletteOpen}
-        onClose={() => setIsAddPaletteOpen(false)}
-        collectionId={selectedCollectionId as number}
-        onSave={(palette) => {
-          onAddPalette(palette);
-        }}
-      />
-
-      <ColorPaletteModal
-        key={`edit-palette-${selectedPaletteId}`}
-        isOpen={isEditPaletteOpen}
-        onClose={() => setIsEditPaletteOpen(false)}
-        collectionId={selectedCollectionId as number}
-        paletteId={selectedPaletteId === "" ? undefined : selectedPaletteId}
-        initialName={selectedPalette?.name ?? ""}
-        initialColors={selectedPalette?.colors ?? []}
-        title="Update Color Palette"
-        confirmLabel="Update"
-        onSave={(palette) => {
-          onUpdatePalette?.(palette);
-        }}
-      />
-
-      <ConfirmationModal
-        isOpen={isDeletePaletteOpen}
-        onClose={() => setIsDeletePaletteOpen(false)}
-        action="delete palette"
-        bodyText="Are you sure you want to delete this palette?"
-        onConfirm={async () => {
-          if (selectedPaletteId === "") return;
-          await deletePalette({ variables: { data: { id: selectedPaletteId } } });
-          onDeletePalette?.(selectedPaletteId);
-          setIsDeletePaletteOpen(false);
-        }}
-        isLoading={deletingPalette}
-      />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- simplify `SlideToolbar` by replacing CRUD dropdowns with read-only components
- update `LessonEditor` to match the new toolbar props

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849de3f515883268757b01a9c598abd