### PR TITLE
Add clone/delete buttons to Theme Builder

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeAttributesPane.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeAttributesPane.tsx
@@ -17,6 +17,8 @@ interface ThemeAttributesPaneProps {
   onUpdateColumn: (col: ColumnType<SlideElementDnDItemProps>) => void;
   onUpdateBoard: (board: BoardRow) => void;
   onSave: () => void;
+  onClone?: () => void;
+  onDelete?: () => void;
 }
 
 export default function ThemeAttributesPane({
@@ -29,6 +31,8 @@ export default function ThemeAttributesPane({
   onUpdateColumn,
   onUpdateBoard,
   onSave,
+  onClone,
+  onDelete,
 }: ThemeAttributesPaneProps) {
   return (
     <Box p={4} borderWidth="1px" borderRadius="md" minW="250px">
@@ -42,6 +46,8 @@ export default function ThemeAttributesPane({
         <ElementAttributesPane
           element={element}
           onChange={onUpdateElement}
+          onClone={onClone}
+          onDelete={onDelete}
           colorPalettes={colorPalettes}
           selectedPaletteId={selectedPaletteId}
         />

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeCanvas.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeCanvas.tsx
@@ -94,6 +94,58 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     setBoards((bs) => bs.map((b) => (b.id === updated.id ? updated : b)));
   };
 
+  const cloneElement = () => {
+    if (!selectedElementId) return;
+    setColumnMap((prev) => {
+      const newMap = { ...prev };
+      for (const board of boards) {
+        for (const colId of board.orderedColumnIds) {
+          const col = newMap[colId];
+          const idx = col.items.findIndex((i) => i.id === selectedElementId);
+          if (idx !== -1) {
+            const orig = col.items[idx];
+            const copy = { ...orig, id: crypto.randomUUID() };
+            newMap[colId] = {
+              ...col,
+              items: [
+                ...col.items.slice(0, idx + 1),
+                copy,
+                ...col.items.slice(idx + 1),
+              ],
+            };
+            return newMap;
+          }
+        }
+      }
+      return newMap;
+    });
+  };
+
+  const deleteElement = () => {
+    if (!selectedElementId) return;
+    setColumnMap((prev) => {
+      const newMap = { ...prev };
+      for (const board of boards) {
+        for (const colId of board.orderedColumnIds) {
+          const col = newMap[colId];
+          const idx = col.items.findIndex((i) => i.id === selectedElementId);
+          if (idx !== -1) {
+            newMap[colId] = {
+              ...col,
+              items: [
+                ...col.items.slice(0, idx),
+                ...col.items.slice(idx + 1),
+              ],
+            };
+            return newMap;
+          }
+        }
+      }
+      return newMap;
+    });
+    setSelectedElementId(null);
+  };
+
   const handleDropElement = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
     const raw = e.dataTransfer.getData("text/plain");
@@ -277,6 +329,8 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
         onUpdateColumn={updateColumn}
         onUpdateBoard={updateBoard}
         onSave={() => setIsSaveOpen(true)}
+        onClone={cloneElement}
+        onDelete={deleteElement}
         colorPalettes={colorPalettes}
         selectedPaletteId={paletteId ?? ""}
       />


### PR DESCRIPTION
## Summary
- enable clone and delete actions in the theme builder
- pass clone/delete handlers through the attributes pane

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684be40f44a48326b37f24c4ee5a1a9b