### PR TITLE
Add tests for theme builder components

### DIFF
--- a/insight-fe/jest.config.ts
+++ b/insight-fe/jest.config.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+    '^@generated/(.*)$': '<rootDir>/src/generated/$1',
+  },
+};
+
+export default config;

--- a/insight-fe/package.json
+++ b/insight-fe/package.json
@@ -9,7 +9,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@apollo/client": "3.12",
@@ -48,6 +49,12 @@
     "eslint": "^8",
     "eslint-config-next": "14.2.24",
     "graphql-zeus": "^7.0.5",
-    "typescript": "^5"
+    "typescript": "^5",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/jest-dom": "^6.0.0",
+    "@testing-library/user-event": "^14.4.3",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.2.5",
+    "@types/jest": "^29.5.14"
   }
 }

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/AvailableElements.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/AvailableElements.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AvailableElements } from '../components/AvailableElements';
+
+describe('AvailableElements', () => {
+  it('renders all element buttons', () => {
+    render(<AvailableElements selectedType={null} onSelect={() => {}} />);
+    expect(screen.getByRole('button', { name: 'Text' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Table' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Image' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Video' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Quiz' })).toBeInTheDocument();
+  });
+
+  it('calls onSelect when clicking a button', () => {
+    const onSelect = jest.fn();
+    render(<AvailableElements selectedType={null} onSelect={onSelect} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Text' }));
+    expect(onSelect).toHaveBeenCalledWith('text');
+  });
+});

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ColorPaletteManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ColorPaletteManagement.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ColorPaletteManagement from '../components/ColorPaletteManagement';
+import { useQuery, useMutation } from '@apollo/client';
+
+jest.mock('@apollo/client');
+
+let dropdownProps: any = null;
+jest.mock('@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown', () => (props: any) => {
+  dropdownProps = props;
+  return <select data-testid="crud" value={props.value} onChange={e => props.onChange(e)}></select>;
+});
+
+jest.mock('@/components/lesson/modals/AddColorPaletteModal', () => () => <div data-testid="add-modal" />);
+jest.mock('@/components/modals/ConfirmationModal', () => () => <div data-testid="confirm-modal" />);
+
+describe('ColorPaletteManagement', () => {
+  beforeEach(() => {
+    (useQuery as jest.Mock).mockReturnValue({ data: { getAllColorPalette: [ { id: '1', name: 'Palette 1', colors: [] } ] }, refetch: jest.fn() });
+    (useMutation as jest.Mock).mockReturnValue([jest.fn(), { loading: false }]);
+    dropdownProps = null;
+  });
+
+  it('provides palettes as options', () => {
+    render(<ColorPaletteManagement collectionId={1} />);
+    expect(dropdownProps.options).toEqual([{ label: 'Palette 1', value: '1' }]);
+  });
+
+  it('clears selection when collection changes', async () => {
+    const { rerender } = render(<ColorPaletteManagement collectionId={1} />);
+    await userEvent.selectOptions(screen.getByTestId('crud'), ['1']);
+    expect(dropdownProps.value).toBe(1);
+    rerender(<ColorPaletteManagement collectionId={2} />);
+    expect(dropdownProps.value).toBe('');
+  });
+});

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleCollectionManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleCollectionManagement.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import StyleCollectionManagement from '../components/StyleCollectionManagement';
+import { useQuery, useMutation } from '@apollo/client';
+
+jest.mock('@apollo/client');
+
+let dropdownProps: any = null;
+jest.mock('@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown', () => (props: any) => {
+  dropdownProps = props;
+  return <select data-testid="crud" value={props.value} onChange={e => props.onChange(e)}></select>;
+});
+
+jest.mock('@/components/lesson/modals/AddStyleCollectionModal', () => () => <div data-testid="collection-modal" />);
+jest.mock('@/components/modals/ConfirmationModal', () => () => <div data-testid="confirm-modal" />);
+
+describe('StyleCollectionManagement', () => {
+  beforeEach(() => {
+    (useQuery as jest.Mock).mockReturnValue({ data: { getAllStyleCollection: [ { id: '1', name: 'Collection 1' } ] }, refetch: jest.fn() });
+    (useMutation as jest.Mock).mockReturnValue([jest.fn(), { loading: false }]);
+    dropdownProps = null;
+  });
+
+  it('provides collections as options', () => {
+    render(<StyleCollectionManagement onSelectCollection={() => {}} />);
+    expect(dropdownProps.options).toEqual([{ label: 'Collection 1', value: '1' }]);
+  });
+});

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleGroupManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleGroupManagement.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import StyleGroupManagement from '../components/StyleGroupManagement';
+import { useQuery, useMutation } from '@apollo/client';
+
+jest.mock('@apollo/client');
+
+let dropdownProps: any = null;
+jest.mock('@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown', () => (props: any) => {
+  dropdownProps = props;
+  return <select data-testid="crud" value={props.value} onChange={e => props.onChange(e)}></select>;
+});
+
+jest.mock('@/components/lesson/modals/AddStyleGroupModal', () => () => <div data-testid="group-modal" />);
+jest.mock('@/components/modals/ConfirmationModal', () => () => <div data-testid="confirm-modal" />);
+
+describe('StyleGroupManagement', () => {
+  beforeEach(() => {
+    (useQuery as jest.Mock).mockReturnValue({ data: { getAllStyleGroup: [ { id: '1', name: 'Group 1' } ] }, refetch: jest.fn() });
+    (useMutation as jest.Mock).mockReturnValue([jest.fn(), { loading: false }]);
+    dropdownProps = null;
+  });
+
+  it('provides groups as options', () => {
+    render(<StyleGroupManagement collectionId={1} elementType="text" />);
+    expect(dropdownProps.options).toEqual([{ label: 'Group 1', value: '1' }]);
+  });
+});

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeBuilderPageClient } from '../ThemeBuilderPageClient';
+
+let collectionProps: any = null;
+let paletteProps: any = null;
+let availableProps: any = null;
+let groupProps: any = null;
+
+jest.mock('../components/StyleCollectionManagement', () => (props: any) => {
+  collectionProps = props;
+  return <button data-testid="collection" onClick={() => props.onSelectCollection(1)}>collection</button>;
+});
+
+jest.mock('../components/ColorPaletteManagement', () => (props: any) => {
+  paletteProps = props;
+  return <div data-testid="palette" />;
+});
+
+jest.mock('../components/AvailableElements', () => ({ onSelect, selectedType }: any) => {
+  availableProps = { onSelect, selectedType };
+  return <button data-testid="available" onClick={() => onSelect('text')}>available</button>;
+});
+
+jest.mock('../components/StyleGroupManagement', () => (props: any) => {
+  groupProps = props;
+  return <div data-testid="group" />;
+});
+
+describe('ThemeBuilderPageClient', () => {
+  it('updates state based on child callbacks', async () => {
+    render(<ThemeBuilderPageClient />);
+    expect(paletteProps.collectionId).toBeNull();
+    expect(groupProps.collectionId).toBeNull();
+    expect(groupProps.elementType).toBeNull();
+    // select collection
+    await userEvent.click(screen.getByTestId('collection'));
+    expect(paletteProps.collectionId).toBe(1);
+    expect(groupProps.collectionId).toBe(1);
+    // select element
+    await userEvent.click(screen.getByTestId('available'));
+    expect(groupProps.elementType).toBe('text');
+  });
+});


### PR DESCRIPTION
## Summary
- add Jest config for insight-fe
- add tests for ThemeBuilderPageClient and related components
- update package.json with test script and dev dependencies

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in insight-be *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b16ee2b10832693b4b4d741c4911a