### PR TITLE
Add theme builder drag-and-drop palettes

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -5,6 +5,8 @@ import { useState } from "react";
 import ColorPaletteManagement from "./components/ColorPaletteManagement";
 import StyleGroupManagement from "./components/StyleGroupManagement";
 import { AvailableElements } from "./components/AvailableElements";
+import StyledElementsPalette from "./components/StyledElementsPalette";
+import BaseElementsPalette from "./components/BaseElementsPalette";
 
 export const ThemeBuilderPageClient = () => {
   const [selectedCollectionId, setSelectedCollectionId] = useState<
@@ -13,6 +15,7 @@ export const ThemeBuilderPageClient = () => {
   const [selectedElementType, setSelectedElementType] = useState<string | null>(
     null
   );
+  const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
 
   return (
     <VStack w="100%">
@@ -30,7 +33,16 @@ export const ThemeBuilderPageClient = () => {
         <StyleGroupManagement
           collectionId={selectedCollectionId}
           elementType={selectedElementType}
+          onSelectGroup={setSelectedGroupId}
         />
+      </HStack>
+      <HStack w="100%" align="start" pt={4} spacing={4}>
+        <StyledElementsPalette
+          collectionId={selectedCollectionId}
+          elementType={selectedElementType}
+          groupId={selectedGroupId}
+        />
+        <BaseElementsPalette />
       </HStack>
     </VStack>
   );

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleGroupManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleGroupManagement.test.tsx
@@ -1,4 +1,5 @@
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import StyleGroupManagement from '../components/StyleGroupManagement';
 import { useQuery, useMutation } from '@apollo/client';
 
@@ -23,5 +24,18 @@ describe('StyleGroupManagement', () => {
   it('provides groups as options', () => {
     render(<StyleGroupManagement collectionId={1} elementType="text" />);
     expect(dropdownProps.options).toEqual([{ label: 'Group 1', value: '1' }]);
+  });
+
+  it('calls onSelectGroup when a group is selected', async () => {
+    const onSelect = jest.fn();
+    render(
+      <StyleGroupManagement
+        collectionId={1}
+        elementType="text"
+        onSelectGroup={onSelect}
+      />
+    );
+    await userEvent.selectOptions(screen.getByTestId('crud'), ['1']);
+    expect(onSelect).toHaveBeenCalledWith(1);
   });
 });

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
@@ -1,15 +1,24 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeBuilderPageClient } from '../ThemeBuilderPageClient';
+import { useLazyQuery } from '@apollo/client';
+
+jest.mock('@apollo/client');
 
 let collectionProps: any = null;
 let paletteProps: any = null;
 let availableProps: any = null;
 let groupProps: any = null;
+let styledPaletteProps: any = null;
+let basePaletteProps: any = null;
 
 jest.mock('../components/StyleCollectionManagement', () => (props: any) => {
   collectionProps = props;
-  return <button data-testid="collection" onClick={() => props.onSelectCollection(1)}>collection</button>;
+  return (
+    <button data-testid="collection" onClick={() => props.onSelectCollection(1)}>
+      collection
+    </button>
+  );
 });
 
 jest.mock('../components/ColorPaletteManagement', () => (props: any) => {
@@ -19,26 +28,57 @@ jest.mock('../components/ColorPaletteManagement', () => (props: any) => {
 
 jest.mock('../components/AvailableElements', () => ({ onSelect, selectedType }: any) => {
   availableProps = { onSelect, selectedType };
-  return <button data-testid="available" onClick={() => onSelect('text')}>available</button>;
+  return (
+    <button data-testid="available" onClick={() => onSelect('text')}>
+      available
+    </button>
+  );
 });
 
 jest.mock('../components/StyleGroupManagement', () => (props: any) => {
   groupProps = props;
-  return <div data-testid="group" />;
+  return (
+    <button data-testid="group" onClick={() => props.onSelectGroup(2)}>
+      group
+    </button>
+  );
+});
+
+jest.mock('@/components/DnD/DnDPalette', () => (props: any) => {
+  if (props.testId === 'styled') {
+    styledPaletteProps = props;
+    return <div data-testid="styled" />;
+  }
+  if (props.testId === 'base') {
+    basePaletteProps = props;
+    return <div data-testid="base" />;
+  }
+  return null;
 });
 
 describe('ThemeBuilderPageClient', () => {
+  beforeEach(() => {
+    (useLazyQuery as jest.Mock).mockReturnValue([jest.fn(), { data: { getAllStyle: [] } }]);
+    collectionProps = null;
+    paletteProps = null;
+    availableProps = null;
+    groupProps = null;
+    styledPaletteProps = null;
+    basePaletteProps = null;
+  });
+
   it('updates state based on child callbacks', async () => {
     render(<ThemeBuilderPageClient />);
     expect(paletteProps.collectionId).toBeNull();
     expect(groupProps.collectionId).toBeNull();
     expect(groupProps.elementType).toBeNull();
-    // select collection
     await userEvent.click(screen.getByTestId('collection'));
     expect(paletteProps.collectionId).toBe(1);
     expect(groupProps.collectionId).toBe(1);
-    // select element
     await userEvent.click(screen.getByTestId('available'));
     expect(groupProps.elementType).toBe('text');
+    await userEvent.click(screen.getByTestId('group'));
+    expect(styledPaletteProps.items).toEqual([]);
+    expect(basePaletteProps.items.length).toBeGreaterThan(0);
   });
 });

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/BaseElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/BaseElementsPalette.tsx
@@ -3,8 +3,8 @@
 import DnDPalette from "@/components/DnD/DnDPalette";
 import {
   SlideElementDnDItemProps,
-  SlideElementDnDItem,
 } from "@/components/DnD/cards/SlideElementDnDCard";
+import BaseElementDnDItem from "@/components/DnD/cards/BaseElementDnDCard";
 
 const baseItems: SlideElementDnDItemProps[] = [
   { id: "base-text", type: "text" },
@@ -29,7 +29,7 @@ export default function BaseElementsPalette() {
     <DnDPalette
       testId="base"
       items={baseItems}
-      ItemComponent={SlideElementDnDItem}
+      ItemComponent={BaseElementDnDItem}
       getDragData={(item) => JSON.stringify({ type: item.type })}
     />
   );

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/BaseElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/BaseElementsPalette.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import DnDPalette from "@/components/DnD/DnDPalette";
+import {
+  SlideElementDnDItemProps,
+  SlideElementDnDItem,
+} from "@/components/DnD/cards/SlideElementDnDCard";
+
+const baseItems: SlideElementDnDItemProps[] = [
+  { id: "base-text", type: "text" },
+  {
+    id: "base-table",
+    type: "table",
+    table: {
+      rows: 2,
+      cols: 2,
+      cells: Array.from({ length: 2 }, () =>
+        Array.from({ length: 2 }, () => ({ text: "Cell" }))
+      ),
+    },
+  },
+  { id: "base-image", type: "image", src: "https://via.placeholder.com/150" },
+  { id: "base-video", type: "video", url: "" },
+  { id: "base-quiz", type: "quiz", title: "Quiz", description: "", questions: [] },
+];
+
+export default function BaseElementsPalette() {
+  return (
+    <DnDPalette
+      testId="base"
+      items={baseItems}
+      ItemComponent={SlideElementDnDItem}
+      getDragData={(item) => JSON.stringify({ type: item.type })}
+    />
+  );
+}

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleGroupManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleGroupManagement.tsx
@@ -17,6 +17,7 @@ import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 interface StyleGroupManagementProps {
   collectionId: number | null;
   elementType: string | null;
+  onSelectGroup?: (id: number | null) => void;
 }
 
 const ELEMENT_TYPE_TO_ENUM: Record<string, string> = {
@@ -30,6 +31,7 @@ const ELEMENT_TYPE_TO_ENUM: Record<string, string> = {
 export default function StyleGroupManagement({
   collectionId,
   elementType,
+  onSelectGroup,
 }: StyleGroupManagementProps) {
   const { data, refetch } = useQuery(GET_STYLE_GROUPS, {
     variables: {
@@ -49,6 +51,10 @@ export default function StyleGroupManagement({
   const [isAddOpen, setIsAddOpen] = useState(false);
   const [isEditOpen, setIsEditOpen] = useState(false);
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    onSelectGroup?.(selectedId === "" ? null : selectedId);
+  }, [selectedId, onSelectGroup]);
 
   useEffect(() => {
     if (data?.getAllStyleGroup) {

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useLazyQuery } from "@apollo/client";
+import { GET_STYLES_WITH_CONFIG_BY_GROUP } from "@/graphql/lesson";
+import DnDPalette from "@/components/DnD/DnDPalette";
+import {
+  SlideElementDnDItemProps,
+  SlideElementDnDItem,
+} from "@/components/DnD/cards/SlideElementDnDCard";
+
+interface StyledElementsPaletteProps {
+  collectionId: number | null;
+  elementType: string | null;
+  groupId: number | null;
+}
+
+export default function StyledElementsPalette({
+  collectionId,
+  elementType,
+  groupId,
+}: StyledElementsPaletteProps) {
+  const [items, setItems] = useState<SlideElementDnDItemProps[]>([]);
+  const [fetchStyles, { data }] = useLazyQuery(GET_STYLES_WITH_CONFIG_BY_GROUP, {
+    fetchPolicy: "network-only",
+  });
+
+  useEffect(() => {
+    if (collectionId !== null && elementType && groupId !== null) {
+      fetchStyles({
+        variables: {
+          collectionId: String(collectionId),
+          element: elementType,
+          groupId: String(groupId),
+        },
+      });
+    } else {
+      setItems([]);
+    }
+  }, [collectionId, elementType, groupId, fetchStyles]);
+
+  useEffect(() => {
+    if (data?.getAllStyle) {
+      setItems(
+        data.getAllStyle.map((s: any) => ({
+          ...(s.config as SlideElementDnDItemProps),
+          id: crypto.randomUUID(),
+        }))
+      );
+    }
+  }, [data]);
+
+  return (
+    <DnDPalette
+      testId="styled"
+      items={items}
+      ItemComponent={SlideElementDnDItem}
+      getDragData={(item) => JSON.stringify({ type: item.type, config: item })}
+    />
+  );
+}

--- a/insight-fe/src/components/DnD/DnDPalette.tsx
+++ b/insight-fe/src/components/DnD/DnDPalette.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { HStack, Box } from "@chakra-ui/react";
+import React from "react";
+
+export interface DnDPaletteProps<T> {
+  items: T[];
+  ItemComponent: React.ComponentType<{ item: T }>;
+  getDragData?: (item: T) => string;
+  spacing?: number;
+  testId?: string;
+}
+
+export function DnDPalette<T>({
+  items,
+  ItemComponent,
+  getDragData = (item) => JSON.stringify(item),
+  spacing = 2,
+  testId,
+}: DnDPaletteProps<T>) {
+  return (
+    <HStack overflowX="auto" spacing={spacing} data-testid={testId}>
+      {items.map((item, idx) => (
+        <Box
+          key={idx}
+          p={2}
+          borderWidth="1px"
+          borderRadius="md"
+          bg="white"
+          draggable
+          onDragStart={(e) => e.dataTransfer.setData("text/plain", getDragData(item))}
+        >
+          <ItemComponent item={item} />
+        </Box>
+      ))}
+    </HStack>
+  );
+}
+export default DnDPalette;

--- a/insight-fe/src/components/DnD/cards/BaseElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/BaseElementDnDCard.tsx
@@ -1,0 +1,14 @@
+"use client";
+
+import { Text } from "@chakra-ui/react";
+
+export interface BaseElementDnDItemProps {
+  id: string;
+  type: string;
+}
+
+export function BaseElementDnDItem({ item }: { item: BaseElementDnDItemProps }) {
+  return <Text>{item.type}</Text>;
+}
+
+export default BaseElementDnDItem;


### PR DESCRIPTION
## Summary
- create BaseElementsPalette and StyledElementsPalette components
- simplify ThemeBuilderPageClient to use the new palette components
- keep drag-and-drop palette logic encapsulated in reusable components

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684bca9a9ec08326b8c939b8c14e68b9