### PR TITLE
Add color palette tokens

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.entity.ts
@@ -1,5 +1,14 @@
 import { Column, Entity, ManyToOne, JoinColumn, RelationId } from 'typeorm';
 import { Field, ObjectType, ID } from '@nestjs/graphql';
+
+@ObjectType()
+export class PaletteToken {
+  @Field()
+  token: string;
+
+  @Field()
+  color: string;
+}
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
 
@@ -10,9 +19,9 @@ export class ColorPaletteEntity extends AbstractBaseEntity {
   @Column()
   name: string;
 
-  @Field(() => [String])
+  @Field(() => [PaletteToken])
   @Column({ type: 'jsonb' })
-  colors: string[];
+  tokens: PaletteToken[];
 
   @Field(() => StyleCollectionEntity)
   @ManyToOne(() => StyleCollectionEntity, (collection) => collection.colorPalettes, { nullable: false })

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
@@ -2,12 +2,21 @@ import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
 import { HasRelationsInput, FindAllInput } from 'src/common/base.inputs';
 
 @InputType()
+export class PaletteTokenInput {
+  @Field()
+  token: string;
+
+  @Field()
+  color: string;
+}
+
+@InputType()
 export class CreateColorPaletteInput extends HasRelationsInput {
   @Field()
   name: string;
 
-  @Field(() => [String])
-  colors: string[];
+  @Field(() => [PaletteTokenInput])
+  tokens: PaletteTokenInput[];
 
   @Field(() => ID)
   collectionId: number;

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -52,7 +52,7 @@ export default function ThemeBuilderPageClient() {
     {
       id: number;
       name: string;
-      colors: string[];
+      tokens: { token: string; color: string }[];
     }[]
   >([]);
   const [selectedPaletteId, setSelectedPaletteId] = useState<number | "">("");
@@ -340,7 +340,7 @@ export default function ThemeBuilderPageClient() {
             selectedPaletteId === "" ? undefined : (selectedPaletteId as number)
           }
           initialName={selectedPalette?.name ?? ""}
-          initialColors={selectedPalette?.colors ?? []}
+          initialTokens={selectedPalette?.tokens ?? []}
           title="Update Color Palette"
           confirmLabel="Update"
           onSave={(palette) => {

--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -54,7 +54,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
   const [colorPalettes, setColorPalettes] = useState<{
     id: number;
     name: string;
-    colors: string[];
+    tokens: { token: string; color: string }[];
   }[]>([]);
   const [themes, setThemes] = useState<{
     id: number;
@@ -90,7 +90,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
       : undefined;
 
   const editor = useLessonEditorState(undefined, {
-    defaultColor: selectedPalette?.colors[0] ?? "#000000",
+    defaultColor: selectedPalette?.tokens[0]?.color ?? "#000000",
     defaultFontFamily: availableFonts[0].fontFamily,
   });
 
@@ -208,7 +208,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         palettesData.getAllColorPalette.map((p: any) => ({
           id: Number(p.id),
           name: p.name,
-          colors: p.colors,
+          tokens: p.tokens,
         }))
       );
     } else {
@@ -236,12 +236,12 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
   const handleUpdatePalette = async (palette: {
     id: number;
     name: string;
-    colors: string[];
+    tokens: { token: string; color: string }[];
   }) => {
     const normalized = {
       id: Number(palette.id),
       name: palette.name,
-      colors: palette.colors,
+      tokens: palette.tokens,
     };
     setColorPalettes((p) => p.map((pl) => (pl.id === normalized.id ? normalized : pl)));
     await fetchPalettes({
@@ -252,11 +252,11 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
   const handleAddPalette = async (palette: {
     id: number;
     name: string;
-    colors: string[];
+    tokens: { token: string; color: string }[];
   }) => {
     setColorPalettes((p) => [
       ...p,
-      { id: Number(palette.id), name: palette.name, colors: palette.colors },
+      { id: Number(palette.id), name: palette.name, tokens: palette.tokens },
     ]);
     await fetchPalettes({
       variables: { collectionId: String(selectedCollectionId) },

--- a/insight-fe/src/components/lesson/StyleModals.tsx
+++ b/insight-fe/src/components/lesson/StyleModals.tsx
@@ -20,7 +20,7 @@ interface StyleModalsProps {
   onSave: (data: { name: string; collectionId: number; groupId: number | null }) => void;
   onAddCollection: (collection: { id: number; name: string }) => void;
   onAddGroup: (group: { id: number; name: string }) => void;
-  onAddPalette: (palette: { id: number; name: string; colors: string[] }) => void;
+  onAddPalette: (palette: { id: number; name: string; tokens: { token: string; color: string }[] }) => void;
   onLoad: (styleId: number) => void;
 }
 

--- a/insight-fe/src/components/lesson/attributes-pane/BoardAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/BoardAttributesPane.tsx
@@ -8,7 +8,7 @@ import { BoardRow } from "../slide/SlideElementsContainer";
 interface BoardAttributesPaneProps {
   board: BoardRow;
   onChange: (updated: BoardRow) => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  colorPalettes?: { id: number; name: string; tokens: { token: string; color: string }[] }[];
   selectedPaletteId?: number | "";
 }
 

--- a/insight-fe/src/components/lesson/attributes-pane/ColumnAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ColumnAttributesPane.tsx
@@ -10,7 +10,7 @@ import useStyleAttributes from "../hooks/useStyleAttributes";
 interface ColumnAttributesPaneProps {
   column: ColumnType<SlideElementDnDItemProps>;
   onChange: (updated: ColumnType<SlideElementDnDItemProps>) => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  colorPalettes?: { id: number; name: string; tokens: { token: string; color: string }[] }[];
   selectedPaletteId?: number | "";
 }
 

--- a/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
+++ b/insight-fe/src/components/lesson/attributes-pane/ElementAttributesPane.tsx
@@ -19,7 +19,7 @@ interface ElementAttributesPaneProps {
   onChange: (updated: SlideElementDnDItemProps) => void;
   onClone?: () => void;
   onDelete?: () => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  colorPalettes?: { id: number; name: string; tokens: { token: string; color: string }[] }[];
   selectedPaletteId?: number | "";
 }
 

--- a/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TableAttributes.tsx
@@ -23,7 +23,7 @@ interface TableAttributesProps {
     cells: TableCell[][];
   };
   setTable: (table: { rows: number; cols: number; cells: TableCell[][] }) => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  colorPalettes?: { id: number; name: string; tokens: { token: string; color: string }[] }[];
   selectedPaletteId?: number | "";
 }
 
@@ -90,7 +90,7 @@ export default function TableAttributes({
   };
 
   const paletteColors =
-    colorPalettes?.find((p) => Number(p.id) === Number(selectedPaletteId))?.colors ?? [];
+    colorPalettes?.find((p) => Number(p.id) === Number(selectedPaletteId))?.tokens.map((t) => t.color) ?? [];
 
   const updateCell = (r: number, c: number, cell: TableCell) => {
     updateTableCells((prev) => {

--- a/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
+++ b/insight-fe/src/components/lesson/attributes/TextAttributes.tsx
@@ -30,7 +30,7 @@ interface TextAttributesProps {
   setLineHeight: (val: string) => void;
   textAlign: string;
   setTextAlign: (val: string) => void;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  colorPalettes?: { id: number; name: string; tokens: { token: string; color: string }[] }[];
   selectedPaletteId?: number | "";
 }
 
@@ -55,7 +55,7 @@ export default function TextAttributes({
   const paletteColors =
     colorPalettes?.find(
       (p) => Number(p.id) === Number(selectedPaletteId)
-    )?.colors ?? [];
+    )?.tokens.map((t) => t.color) ?? [];
 
   return (
     <AccordionItem borderWidth="1px" borderColor="purple.300" borderRadius="md" mb={2}>

--- a/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
+++ b/insight-fe/src/components/lesson/attributes/WrapperSettings.tsx
@@ -19,7 +19,7 @@ import PaletteColorPicker from "../PaletteColorPicker";
 
 interface WrapperSettingsProps {
   attrs: ReturnType<typeof useStyleAttributes>;
-  colorPalettes?: { id: number; name: string; colors: string[] }[];
+  colorPalettes?: { id: number; name: string; tokens: { token: string; color: string }[] }[];
   selectedPaletteId?: number | "";
 }
 
@@ -64,7 +64,7 @@ export default function WrapperSettings({
   const paletteColors =
     colorPalettes?.find(
       (p) => Number(p.id) === Number(selectedPaletteId)
-    )?.colors ?? [];
+    )?.tokens.map((t) => t.color) ?? [];
 
   return (
     <>

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -32,7 +32,7 @@ interface SlideCanvasProps {
   handleDropElement: (e: React.DragEvent<HTMLDivElement>) => void;
   openSaveStyle: () => void;
   openLoadStyle: () => void;
-  colorPalettes: { id: number; name: string; colors: string[] }[];
+  colorPalettes: { id: number; name: string; tokens: { token: string; color: string }[] }[];
   selectedPaletteId: number | "";
 } 
 

--- a/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideToolbar.tsx
@@ -36,7 +36,7 @@ interface SlideToolbarProps {
   availableElements: { type: string; label: string }[];
   styleCollections: { id: number; name: string }[];
   styleGroups: { id: number; name: string }[];
-  colorPalettes: { id: number; name: string; colors: string[] }[];
+  colorPalettes: { id: number; name: string; tokens: { token: string; color: string }[] }[];
   themes: { id: number; name: string }[];
   selectedCollectionId: number | "";
   onSelectCollection: (id: number | "") => void;
@@ -55,8 +55,8 @@ interface SlideToolbarProps {
   onAddGroup: (group: { id: number; name: string }) => void;
   onUpdateGroup?: (group: { id: number; name: string }) => void;
   onDeleteGroup?: (id: number) => void;
-  onAddPalette: (palette: { id: number; name: string; colors: string[] }) => void;
-  onUpdatePalette?: (palette: { id: number; name: string; colors: string[] }) => void;
+  onAddPalette: (palette: { id: number; name: string; tokens: { token: string; color: string }[] }) => void;
+  onUpdatePalette?: (palette: { id: number; name: string; tokens: { token: string; color: string }[] }) => void;
   onDeletePalette?: (id: number) => void;
 }
 
@@ -396,7 +396,7 @@ export default function SlideToolbar({
         collectionId={selectedCollectionId as number}
         paletteId={selectedPaletteId === "" ? undefined : selectedPaletteId}
         initialName={selectedPalette?.name ?? ""}
-        initialColors={selectedPalette?.colors ?? []}
+        initialTokens={selectedPalette?.tokens ?? []}
         title="Update Color Palette"
         confirmLabel="Update"
         onSave={(palette) => {

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -150,7 +150,10 @@ export const GET_COLOR_PALETTES = gql`
     ) {
       id
       name
-      colors
+      tokens {
+        token
+        color
+      }
     }
   }
 `;
@@ -160,7 +163,10 @@ export const GET_COLOR_PALETTE = gql`
     getColorPalette(data: { id: $id }) {
       id
       name
-      colors
+      tokens {
+        token
+        color
+      }
     }
   }
 `;
@@ -170,7 +176,10 @@ export const CREATE_COLOR_PALETTE = gql`
     createColorPalette(data: $data) {
       id
       name
-      colors
+      tokens {
+        token
+        color
+      }
     }
   }
 `;
@@ -180,7 +189,10 @@ export const UPDATE_COLOR_PALETTE = gql`
     updateColorPalette(data: $data) {
       id
       name
-      colors
+      tokens {
+        token
+        color
+      }
     }
   }
 `;


### PR DESCRIPTION
## Summary
- support palette tokens in backend entity and inputs
- adjust GraphQL queries/mutations for tokens
- expand color palette modal to edit token names and colors
- propagate palette token shape through lesson editor and theme builder UI

## Testing
- `npm run lint` (failed to run: `next` not found)
- `npm run lint` in insight-be (failed to run: cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_684a9bb885a08326916aad82343abe4e