### PR TITLE
Refactor theme selection flow

### DIFF
--- a/insight-fe/src/components/lesson/StyleModals.tsx
+++ b/insight-fe/src/components/lesson/StyleModals.tsx
@@ -2,43 +2,30 @@
 
 import LoadStyleModal from "./modals/LoadStyleModal";
 import SaveStyleModal from "./modals/SaveStyleModal";
-import ColorPaletteModal from "./modals/AddColorPaletteModal";
 
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 
 interface StyleModalsProps {
   isSaveOpen: boolean;
   isLoadOpen: boolean;
-  isPaletteOpen: boolean;
   closeSave: () => void;
   closeLoad: () => void;
-  closePalette: () => void;
-  styleCollections: { id: number; name: string }[];
   styleGroups: { id: number; name: string }[];
   selectedCollectionId: number | "";
   selectedElement: SlideElementDnDItemProps | null;
-  onSave: (data: { name: string; collectionId: number; groupId: number | null }) => void;
-  onAddCollection: (collection: { id: number; name: string }) => void;
-  onAddGroup: (group: { id: number; name: string }) => void;
-  onAddPalette: (palette: { id: number; name: string; colors: string[] }) => void;
+  onSave: (data: { name: string; groupId: number | null }) => void;
   onLoad: (styleId: number) => void;
 }
 
 export default function StyleModals({
   isSaveOpen,
   isLoadOpen,
-  isPaletteOpen,
   closeSave,
   closeLoad,
-  closePalette,
-  styleCollections,
   styleGroups,
   selectedCollectionId,
   selectedElement,
   onSave,
-  onAddCollection,
-  onAddGroup,
-  onAddPalette,
   onLoad,
 }: StyleModalsProps) {
   return (
@@ -46,29 +33,19 @@ export default function StyleModals({
       <SaveStyleModal
         isOpen={isSaveOpen}
         onClose={closeSave}
-        collections={styleCollections}
+        collectionId={selectedCollectionId as number}
         elementType={selectedElement ? selectedElement.type : null}
         groups={styleGroups}
-        onSave={onSave}
-        onAddCollection={onAddCollection}
-        onAddGroup={onAddGroup}
+        onSave={(data) => onSave({ name: data.name, groupId: data.groupId })}
       />
       <LoadStyleModal
         isOpen={isLoadOpen}
         onClose={closeLoad}
-        collections={styleCollections}
+        collectionId={selectedCollectionId as number}
         elementType={selectedElement ? selectedElement.type : null}
         groups={styleGroups}
         onLoad={onLoad}
       />
-      {selectedCollectionId !== "" && (
-        <ColorPaletteModal
-          isOpen={isPaletteOpen}
-          onClose={closePalette}
-          collectionId={selectedCollectionId as number}
-          onSave={onAddPalette}
-        />
-      )}
     </>
   );
 }

--- a/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
@@ -15,7 +15,6 @@ interface SlideToolbarProps {
   availableElements: { type: string; label: string }[];
   styleGroups: { id: number; name: string }[];
   selectedCollectionId: number | "";
-  onSelectCollection: (id: number | "") => void;
   selectedThemeId: number | "";
   onSelectTheme: (id: number | "") => void;
   selectedPaletteId: number | "";
@@ -31,7 +30,6 @@ export default function SlideToolbar({
   availableElements,
   styleGroups,
   selectedCollectionId,
-  onSelectCollection,
   selectedThemeId,
   onSelectTheme,
   selectedPaletteId,
@@ -71,7 +69,6 @@ export default function SlideToolbar({
           <ThemeDropdown
             value={selectedThemeId === "" ? null : String(selectedThemeId)}
             onChange={(id) => onSelectTheme(id === null ? "" : parseInt(id, 10))}
-            isDisabled={selectedCollectionId === ""}
           />
           <ColorPaletteDropdown
             collectionId={


### PR DESCRIPTION
## Summary
- rely on theme selection to determine style collection
- fetch theme details when theme changes
- update dropdowns to use selected theme's collection
- simplify style modals

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `insight-be` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849e02407f48326aaa740d6a62e0f75