### PR TITLE
Remove slide-out menus

### DIFF
--- a/insight-fe/src/components/DnD/column.tsx
+++ b/insight-fe/src/components/DnD/column.tsx
@@ -12,7 +12,6 @@ import {
   Box,
   Flex,
   Heading,
-  HStack,
   Spinner,
   Stack,
   IconButton,
@@ -132,7 +131,6 @@ function ColumnBase<TCard extends BaseCardDnD>({
 
   const [state, setState] = useState<State>(idle);
   const [isDragging, setIsDragging] = useState(false);
-  const [showControls, setShowControls] = useState(false);
 
   const { instanceId, registerColumn } = useBoardContext();
 
@@ -370,35 +368,22 @@ function ColumnBase<TCard extends BaseCardDnD>({
                   onClick={() => {
                     if (isDragging) return;
                     onSelectColumn?.(columnId);
-                    setShowControls((v) => !v);
                   }}
                 />
               )}
-              <HStack
-                justify="flex-end"
-                bg="gray.100"
-                px={2}
-                py={1}
-                borderRadius="md"
-                spacing={1}
-                cursor="grab"
-                position="absolute"
-                top={0}
-                right={0}
-                transform={showControls ? "translateY(0)" : "translateY(-100%)"}
-                transition="transform 0.2s"
-              >
-                {onRemoveColumn && (
-                  <IconButton
-                    aria-label="Remove column"
-                    icon={<X size={12} />}
-                    size="xs"
-                    variant="ghost"
-                    colorScheme="red"
-                    onClick={() => onRemoveColumn(columnId)}
-                  />
-                )}
-              </HStack>
+              {onRemoveColumn && (
+                <IconButton
+                  aria-label="Remove column"
+                  icon={<X size={12} />}
+                  size="xs"
+                  variant="ghost"
+                  colorScheme="red"
+                  position="absolute"
+                  top={0}
+                  right={0}
+                  onClick={() => onRemoveColumn(columnId)}
+                />
+              )}
             </Box>
 
             <Box ref={scrollableRef} sx={scrollContainerStyles}>

--- a/insight-fe/src/components/lesson/slide/SlideElementsBoard.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideElementsBoard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, HStack, IconButton } from "@chakra-ui/react";
+import { Box, IconButton } from "@chakra-ui/react";
 import { useState, useRef } from "react";
 import { DnDBoardMain } from "@/components/DnD/DnDBoardMain";
 import {
@@ -80,7 +80,6 @@ export default function SlideElementsBoard({
   const boardRef = useRef<HTMLDivElement | null>(null);
   const dragHandleRef = useRef<HTMLButtonElement | null>(null);
   const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
-  const [showControls, setShowControls] = useState(false);
   const [isDragging, setIsDragging] = useState(false);
 
   useBoardDragDrop(
@@ -169,7 +168,6 @@ export default function SlideElementsBoard({
         left={0}
         role="group"
         zIndex={1}
-        onMouseLeave={() => setShowControls(false)}
       >
         <IconButton
           ref={dragHandleRef}
@@ -181,42 +179,26 @@ export default function SlideElementsBoard({
           onClick={() => {
             if (isDragging) return;
             onSelectBoard?.();
-            setShowControls((v) => !v);
           }}
         />
-        <HStack
-          justify="flex-start"
-          bg="gray.100"
-          px={2}
-          py={1}
-          borderRadius="md"
-          spacing={1}
-          cursor="grab"
-          position="absolute"
-          top={0}
-          left={0}
-          transform={showControls ? "translateY(0)" : "translateY(-100%)"}
-          transition="transform 0.2s"
-        >
-          {onRemoveBoard && (
-            <IconButton
-              aria-label="Delete container"
-              icon={<X size={12} />}
-              size="xs"
-              variant="ghost"
-              colorScheme="red"
-              onClick={onRemoveBoard}
-            />
-          )}
+        {onRemoveBoard && (
           <IconButton
-            aria-label="Add column"
-            icon={<Plus size={12} />}
+            aria-label="Delete container"
+            icon={<X size={12} />}
             size="xs"
             variant="ghost"
-            colorScheme="teal"
-            onClick={addColumn}
+            colorScheme="red"
+            onClick={onRemoveBoard}
           />
-        </HStack>
+        )}
+        <IconButton
+          aria-label="Add column"
+          icon={<Plus size={12} />}
+          size="xs"
+          variant="ghost"
+          colorScheme="teal"
+          onClick={addColumn}
+        />
       </Box>
       <ElementWrapper
         styles={wrapperStyles}


### PR DESCRIPTION
## Summary
- update board row to always show control buttons
- update column component to show controls without sliding menus

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_684c1389522083269867264fc0936542