### PR TITLE
Fix palette name input focus

### DIFF
--- a/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useRef } from "react";
 import {
   Button,
   HStack,
@@ -45,6 +45,7 @@ export default function ColorPaletteModal({
   title = "Add Color Palette",
   confirmLabel = "Save",
 }: ColorPaletteModalProps) {
+  const inputRef = useRef<HTMLInputElement>(null);
   const [name, setName] = useState(initialName);
   const [colors, setColors] = useState<string[]>(
     initialColors.length > 0 ? initialColors : ["#000000"]
@@ -92,6 +93,7 @@ export default function ColorPaletteModal({
       isOpen={isOpen}
       onClose={onClose}
       title={title}
+      initialFocusRef={inputRef}
       footer={
         <HStack>
           <Button
@@ -138,6 +140,8 @@ export default function ColorPaletteModal({
     >
       <VStack align="stretch" spacing={2}>
         <Input
+          ref={inputRef}
+          autoFocus
           placeholder="Palette name"
           value={name}
           onChange={(e) => setName(e.target.value)}

--- a/insight-fe/src/components/modals/BaseModal.tsx
+++ b/insight-fe/src/components/modals/BaseModal.tsx
@@ -16,6 +16,10 @@ interface BaseModalProps
   showCloseButton?: boolean;
   footer?: React.ReactNode;
   children: React.ReactNode;
+  /** Element to focus when the modal opens */
+  initialFocusRef?: React.RefObject<HTMLElement>;
+  /** Element to return focus to when the modal closes */
+  finalFocusRef?: React.RefObject<HTMLElement>;
 }
 
 export const BaseModal: React.FC<BaseModalProps> = ({
@@ -26,9 +30,18 @@ export const BaseModal: React.FC<BaseModalProps> = ({
   showCloseButton = true,
   footer,
   children,
+  initialFocusRef,
+  finalFocusRef,
 }) => {
   return (
-    <Modal isOpen={isOpen} onClose={onClose} size={size} isCentered>
+    <Modal
+      isOpen={isOpen}
+      onClose={onClose}
+      size={size}
+      isCentered
+      initialFocusRef={initialFocusRef}
+      finalFocusRef={finalFocusRef}
+    >
       <ModalOverlay />
       <ModalContent>
         {title && <ModalHeader>{title}</ModalHeader>}


### PR DESCRIPTION
## Summary
- expose focus refs in BaseModal
- auto-focus palette name when adding a color palette

## Testing
- `npx tsc -p tsconfig.json --noEmit` *(fails: Cannot find type definition file)*

------
https://chatgpt.com/codex/tasks/task_e_684afc5428e4832698831a4740513df6