### PR TITLE
Add slide management to lesson builder

### DIFF
--- a/insight-fe/src/components/lesson/LessonEditor.tsx
+++ b/insight-fe/src/components/lesson/LessonEditor.tsx
@@ -386,6 +386,7 @@ const LessonEditor = forwardRef<LessonEditorHandle>(function LessonEditor(
         openLoadStyle={() => setIsLoadStyleOpen(true)}
         colorPalettes={colorPalettes}
         selectedPaletteId={selectedPaletteId}
+        deleteSlide={editor.deleteSlide}
       />
 
       <StyleModals

--- a/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
+++ b/insight-fe/src/components/lesson/hooks/useLessonEditorState.ts
@@ -26,6 +26,7 @@ export function useLessonEditorState(
     selectElement: selection.selectElement,
     selectColumn: selection.selectColumn,
     selectBoard: selection.selectBoard,
+    deleteSlide: selection.deleteSlide,
     selectedSlide: selection.selectedSlide,
     selectedElement: selection.selectedElement,
     selectedColumn: selection.selectedColumn,

--- a/insight-fe/src/components/lesson/hooks/useLessonSelection.ts
+++ b/insight-fe/src/components/lesson/hooks/useLessonSelection.ts
@@ -36,7 +36,8 @@ export type Action =
       slideId: string;
       boardId: string;
       updater: (board: BoardRow) => BoardRow;
-    };
+    }
+  | { type: "deleteSlide"; slideId: string };
 
 function reducer(state: LessonState, action: Action): LessonState {
   switch (action.type) {
@@ -99,6 +100,17 @@ function reducer(state: LessonState, action: Action): LessonState {
             : s
         ),
       };
+    case "deleteSlide":
+      if (state.slides.length <= 1) return state;
+      const filtered = state.slides.filter((s) => s.id !== action.slideId);
+      return {
+        ...state,
+        slides: filtered,
+        selectedSlideId:
+          state.selectedSlideId === action.slideId
+            ? filtered[0]?.id ?? null
+            : state.selectedSlideId,
+      };
     default:
       return state;
   }
@@ -154,6 +166,11 @@ export function useLessonSelection(ref?: React.Ref<LessonEditorHandle>) {
     [dispatch]
   );
 
+  const deleteSlide = useCallback(
+    (id: string) => dispatch({ type: "deleteSlide", slideId: id }),
+    [dispatch]
+  );
+
   const selectedSlide = useMemo(
     () => state.slides.find((s) => s.id === state.selectedSlideId) || null,
     [state.slides, state.selectedSlideId]
@@ -195,5 +212,6 @@ export function useLessonSelection(ref?: React.Ref<LessonEditorHandle>) {
     selectedElement,
     selectedColumn,
     selectedBoard,
+    deleteSlide,
   };
 }

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -65,14 +65,6 @@ export default function SlideCanvas({
 }: SlideCanvasProps) {
   return (
     <Stack gap={4} alignItems="flex-start">
-      <SlideSequencer
-        orientation="horizontal"
-        slides={slides}
-        setSlides={setSlides as any}
-        selectedSlideId={selectedSlideId}
-        onSelect={selectSlide}
-        onDelete={deleteSlide}
-      />
       {selectedSlideId && selectedSlide && (
         <Grid gap={4} flex={1} templateColumns="1fr 300px">
           <Box
@@ -148,6 +140,14 @@ export default function SlideCanvas({
           </Box>
         </Grid>
       )}
+      <SlideSequencer
+        orientation="horizontal"
+        slides={slides}
+        setSlides={setSlides as any}
+        selectedSlideId={selectedSlideId}
+        onSelect={selectSlide}
+        onDelete={deleteSlide}
+      />
     </Stack>
   );
 }

--- a/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideCanvas.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-  import { Flex, Grid, Box, Text, HStack, Button } from "@chakra-ui/react";
+import { Grid, Box, Text, HStack, Button, Stack } from "@chakra-ui/react";
 
 import BoardAttributesPane from "../attributes-pane/BoardAttributesPane";
 import { ColumnType } from "@/components/DnD/types";
@@ -34,7 +34,8 @@ interface SlideCanvasProps {
   openLoadStyle: () => void;
   colorPalettes: { id: number; name: string; colors: string[] }[];
   selectedPaletteId: number | "";
-} 
+  deleteSlide: (id: string) => void;
+}
 
 export default function SlideCanvas({
   slides,
@@ -60,14 +61,17 @@ export default function SlideCanvas({
   openLoadStyle,
   colorPalettes,
   selectedPaletteId,
+  deleteSlide,
 }: SlideCanvasProps) {
   return (
-    <Flex gap={6} alignItems="flex-start">
+    <Stack gap={4} alignItems="flex-start">
       <SlideSequencer
+        orientation="horizontal"
         slides={slides}
         setSlides={setSlides as any}
         selectedSlideId={selectedSlideId}
         onSelect={selectSlide}
+        onDelete={deleteSlide}
       />
       {selectedSlideId && selectedSlide && (
         <Grid gap={4} flex={1} templateColumns="1fr 300px">
@@ -144,6 +148,6 @@ export default function SlideCanvas({
           </Box>
         </Grid>
       )}
-    </Flex>
+    </Stack>
   );
 }

--- a/insight-fe/src/components/lesson/slide/SlideSequencer.tsx
+++ b/insight-fe/src/components/lesson/slide/SlideSequencer.tsx
@@ -70,6 +70,8 @@ interface SlideItemProps {
   instanceId: symbol;
   onSelect: (id: string) => void;
   isSelected: boolean;
+  onDelete?: (id: string) => void;
+  orientation: "vertical" | "horizontal";
 }
 
 function SlideItem({
@@ -77,6 +79,8 @@ function SlideItem({
   instanceId,
   onSelect,
   isSelected,
+  onDelete,
+  orientation,
 }: SlideItemProps) {
   const ref = useRef<HTMLDivElement | null>(null);
   const [closestEdge, setClosestEdge] = useState<Edge | null>(null);
@@ -105,7 +109,8 @@ function SlideItem({
             {
               input,
               element,
-              allowedEdges: ["top", "bottom"],
+              allowedEdges:
+                orientation === "horizontal" ? ["left", "right"] : ["top", "bottom"],
             }
           ),
         onDragEnter: (args) =>
@@ -128,6 +133,20 @@ function SlideItem({
       cursor="grab"
       onClick={() => onSelect(slide.id)}
     >
+      {onDelete && (
+        <Button
+          size="xs"
+          position="absolute"
+          top="2px"
+          right="2px"
+          onClick={(e) => {
+            e.stopPropagation();
+            onDelete(slide.id);
+          }}
+        >
+          X
+        </Button>
+      )}
       {slide.title}
       {closestEdge && <DropIndicator edge={closestEdge} gap="4px" />}
     </Box>
@@ -139,6 +158,8 @@ export interface SlideSequencerProps {
   setSlides: React.Dispatch<React.SetStateAction<Slide[]>>;
   selectedSlideId: string | null;
   onSelect: (id: string) => void;
+  onDelete?: (id: string) => void;
+  orientation?: "vertical" | "horizontal";
 }
 
 export default function SlideSequencer({
@@ -146,6 +167,8 @@ export default function SlideSequencer({
   setSlides,
   selectedSlideId,
   onSelect,
+  onDelete,
+  orientation = "vertical",
 }: SlideSequencerProps) {
   const counter = useRef(slides.length + 1);
   const containerRef = useRef<HTMLDivElement | null>(null);
@@ -169,14 +192,19 @@ export default function SlideSequencer({
   }, [setSlides]);
 
   // Setup drop targets and reorder logic via dedicated hook
-  useSlideDnD(containerRef, slides, setSlides, instanceId);
+  useSlideDnD(containerRef, slides, setSlides, instanceId, orientation);
 
   return (
-    <Stack spacing={4}>
+    <Stack spacing={4} direction={orientation === "horizontal" ? "row" : "column"}>
       <Button onClick={addSlide} colorScheme="teal" alignSelf="flex-start">
         Add Slide
       </Button>
-      <Stack ref={containerRef} gap={2}>
+      <Stack
+        ref={containerRef}
+        gap={2}
+        direction={orientation === "horizontal" ? "row" : "column"}
+        overflowX={orientation === "horizontal" ? "auto" : "visible"}
+      >
         {slides.map((slide) => (
           <SlideItem
             key={slide.id}
@@ -184,6 +212,8 @@ export default function SlideSequencer({
             instanceId={instanceId.current}
             onSelect={onSelect}
             isSelected={selectedSlideId === slide.id}
+            onDelete={onDelete}
+            orientation={orientation}
           />
         ))}
       </Stack>

--- a/insight-fe/src/hooks/useSlideDnD.tsx
+++ b/insight-fe/src/hooks/useSlideDnD.tsx
@@ -20,7 +20,8 @@ export function useSlideDnD(
   containerRef: RefObject<HTMLDivElement>,
   slides: Slide[],
   setSlides: React.Dispatch<React.SetStateAction<Slide[]>>,
-  instanceId: React.MutableRefObject<symbol>
+  instanceId: React.MutableRefObject<symbol>,
+  axis: "vertical" | "horizontal" = "vertical"
 ) {
   // Register the container to accept slide drops
   useEffect(() => {
@@ -54,7 +55,7 @@ export function useSlideDnD(
             startIndex,
             indexOfTarget: slides.length - 1,
             closestEdgeOfTarget: null,
-            axis: "vertical",
+            axis,
           });
           setSlides((prev) => reorder({ list: prev, startIndex, finishIndex: destinationIndex }));
           return;
@@ -70,11 +71,11 @@ export function useSlideDnD(
             startIndex,
             indexOfTarget,
             closestEdgeOfTarget,
-            axis: "vertical",
+            axis,
           });
           setSlides((prev) => reorder({ list: prev, startIndex, finishIndex: destinationIndex }));
         }
       },
     });
-  }, [instanceId, slides, setSlides]);
+  }, [instanceId, slides, setSlides, axis]);
 }


### PR DESCRIPTION
## Summary
- add optional orientation to slide DnD hook
- allow slide deletion and horizontal ordering in SlideSequencer
- expose deleteSlide via lesson editor state
- update SlideCanvas to show a horizontal slide list
- wire deleteSlide prop in LessonEditor

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc -p insight-fe/tsconfig.json` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_684e7af5c4908326a1abfec133a17584