### PR TITLE
Fix theme loading without style collection

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -10,8 +10,8 @@ import BaseElementsPalette from "./components/BaseElementsPalette";
 import ThemeCanvas from "./components/ThemeCanvas";
 import SaveThemeModal from "./components/SaveThemeModal";
 import LoadThemeModal, { ThemeInfo } from "./components/LoadThemeModal";
-import { useLazyQuery, useMutation } from "@apollo/client";
-import { GET_THEMES, CREATE_THEME } from "@/graphql/lesson";
+import { useQuery, useMutation } from "@apollo/client";
+import { GET_ALL_THEMES, CREATE_THEME } from "@/graphql/lesson";
 
 export const ThemeBuilderPageClient = () => {
   const [selectedCollectionId, setSelectedCollectionId] = useState<
@@ -28,16 +28,8 @@ export const ThemeBuilderPageClient = () => {
   const [isLoadThemeOpen, setIsLoadThemeOpen] = useState(false);
   const [themes, setThemes] = useState<ThemeInfo[]>([]);
 
-  const [fetchThemes, { data: themesData }] = useLazyQuery(GET_THEMES);
+  const { data: themesData } = useQuery(GET_ALL_THEMES);
   const [createTheme] = useMutation(CREATE_THEME);
-
-  useEffect(() => {
-    if (selectedCollectionId !== null) {
-      fetchThemes({ variables: { collectionId: String(selectedCollectionId) } });
-    } else {
-      setThemes([]);
-    }
-  }, [selectedCollectionId, fetchThemes]);
 
   useEffect(() => {
     if (themesData?.getAllTheme) {
@@ -87,10 +79,12 @@ export const ThemeBuilderPageClient = () => {
       <HStack flex={1} w="100%" align="start">
         <StyleCollectionManagement
           onSelectCollection={setSelectedCollectionId}
+          selectedId={selectedCollectionId}
         />
         <ColorPaletteManagement
           collectionId={selectedCollectionId}
           onSelectPalette={setSelectedPaletteId}
+          selectedId={selectedPaletteId}
         />
       </HStack>
       <HStack w="100%">

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
@@ -67,9 +67,7 @@ describe('ThemeBuilderPageClient', () => {
     (useLazyQuery as jest.Mock).mockReturnValue([jest.fn(), { data: { getAllStyle: [] } }]);
     (useQuery as jest.Mock).mockReturnValue({
       data: {
-        getAllStyle: [
-          { config: { type: 'text' } },
-        ],
+        getAllTheme: [],
       },
     });
     collectionProps = null;

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -207,6 +207,17 @@ export const GET_THEMES = gql`
   }
 `;
 
+export const GET_ALL_THEMES = gql`
+  query GetAllThemes {
+    getAllTheme(data: { all: true }) {
+      id
+      name
+      styleCollectionId
+      defaultPaletteId
+    }
+  }
+`;
+
 export const GET_THEME = gql`
   query GetTheme($id: String!) {
     getTheme(data: { id: $id }) {


### PR DESCRIPTION
## Summary
- fetch all themes on theme builder load
- sync theme builder dropdown selections with loaded theme
- allow passing selected ids to style and palette components
- update theme builder tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e70b25ef48326a6f41e991265aed0