### PR TITLE
Fix palette fetching on ThemeBuilder selection

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -161,6 +161,7 @@ export default function ThemeBuilderPageClient() {
 
   useEffect(() => {
     if (selectedCollectionId !== "") {
+      setSelectedPaletteId("");
       fetchPalettes({
         variables: { collectionId: String(selectedCollectionId) },
       });
@@ -168,7 +169,7 @@ export default function ThemeBuilderPageClient() {
       setColorPalettes([]);
       setSelectedPaletteId("");
     }
-  }, [selectedCollectionId]);
+  }, [selectedCollectionId, fetchPalettes]);
 
   useEffect(() => {
     if (palettesData?.getAllColorPalette) {


### PR DESCRIPTION
## Summary
- ensure color palettes are fetched whenever a style collection is selected

## Testing
- `npm test --silent --prefix insight-fe` *(fails: jest not found)*
- `npm test --silent --prefix insight-be` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af58ffc248326ae17b6fb6871e805