### PR TITLE
Add labels for theme builder dropdowns and palettes

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/AvailableElements.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/AvailableElements.tsx
@@ -1,4 +1,4 @@
-import { Button, HStack, Text } from "@chakra-ui/react";
+import { Button, HStack, Text, VStack } from "@chakra-ui/react";
 
 /// this should be standardised with lesson editor
 const AVAILABLE_ELEMENTS = [
@@ -19,18 +19,20 @@ export const AvailableElements = ({
   onSelect,
 }: AvailableElementsProps) => {
   return (
-    <HStack w="50%" gap={4} pl={4}>
-      {AVAILABLE_ELEMENTS.map((el) => (
-        <Button
-          key={el.type}
-          size="lg"
-          colorScheme={selectedType === el.type ? "green" : "yellow"}
-          onClick={() => onSelect(el.type)}
-          //   p={4}
-        >
-          <Text>{el.label}</Text>
-        </Button>
-      ))}
-    </HStack>
+    <VStack align="start" w="50%" pl={4} gap={2}>
+      <Text fontSize="sm">Available Elements</Text>
+      <HStack w="100%" gap={4}>
+        {AVAILABLE_ELEMENTS.map((el) => (
+          <Button
+            key={el.type}
+            size="lg"
+            colorScheme={selectedType === el.type ? "green" : "yellow"}
+            onClick={() => onSelect(el.type)}
+          >
+            <Text>{el.label}</Text>
+          </Button>
+        ))}
+      </HStack>
+    </VStack>
   );
 };

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/BaseElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/BaseElementsPalette.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import DnDPalette from "@/components/DnD/DnDPalette";
+import { VStack, Text } from "@chakra-ui/react";
 import {
   SlideElementDnDItemProps,
 } from "@/components/DnD/cards/SlideElementDnDCard";
@@ -28,11 +29,14 @@ const baseItems: SlideElementDnDItemProps[] = [
 
 export default function BaseElementsPalette() {
   return (
-    <DnDPalette
-      testId="base"
-      items={baseItems}
-      ItemComponent={BaseElementDnDItem}
-      getDragData={(item) => JSON.stringify({ type: item.type })}
-    />
+    <VStack align="start" w="100%">
+      <Text fontSize="sm" mb={2}>Base Elements</Text>
+      <DnDPalette
+        testId="base"
+        items={baseItems}
+        ItemComponent={BaseElementDnDItem}
+        getDragData={(item) => JSON.stringify({ type: item.type })}
+      />
+    </VStack>
   );
 }

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ColorPaletteManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ColorPaletteManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Flex } from "@chakra-ui/react";
+import { Box, Flex, Text } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 
@@ -62,7 +62,8 @@ export default function ColorPaletteManagement({
   const isDisabled = collectionId === null;
 
   return (
-    <Flex flex={1} p={4} w="100%">
+    <Flex flex={1} p={4} w="100%" direction="column" align="start">
+      <Text fontSize="sm" mb={2}>Color Palettes</Text>
       <CrudDropdown
         options={options}
         value={selectedId}

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleCollectionManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleCollectionManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Flex } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 
@@ -60,7 +60,8 @@ export default function StyleCollectionManagement({
   }));
 
   return (
-    <Flex flex={1} p={4} w="100%">
+    <Flex flex={1} p={4} w="100%" direction="column" align="start">
+      <Text fontSize="sm" mb={2}>Style Collections</Text>
       <CrudDropdown
         options={options}
         value={selectedId}

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleGroupManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleGroupManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Flex } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { useMutation, useQuery } from "@apollo/client";
 
@@ -78,7 +78,8 @@ export default function StyleGroupManagement({
   const isDisabled = collectionId === null || !elementType;
 
   return (
-    <Flex flex={1} p={4} w="100%">
+    <Flex flex={1} p={4} w="100%" direction="column" align="start">
+      <Text fontSize="sm" mb={2}>Style Groups</Text>
       <CrudDropdown
         options={options}
         value={selectedId}

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
 import { GET_STYLES_WITH_CONFIG_BY_GROUP } from "@/graphql/lesson";
 import DnDPalette from "@/components/DnD/DnDPalette";
+import { VStack, Text } from "@chakra-ui/react";
 import {
   SlideElementDnDItemProps,
   SlideElementDnDItem,
@@ -49,11 +50,16 @@ export default function StyledElementsPalette({
   }, [data]);
 
   return (
-    <DnDPalette
-      testId="styled"
-      items={items}
-      ItemComponent={SlideElementDnDItem}
-      getDragData={(item) => JSON.stringify({ type: item.type, config: item })}
-    />
+    <VStack align="start" w="100%">
+      <Text fontSize="sm" mb={2}>Styled Elements</Text>
+      <DnDPalette
+        testId="styled"
+        items={items}
+        ItemComponent={SlideElementDnDItem}
+        getDragData={(item) =>
+          JSON.stringify({ type: item.type, config: item })
+        }
+      />
+    </VStack>
   );
 }


### PR DESCRIPTION
## Summary
- add heading labels to theme builder dropdowns
- label the available elements selection buttons
- add labels above base and styled element palettes

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c0d98da3c8326abd339aa6a595a26