### PR TITLE
Add drag to create rows and columns

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/BaseElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/BaseElementsPalette.tsx
@@ -8,6 +8,8 @@ import BaseElementDnDItem from "@/components/DnD/cards/BaseElementDnDCard";
 
 const baseItems: SlideElementDnDItemProps[] = [
   { id: "base-text", type: "text" },
+  { id: "base-row", type: "row" },
+  { id: "base-column", type: "column" },
   {
     id: "base-table",
     type: "table",


### PR DESCRIPTION
## Summary
- enable row/column drag addition in theme builder
- skip drag-over indicator for row/column drags

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c09bb82308326a58c5fffef986e3b