### PR TITLE
Update palette merging logic

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -25,6 +25,7 @@ import {
 import SlideToolbar from "./slide/SlideToolbar";
 import { extendTheme, ChakraProvider } from "@chakra-ui/react";
 import baseTheme from "@/theme/theme";
+import { ColorPalette } from "@/theme/helpers";
 
 const AVAILABLE_ELEMENTS = [
   { type: "text", label: "Text" },
@@ -50,11 +51,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
     id: number;
     name: string;
   }[]>([]);
-  const [colorPalettes, setColorPalettes] = useState<{
-    id: number;
-    name: string;
-    colors: { name: string; value: string }[];
-  }[]>([]);
+  const [colorPalettes, setColorPalettes] = useState<ColorPalette[]>([]);
   const [theme, setThemeState] = useState<any | null>(null);
   const [selectedCollectionId, setSelectedCollectionId] = useState<number | "">(
     ""
@@ -196,8 +193,8 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         palettesData.getAllColorPalette.map((p: any) => ({
           id: Number(p.id),
           name: p.name,
-          colors: p.colors,
-        }))
+          colors: p.colors as { name: string; value: string }[],
+        })) as ColorPalette[],
       );
     } else {
       setColorPalettes([]);
@@ -235,13 +232,15 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
       JSON.stringify(theme.foundationTokens || {}),
     );
     if (foundation.colors && paletteData?.getColorPalette?.colors) {
-      const keys = Object.keys(foundation.colors);
+      const paletteMap = paletteData.getColorPalette.colors.reduce(
+        (acc: Record<string, string>, cur: { name: string; value: string }) => {
+          acc[cur.name] = cur.value;
+          return acc;
+        },
+      {});
       const merged: Record<string, string> = {};
-      keys.forEach((key) => {
-        const found = paletteData.getColorPalette.colors.find(
-          (c: { name: string; value: string }) => c.name === key,
-        );
-        merged[key] = found?.value ?? foundation.colors[key];
+      Object.entries(foundation.colors).forEach(([key, val]) => {
+        merged[key] = paletteMap[key] ?? (val as string);
       });
       foundation.colors = merged;
     }

--- a/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
+++ b/insight-fe/src/components/lesson/modals/LessonPreviewModal.tsx
@@ -6,7 +6,7 @@ import SlidePreview from "../slide/SlidePreview";
 import { Slide } from "../slide/SlideSequencer";
 import { useQuery } from "@apollo/client";
 import { GET_THEME, GET_COLOR_PALETTE } from "@/graphql/lesson";
-import { ComponentVariant, SemanticTokens } from "@/theme/helpers";
+import { ComponentVariant, SemanticTokens, ColorPalette } from "@/theme/helpers";
 import baseTheme from "@/theme/theme";
 
 interface LessonPreviewModalProps {
@@ -34,18 +34,23 @@ export default function LessonPreviewModal({
     skip: !paletteId || !isOpen,
   });
 
+  const palette: ColorPalette | undefined = paletteData?.getColorPalette;
+
   const theme = themeData?.getTheme;
   const variants: ComponentVariant[] | undefined = theme?.componentVariants;
 
   const foundation = theme ? { ...(theme.foundationTokens as any) } : undefined;
-  if (foundation?.colors && paletteData?.getColorPalette?.colors) {
-    const keys = Object.keys(foundation.colors);
+  if (foundation?.colors && palette) {
+    const paletteMap = palette.colors.reduce(
+      (acc: Record<string, string>, cur: { name: string; value: string }) => {
+        acc[cur.name] = cur.value;
+        return acc;
+      },
+      {},
+    );
     const merged: Record<string, string> = {};
-    keys.forEach((k) => {
-      const found = paletteData.getColorPalette.colors.find(
-        (c: { name: string; value: string }) => c.name === k,
-      );
-      merged[k] = found?.value ?? foundation.colors[k];
+    Object.entries(foundation.colors).forEach(([k, val]) => {
+      merged[k] = paletteMap[k] ?? (val as string);
     });
     foundation.colors = merged;
   }


### PR DESCRIPTION
## Summary
- merge palette colors by token name using a lookup table
- clarify palette typing

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aecb8e87c832694ce94ce819d5922