### PR TITLE
Make sequencer optional in SlideCanvas

### DIFF
--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -35,6 +35,8 @@ interface SlideCanvasProps {
   openLoadStyle: () => void;
   tokens?: ThemeTokens;
   variants?: ComponentVariant[];
+  /** Whether to display the slide sequencer */
+  showSequencer?: boolean;
 }
 
 export default function SlideCanvas({
@@ -61,15 +63,18 @@ export default function SlideCanvas({
   openLoadStyle,
   tokens,
   variants,
+  showSequencer = true,
 }: SlideCanvasProps) {
   return (
     <Flex gap={6} alignItems="flex-start">
-      <SlideSequencer
-        slides={slides}
-        setSlides={setSlides as any}
-        selectedSlideId={selectedSlideId}
-        onSelect={selectSlide}
-      />
+      {showSequencer && (
+        <SlideSequencer
+          slides={slides}
+          setSlides={setSlides as any}
+          selectedSlideId={selectedSlideId}
+          onSelect={selectSlide}
+        />
+      )}
       {selectedSlideId && selectedSlide && (
         <Grid gap={4} flex={1} templateColumns="1fr 300px">
           <Box

--- a/insight-fe/src/components/theme/ThemeCanvas.tsx
+++ b/insight-fe/src/components/theme/ThemeCanvas.tsx
@@ -86,6 +86,7 @@ export default function ThemeCanvas({
         handleDropElement={editor.handleDropElement}
         openSaveStyle={() => setIsSaveStyleOpen(true)}
         openLoadStyle={() => {}}
+        showSequencer={false}
       />
       {editor.selectedElement && (
         <SaveStyleModal


### PR DESCRIPTION
## Summary
- add `showSequencer` prop to `SlideCanvas` with default `true`
- render `SlideSequencer` only when `showSequencer` is enabled
- hide slide sequencer in `ThemeCanvas`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a8d215a80832693dc8e7de0783f9b