### PR TITLE
Add palette dropdown to theme builder

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -187,6 +187,24 @@ export default function ThemeBuilderPageClient() {
             isDeleteDisabled={selectedCollectionId === ""}
           />
         </FormControl>
+        <FormControl flex={1}>
+          <FormLabel>Color Palette</FormLabel>
+          <CrudDropdown
+            options={paletteOptions}
+            value={selectedPaletteId}
+            onChange={(e) =>
+              setSelectedPaletteId(
+                e.target.value === "" ? "" : parseInt(e.target.value, 10),
+              )
+            }
+            onCreate={() => setIsAddPaletteOpen(true)}
+            onUpdate={() => setIsEditPaletteOpen(true)}
+            onDelete={() => setIsDeletePaletteOpen(true)}
+            isDisabled={selectedCollectionId === ""}
+            isUpdateDisabled={selectedPaletteId === ""}
+            isDeleteDisabled={selectedPaletteId === ""}
+          />
+        </FormControl>
       </HStack>
 
       <Accordion allowMultiple>


### PR DESCRIPTION
## Summary
- add CRUD dropdown for palettes in theme builder

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*
- `npm test` in insight-be *(fails: `jest` not found)*
- `npm run lint` in insight-be *(fails: Cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6849fa1d59ec8326bd8c0bd7c1a30e22