### PR TITLE
Remove Lesson Builder save element options

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -5,7 +5,6 @@ import ThemeDropdown from "@/components/dropdowns/ThemeDropdown";
 import StyleGroupManagement from "./components/StyleGroupManagement";
 import { AvailableElements } from "./components/AvailableElements";
 import StyledElementsPalette from "./components/StyledElementsPalette";
-import BaseElementsPalette from "./components/BaseElementsPalette";
 import SlideCanvas from "./components/SlideCanvas";
 import SlideManager from "./components/SlideManager";
 import { Slide, createInitialBoard } from "@/components/lesson/slide/SlideSequencer";
@@ -61,10 +60,7 @@ export const LessonBuilderPageClient = () => {
         />
       </HStack>
       <HStack w="100%" align="start" pt={4} spacing={4}>
-        <Flex flex={1} width="50%" bg="blue.100" p={4}>
-          <BaseElementsPalette />
-        </Flex>
-        <Flex flex={1} width="50%" bg="green.100" p={4}>
+        <Flex flex={1} bg="green.100" p={4}>
           <StyledElementsPalette
             collectionId={selectedCollectionId}
             elementType={selectedElementType}

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/ThemeAttributesPane.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/ThemeAttributesPane.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, HStack, Text, Button } from "@chakra-ui/react";
+import { Box, HStack, Text } from "@chakra-ui/react";
 import BoardAttributesPane from "@/components/lesson/attributes-pane/BoardAttributesPane";
 import ColumnAttributesPane from "@/components/lesson/attributes-pane/ColumnAttributesPane";
 import ElementAttributesPane from "@/components/lesson/attributes-pane/ElementAttributesPane";
@@ -16,7 +16,6 @@ interface ThemeAttributesPaneProps {
   onUpdateElement: (el: SlideElementDnDItemProps) => void;
   onUpdateColumn: (col: ColumnType<SlideElementDnDItemProps>) => void;
   onUpdateBoard: (board: BoardRow) => void;
-  onSave: (target: 'element' | 'column' | 'row') => void;
   onClone?: () => void;
   onDelete?: () => void;
 }
@@ -30,7 +29,6 @@ export default function ThemeAttributesPane({
   onUpdateElement,
   onUpdateColumn,
   onUpdateBoard,
-  onSave,
   onClone,
   onDelete,
 }: ThemeAttributesPaneProps) {
@@ -38,21 +36,6 @@ export default function ThemeAttributesPane({
     <Box p={4} borderWidth="1px" borderRadius="md" minW="250px">
       <HStack justify="space-between" mb={2}>
         <Text>Attributes</Text>
-        {element && (
-          <Button size="xs" onClick={() => onSave('element')}>
-            Save Element
-          </Button>
-        )}
-        {column && (
-          <Button size="xs" onClick={() => onSave('column')}>
-            Save Column
-          </Button>
-        )}
-        {board && (
-          <Button size="xs" onClick={() => onSave('row')}>
-            Save Row
-          </Button>
-        )}
       </HStack>
       {element && (
         <ElementAttributesPane

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/ThemeCanvas.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/ThemeCanvas.tsx
@@ -2,7 +2,7 @@
 
 import { Box, HStack, VStack } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
-import { useQuery, useMutation } from "@apollo/client";
+import { useQuery } from "@apollo/client";
 import SlideElementsContainer, { BoardRow } from "@/components/lesson/slide/SlideElementsContainer";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap, ColumnType } from "@/components/DnD/types";
@@ -14,8 +14,7 @@ import {
 } from "@/components/lesson/defaultStyles";
 import ThemeAttributesPane from "./ThemeAttributesPane";
 import DeleteDropArea from "./DeleteDropArea";
-import SaveElementModal from "./SaveElementModal";
-import { CREATE_STYLE, GET_COLOR_PALETTES } from "@/graphql/lesson";
+import { GET_COLOR_PALETTES } from "@/graphql/lesson";
 
 const ELEMENT_TYPE_TO_ENUM: Record<string, string> = {
   text: "Text",
@@ -57,9 +56,6 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     setSelectedElementId(null);
     setSelectedColumnId(null);
   };
-  const [saveTarget, setSaveTarget] = useState<'element' | 'column' | 'row' | null>(null);
-
-  const [createStyle] = useMutation(CREATE_STYLE);
 
   const { data: paletteData, refetch: refetchPalettes } = useQuery(
     GET_COLOR_PALETTES,
@@ -426,38 +422,6 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
   const selectedColumn = selectedColumnId ? columnMap[selectedColumnId] || null : null;
   const selectedBoard = selectedBoardId ? boards.find((b) => b.id === selectedBoardId) || null : null;
 
-  const handleSave = async ({ name, groupId }: { name: string; groupId: number | null }) => {
-    if (collectionId === null || !saveTarget) return;
-    let elementType: string;
-    let config: any;
-    if (saveTarget === 'element') {
-      if (!selectedElement) return;
-      elementType = selectedElement.type;
-      config = selectedElement;
-    } else if (saveTarget === 'column') {
-      if (!selectedColumn) return;
-      elementType = 'column';
-      config = selectedColumn;
-    } else {
-      if (!selectedBoard) return;
-      elementType = 'row';
-      config = selectedBoard;
-    }
-
-    await createStyle({
-      variables: {
-        data: {
-          name,
-          collectionId,
-          groupId: groupId ?? undefined,
-          element: ELEMENT_TYPE_TO_ENUM[elementType],
-          config,
-        },
-      },
-    });
-    setSaveTarget(null);
-  };
-
   return (
     <HStack
       w="100%"
@@ -490,7 +454,6 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           onUpdateElement={updateElement}
           onUpdateColumn={updateColumn}
           onUpdateBoard={updateBoard}
-          onSave={setSaveTarget}
           onClone={cloneElement}
           onDelete={deleteElement}
           colorPalettes={colorPalettes}
@@ -502,19 +465,6 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           onDropBoard={deleteBoardById}
         />
       </VStack>
-      {saveTarget && collectionId !== null && (
-        <SaveElementModal
-          isOpen={saveTarget !== null}
-          onClose={() => setSaveTarget(null)}
-          collectionId={collectionId}
-          elementType={
-            saveTarget === 'element'
-              ? selectedElement?.type || ''
-              : saveTarget
-          }
-          onSave={handleSave}
-        />
-      )}
     </HStack>
   );
 }


### PR DESCRIPTION
## Summary
- drop the base element palette from the lesson builder UI
- delete Save Element buttons and modal usage in lesson builder

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: cannot find module errors)*

------
https://chatgpt.com/codex/tasks/task_e_684e9af4a58883268fe98f4653178762