### PR TITLE
Add theme save/load functionality

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -1,13 +1,17 @@
 "use client";
-import { Flex, HStack, VStack } from "@chakra-ui/react";
+import { Flex, HStack, VStack, Button } from "@chakra-ui/react";
 import StyleCollectionManagement from "./components/StyleCollectionManagement";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import ColorPaletteManagement from "./components/ColorPaletteManagement";
 import StyleGroupManagement from "./components/StyleGroupManagement";
 import { AvailableElements } from "./components/AvailableElements";
 import StyledElementsPalette from "./components/StyledElementsPalette";
 import BaseElementsPalette from "./components/BaseElementsPalette";
 import ThemeCanvas from "./components/ThemeCanvas";
+import SaveThemeModal from "./components/SaveThemeModal";
+import LoadThemeModal, { ThemeInfo } from "./components/LoadThemeModal";
+import { useLazyQuery, useMutation } from "@apollo/client";
+import { GET_THEMES, CREATE_THEME } from "@/graphql/lesson";
 
 export const ThemeBuilderPageClient = () => {
   const [selectedCollectionId, setSelectedCollectionId] = useState<
@@ -20,6 +24,63 @@ export const ThemeBuilderPageClient = () => {
   const [selectedPaletteId, setSelectedPaletteId] = useState<number | null>(
     null
   );
+  const [isSaveThemeOpen, setIsSaveThemeOpen] = useState(false);
+  const [isLoadThemeOpen, setIsLoadThemeOpen] = useState(false);
+  const [themes, setThemes] = useState<ThemeInfo[]>([]);
+
+  const [fetchThemes, { data: themesData }] = useLazyQuery(GET_THEMES);
+  const [createTheme] = useMutation(CREATE_THEME);
+
+  useEffect(() => {
+    if (selectedCollectionId !== null) {
+      fetchThemes({ variables: { collectionId: String(selectedCollectionId) } });
+    } else {
+      setThemes([]);
+    }
+  }, [selectedCollectionId, fetchThemes]);
+
+  useEffect(() => {
+    if (themesData?.getAllTheme) {
+      setThemes(
+        themesData.getAllTheme.map((t: any) => ({
+          id: Number(t.id),
+          name: t.name,
+          styleCollectionId: t.styleCollectionId,
+          defaultPaletteId: t.defaultPaletteId,
+        }))
+      );
+    }
+  }, [themesData]);
+
+  const handleSaveTheme = async (name: string) => {
+    if (selectedCollectionId === null || selectedPaletteId === null) return;
+    const { data } = await createTheme({
+      variables: {
+        data: {
+          name,
+          styleCollectionId: selectedCollectionId,
+          defaultPaletteId: selectedPaletteId,
+        },
+      },
+    });
+    const created = data?.createTheme;
+    if (created) {
+      setThemes((ts) => [
+        ...ts,
+        {
+          id: Number(created.id),
+          name: created.name,
+          styleCollectionId: created.styleCollectionId,
+          defaultPaletteId: created.defaultPaletteId,
+        },
+      ]);
+    }
+  };
+
+  const handleLoadTheme = (theme: ThemeInfo) => {
+    setSelectedCollectionId(theme.styleCollectionId);
+    setSelectedPaletteId(theme.defaultPaletteId);
+  };
 
   return (
     <VStack w="100%">
@@ -55,9 +116,32 @@ export const ThemeBuilderPageClient = () => {
           />
         </Flex>
       </HStack>
+      <HStack w="100%" justify="flex-end" pt={2}>
+        <Button onClick={() => setIsLoadThemeOpen(true)}>Load Theme</Button>
+        <Button colorScheme="blue" onClick={() => setIsSaveThemeOpen(true)}>
+          Save Theme
+        </Button>
+      </HStack>
       <ThemeCanvas
         collectionId={selectedCollectionId}
         paletteId={selectedPaletteId}
+      />
+      <SaveThemeModal
+        isOpen={isSaveThemeOpen}
+        onClose={() => setIsSaveThemeOpen(false)}
+        onSave={(name) => {
+          handleSaveTheme(name);
+          setIsSaveThemeOpen(false);
+        }}
+      />
+      <LoadThemeModal
+        isOpen={isLoadThemeOpen}
+        onClose={() => setIsLoadThemeOpen(false)}
+        themes={themes}
+        onLoad={(theme) => {
+          handleLoadTheme(theme);
+          setIsLoadThemeOpen(false);
+        }}
       />
     </VStack>
   );

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/LoadThemeModal.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/LoadThemeModal.tsx
@@ -1,0 +1,70 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Button, Stack, FormControl, FormLabel, Select } from "@chakra-ui/react";
+import { BaseModal } from "@/components/modals/BaseModal";
+
+export interface ThemeInfo {
+  id: number;
+  name: string;
+  styleCollectionId: number;
+  defaultPaletteId: number;
+}
+
+interface LoadThemeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  themes: ThemeInfo[];
+  onLoad: (theme: ThemeInfo) => void;
+}
+
+export default function LoadThemeModal({
+  isOpen,
+  onClose,
+  themes,
+  onLoad,
+}: LoadThemeModalProps) {
+  const [themeId, setThemeId] = useState<number | "">("");
+
+  useEffect(() => {
+    if (isOpen) {
+      setThemeId("");
+    }
+  }, [isOpen]);
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} title="Load Theme">
+      <Stack spacing={4}>
+        <FormControl>
+          <FormLabel>Select Theme</FormLabel>
+          <Select
+            placeholder="Select theme"
+            value={themeId}
+            onChange={(e) => {
+              const val = e.target.value;
+              setThemeId(val === "" ? "" : parseInt(val, 10));
+            }}
+          >
+            {themes.map((t) => (
+              <option key={t.id} value={t.id}>
+                {t.name}
+              </option>
+            ))}
+          </Select>
+        </FormControl>
+        <Button
+          colorScheme="blue"
+          isDisabled={themeId === ""}
+          onClick={() => {
+            if (themeId === "") return;
+            const theme = themes.find((t) => t.id === themeId);
+            if (theme) {
+              onLoad(theme);
+            }
+          }}
+        >
+          Load
+        </Button>
+      </Stack>
+    </BaseModal>
+  );
+}

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/SaveThemeModal.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/SaveThemeModal.tsx
@@ -1,0 +1,44 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Button, Stack, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import { BaseModal } from "@/components/modals/BaseModal";
+
+interface SaveThemeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (name: string) => void;
+}
+
+export default function SaveThemeModal({
+  isOpen,
+  onClose,
+  onSave,
+}: SaveThemeModalProps) {
+  const [name, setName] = useState("");
+
+  useEffect(() => {
+    if (isOpen) {
+      setName("");
+    }
+  }, [isOpen]);
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} title="Save Theme">
+      <Stack spacing={4}>
+        <FormControl>
+          <FormLabel>Theme Name</FormLabel>
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+        </FormControl>
+        <Button
+          colorScheme="blue"
+          isDisabled={!name}
+          onClick={() => {
+            onSave(name);
+          }}
+        >
+          Save
+        </Button>
+      </Stack>
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- add SaveThemeModal and LoadThemeModal components
- load/save theme buttons in ThemeBuilderPageClient

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c27824c448326a709b815ff38e44f