### PR TITLE
Fix palette merging to use token names

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -237,10 +237,11 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     if (foundation.colors && paletteData?.getColorPalette?.colors) {
       const keys = Object.keys(foundation.colors);
       const merged: Record<string, string> = {};
-      keys.forEach((key, idx) => {
-        merged[key] =
-          paletteData.getColorPalette.colors[idx]?.value ??
-          foundation.colors[key];
+      keys.forEach((key) => {
+        const found = paletteData.getColorPalette.colors.find(
+          (c: { name: string; value: string }) => c.name === key,
+        );
+        merged[key] = found?.value ?? foundation.colors[key];
       });
       foundation.colors = merged;
     }

--- a/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
@@ -41,9 +41,11 @@ export default function LessonPreviewModal({
   if (foundation?.colors && paletteData?.getColorPalette?.colors) {
     const keys = Object.keys(foundation.colors);
     const merged: Record<string, string> = {};
-    keys.forEach((k, idx) => {
-      merged[k] =
-        paletteData.getColorPalette.colors[idx]?.value ?? foundation.colors[k];
+    keys.forEach((k) => {
+      const found = paletteData.getColorPalette.colors.find(
+        (c: { name: string; value: string }) => c.name === k,
+      );
+      merged[k] = found?.value ?? foundation.colors[k];
     });
     foundation.colors = merged;
   }


### PR DESCRIPTION
## Summary
- merge palette colors by token name for lesson editor and previews

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ac2f7436083268efe8b1848a996c2