### PR TITLE
Add token name input to color palette modal

### DIFF
--- a/insight-fe/src/components/lesson/modals/AddColorPaletteModal.test.tsx
+++ b/insight-fe/src/components/lesson/modals/AddColorPaletteModal.test.tsx
@@ -14,4 +14,20 @@ describe('AddColorPaletteModal', () => {
     fireEvent.change(input, { target: { value: 'My Palette' } });
     expect(input.value).toBe('My Palette');
   });
+
+  it('updates color token name and value', () => {
+    render(
+      <ChakraProvider>
+        <AddColorPaletteModal isOpen={true} onClose={() => {}} collectionId={1} />
+      </ChakraProvider>
+    );
+
+    const nameInput = screen.getByPlaceholderText('Token name') as HTMLInputElement;
+    fireEvent.change(nameInput, { target: { value: 'primary' } });
+    expect(nameInput.value).toBe('primary');
+
+    const colorInput = screen.getByDisplayValue('#000000') as HTMLInputElement;
+    fireEvent.change(colorInput, { target: { value: '#ff0000' } });
+    expect(colorInput.value).toBe('#ff0000');
+  });
 });

--- a/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
@@ -42,7 +42,7 @@ export default function ColorPaletteModal({
   collectionId,
   onSave,
   initialName = "",
-  initialColors = ["#000000"],
+  initialColors = [{ name: "", value: "#000000" }],
   paletteId,
   title = "Add Color Palette",
   confirmLabel = "Save",
@@ -100,6 +100,11 @@ export default function ColorPaletteModal({
     setColors((cols) =>
       cols.map((c, i) => (i === idx ? { ...c, value } : c))
     );
+    setInitialized(true);
+  };
+
+  const handleColorNameChange = (idx: number, name: string) => {
+    setColors((cols) => cols.map((c, i) => (i === idx ? { ...c, name } : c)));
     setInitialized(true);
   };
 
@@ -173,6 +178,11 @@ export default function ColorPaletteModal({
         />
         {colors.map((color, idx) => (
           <HStack key={idx}>
+            <Input
+              placeholder="Token name"
+              value={color.name}
+              onChange={(e) => handleColorNameChange(idx, e.target.value)}
+            />
             <Input
               type="color"
               value={color.value}


### PR DESCRIPTION
## Summary
- allow entering token names for each palette color
- update palette modal tests for color name and value inputs

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aa389e190832693ee028dc46cd380