### PR TITLE
Fix style group creation

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -627,7 +627,7 @@ export default function ThemeBuilderPageClient() {
                 data: {
                   name,
                   collectionId: selectedCollectionId as number,
-                  element: selectedElementType,
+                  element: ELEMENT_TYPE_TO_ENUM[selectedElementType],
                 },
               },
             });


### PR DESCRIPTION
## Summary
- map element type string to enum when creating style groups

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm test` in insight-be *(fails: jest not found)*
- `npm run lint` in insight-be *(fails: cannot find @eslint/js)*

------
https://chatgpt.com/codex/tasks/task_e_684a97e875fc8326ba0d81b34c8a3601