### PR TITLE
Add lesson save feature with style references

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -1,23 +1,30 @@
 "use client";
-import { Flex, HStack, VStack } from "@chakra-ui/react";
+import { Flex, HStack, VStack, Button } from "@chakra-ui/react";
 import { useState } from "react";
+import { useMutation } from "@apollo/client";
+import { CREATE_LESSON } from "@/graphql/lesson";
 import ThemeDropdown from "@/components/dropdowns/ThemeDropdown";
 import StyleGroupManagement from "./components/StyleGroupManagement";
 import { AvailableElements } from "./components/AvailableElements";
 import StyledElementsPalette from "./components/StyledElementsPalette";
 import SlideCanvas from "./components/SlideCanvas";
 import SlideManager from "./components/SlideManager";
-import { Slide, createInitialBoard } from "@/components/lesson/slide/SlideSequencer";
+import {
+  Slide,
+  createInitialBoard,
+} from "@/components/lesson/slide/SlideSequencer";
 
 export const LessonBuilderPageClient = () => {
   const [selectedThemeId, setSelectedThemeId] = useState<number | null>(null);
-  const [selectedCollectionId, setSelectedCollectionId] = useState<number | null>(null);
+  const [selectedCollectionId, setSelectedCollectionId] = useState<
+    number | null
+  >(null);
   const [selectedElementType, setSelectedElementType] = useState<string | null>(
-    null
+    null,
   );
   const [selectedGroupId, setSelectedGroupId] = useState<number | null>(null);
   const [selectedPaletteId, setSelectedPaletteId] = useState<number | null>(
-    null
+    null,
   );
   const initial = createInitialBoard();
   const [slides, setSlides] = useState<Slide[]>([
@@ -29,6 +36,37 @@ export const LessonBuilderPageClient = () => {
     },
   ]);
   const [selectedSlideId, setSelectedSlideId] = useState<string>(slides[0].id);
+
+  const [createLesson] = useMutation(CREATE_LESSON);
+
+  const prepareContent = () => {
+    return {
+      slides: slides.map((s) => ({
+        ...s,
+        columnMap: Object.fromEntries(
+          Object.entries(s.columnMap).map(([cid, col]) => [
+            cid,
+            {
+              ...col,
+              items: col.items.map(({ styles, ...rest }) => rest),
+            },
+          ]),
+        ),
+      })),
+    };
+  };
+
+  const handleSave = async () => {
+    await createLesson({
+      variables: {
+        data: {
+          title: "Untitled Lesson",
+          themeId: selectedThemeId,
+          content: prepareContent(),
+        },
+      },
+    });
+  };
 
   return (
     <VStack w="100%">
@@ -81,12 +119,17 @@ export const LessonBuilderPageClient = () => {
           onChange={(map, b) =>
             setSlides((prev) =>
               prev.map((s) =>
-                s.id === selectedSlideId ? { ...s, columnMap: map, boards: b } : s
-              )
+                s.id === selectedSlideId
+                  ? { ...s, columnMap: map, boards: b }
+                  : s,
+              ),
             )
           }
         />
       )}
+      <Button onClick={handleSave} colorScheme="teal" alignSelf="flex-start">
+        Save Lesson
+      </Button>
     </VStack>
   );
 };

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/SlideCanvas.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/SlideCanvas.tsx
@@ -3,7 +3,9 @@
 import { Box, HStack, VStack } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useQuery } from "@apollo/client";
-import SlideElementsContainer, { BoardRow } from "@/components/lesson/slide/SlideElementsContainer";
+import SlideElementsContainer, {
+  BoardRow,
+} from "@/components/lesson/slide/SlideElementsContainer";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap, ColumnType } from "@/components/DnD/types";
 import { availableFonts } from "@/theme/fonts";
@@ -31,7 +33,7 @@ interface SlideCanvasProps {
   boards: BoardRow[];
   onChange: (
     map: ColumnMap<SlideElementDnDItemProps>,
-    boards: BoardRow[]
+    boards: BoardRow[],
   ) => void;
 }
 
@@ -44,8 +46,13 @@ export default function SlideCanvas({
 }: SlideCanvasProps) {
   const [localMap, setLocalMap] = useState(columnMap);
   const [localBoards, setLocalBoards] = useState(boards);
-  const [dropIndicator, setDropIndicator] = useState<{ columnId: string; index: number } | null>(null);
-  const [selectedElementId, setSelectedElementId] = useState<string | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<{
+    columnId: string;
+    index: number;
+  } | null>(null);
+  const [selectedElementId, setSelectedElementId] = useState<string | null>(
+    null,
+  );
   const [selectedColumnId, setSelectedColumnId] = useState<string | null>(null);
   const [selectedBoardId, setSelectedBoardId] = useState<string | null>(null);
 
@@ -54,7 +61,10 @@ export default function SlideCanvas({
     setLocalBoards(boards);
   }, [columnMap, boards]);
 
-  const handleExternalChange = (map: ColumnMap<SlideElementDnDItemProps>, b: BoardRow[]) => {
+  const handleExternalChange = (
+    map: ColumnMap<SlideElementDnDItemProps>,
+    b: BoardRow[],
+  ) => {
     setLocalMap(map);
     setLocalBoards(b);
     onChange(map, b);
@@ -78,12 +88,14 @@ export default function SlideCanvas({
     setSelectedColumnId(null);
   };
 
-
-  const { data: paletteData, refetch: refetchPalettes } = useQuery(GET_COLOR_PALETTES, {
-    variables: { collectionId: String(collectionId) },
-    skip: collectionId === null,
-    fetchPolicy: "network-only",
-  });
+  const { data: paletteData, refetch: refetchPalettes } = useQuery(
+    GET_COLOR_PALETTES,
+    {
+      variables: { collectionId: String(collectionId) },
+      skip: collectionId === null,
+      fetchPolicy: "network-only",
+    },
+  );
 
   useEffect(() => {
     if (collectionId !== null) {
@@ -91,15 +103,17 @@ export default function SlideCanvas({
     }
   }, [collectionId, paletteId, refetchPalettes]);
 
-  const colorPalettes = (paletteData?.getAllColorPalette || []).map((p: any) => ({
-    id: Number(p.id),
-    name: p.name,
-    colors: p.colors,
-  }));
+  const colorPalettes = (paletteData?.getAllColorPalette || []).map(
+    (p: any) => ({
+      id: Number(p.id),
+      name: p.name,
+      colors: p.colors,
+    }),
+  );
 
   const handleChange = (
     map: ColumnMap<SlideElementDnDItemProps>,
-    b: BoardRow[]
+    b: BoardRow[],
   ) => {
     handleExternalChange(map, b);
   };
@@ -114,7 +128,11 @@ export default function SlideCanvas({
           if (idx !== -1) {
             newMap[colId] = {
               ...col,
-              items: [...col.items.slice(0, idx), updated, ...col.items.slice(idx + 1)],
+              items: [
+                ...col.items.slice(0, idx),
+                updated,
+                ...col.items.slice(idx + 1),
+              ],
             };
             handleExternalChange(newMap, localBoards);
             return newMap;
@@ -154,7 +172,11 @@ export default function SlideCanvas({
             const copy = { ...orig, id: crypto.randomUUID() };
             newMap[colId] = {
               ...col,
-              items: [...col.items.slice(0, idx + 1), copy, ...col.items.slice(idx + 1)],
+              items: [
+                ...col.items.slice(0, idx + 1),
+                copy,
+                ...col.items.slice(idx + 1),
+              ],
             };
             handleExternalChange(newMap, localBoards);
             return newMap;
@@ -195,13 +217,18 @@ export default function SlideCanvas({
       const column = prev[id];
       const newMap = { ...prev };
       delete newMap[id];
-      if (selectedElementId && column.items.some((i) => i.id === selectedElementId)) {
+      if (
+        selectedElementId &&
+        column.items.some((i) => i.id === selectedElementId)
+      ) {
         setSelectedElementId(null);
       }
-      const updatedBoards = localBoards.map((b) => ({
-        ...b,
-        orderedColumnIds: b.orderedColumnIds.filter((cid) => cid !== id),
-      })).filter((b) => b.orderedColumnIds.length > 0);
+      const updatedBoards = localBoards
+        .map((b) => ({
+          ...b,
+          orderedColumnIds: b.orderedColumnIds.filter((cid) => cid !== id),
+        }))
+        .filter((b) => b.orderedColumnIds.length > 0);
       setLocalBoards(updatedBoards);
       handleExternalChange(newMap, updatedBoards);
       if (selectedColumnId === id) {
@@ -219,7 +246,10 @@ export default function SlideCanvas({
       const newMap = { ...localMap };
       for (const colId of board.orderedColumnIds) {
         const column = localMap[colId];
-        if (selectedElementId && column?.items.some((i) => i.id === selectedElementId)) {
+        if (
+          selectedElementId &&
+          column?.items.some((i) => i.id === selectedElementId)
+        ) {
           setSelectedElementId(null);
         }
         if (selectedColumnId === colId) {
@@ -274,7 +304,9 @@ export default function SlideCanvas({
         {
           id: boardId,
           orderedColumnIds: [columnId],
-          wrapperStyles: boardConfig?.wrapperStyles ?? { ...defaultBoardWrapperStyles },
+          wrapperStyles: boardConfig?.wrapperStyles ?? {
+            ...defaultBoardWrapperStyles,
+          },
           spacing: boardConfig?.spacing ?? 0,
         },
       ];
@@ -293,18 +325,26 @@ export default function SlideCanvas({
       const boardId = boardEl.dataset.boardId;
       if (!boardId) return;
       const columnId = `col-${crypto.randomUUID()}`;
-      const colConfig = config as Partial<ColumnType<SlideElementDnDItemProps>> | null;
+      const colConfig = config as Partial<
+        ColumnType<SlideElementDnDItemProps>
+      > | null;
       const newColumn: ColumnType<SlideElementDnDItemProps> = {
         title: "",
         columnId,
-        styles: colConfig?.styles ?? { container: { border: "1px dashed gray", width: "100%" } },
-        wrapperStyles: colConfig?.wrapperStyles ?? { ...defaultColumnWrapperStyles },
+        styles: colConfig?.styles ?? {
+          container: { border: "1px dashed gray", width: "100%" },
+        },
+        wrapperStyles: colConfig?.wrapperStyles ?? {
+          ...defaultColumnWrapperStyles,
+        },
         items: [],
         spacing: colConfig?.spacing ?? 0,
       };
       const newMap = { ...localMap, [columnId]: newColumn };
       const newBoards = localBoards.map((b) =>
-        b.id === boardId ? { ...b, orderedColumnIds: [...b.orderedColumnIds, columnId] } : b
+        b.id === boardId
+          ? { ...b, orderedColumnIds: [...b.orderedColumnIds, columnId] }
+          : b,
       );
       setLocalBoards(newBoards);
       setLocalMap(newMap);
@@ -315,11 +355,14 @@ export default function SlideCanvas({
     const columnEl = target?.closest("[data-column-id]") as HTMLElement | null;
     const dropColumnId = columnEl?.dataset.columnId;
     const firstColumn = localBoards[0].orderedColumnIds[0];
-    const columnId = dropColumnId && localMap[dropColumnId] ? dropColumnId : firstColumn;
+    const columnId =
+      dropColumnId && localMap[dropColumnId] ? dropColumnId : firstColumn;
     const column = localMap[columnId];
     let insertIndex = column.items.length;
     if (columnEl) {
-      const cards = Array.from(columnEl.querySelectorAll("[data-card-id]")) as HTMLElement[];
+      const cards = Array.from(
+        columnEl.querySelectorAll("[data-card-id]"),
+      ) as HTMLElement[];
       for (let i = 0; i < cards.length; i++) {
         const rect = cards[i].getBoundingClientRect();
         if (e.clientY < rect.top + rect.height / 2) {
@@ -330,7 +373,7 @@ export default function SlideCanvas({
     }
 
     const newEl: SlideElementDnDItemProps = config
-      ? { ...config, id: crypto.randomUUID() }
+      ? { ...config, id: crypto.randomUUID(), styleId: config.styleId }
       : {
           id: crypto.randomUUID(),
           type,
@@ -347,39 +390,43 @@ export default function SlideCanvas({
                 },
               }
             : type === "image"
-            ? { src: "https://via.placeholder.com/150" }
-            : type === "video"
-            ? { url: "" }
-            : type === "quiz"
-            ? { title: "Untitled Quiz", description: "", questions: [] }
-            : type === "table"
-            ? {
-                table: {
-                  rows: 2,
-                  cols: 2,
-                  cells: Array.from({ length: 2 }, () =>
-                    Array.from({ length: 2 }, () => ({
-                      text: "Cell",
-                      styles: {
-                        color: "#000000",
-                        fontSize: "14px",
-                        fontFamily: availableFonts[0].fontFamily,
-                        fontWeight: "normal",
-                        lineHeight: "1.2",
-                        textAlign: "left",
-                      },
-                    }))
-                  ),
-                },
-              }
-            : {}),
+              ? { src: "https://via.placeholder.com/150" }
+              : type === "video"
+                ? { url: "" }
+                : type === "quiz"
+                  ? { title: "Untitled Quiz", description: "", questions: [] }
+                  : type === "table"
+                    ? {
+                        table: {
+                          rows: 2,
+                          cols: 2,
+                          cells: Array.from({ length: 2 }, () =>
+                            Array.from({ length: 2 }, () => ({
+                              text: "Cell",
+                              styles: {
+                                color: "#000000",
+                                fontSize: "14px",
+                                fontFamily: availableFonts[0].fontFamily,
+                                fontWeight: "normal",
+                                lineHeight: "1.2",
+                                textAlign: "left",
+                              },
+                            })),
+                          ),
+                        },
+                      }
+                    : {}),
           wrapperStyles: { ...defaultColumnWrapperStyles },
           animation: undefined,
         };
 
     const updatedColumn = {
       ...column,
-      items: [...column.items.slice(0, insertIndex), newEl, ...column.items.slice(insertIndex)],
+      items: [
+        ...column.items.slice(0, insertIndex),
+        newEl,
+        ...column.items.slice(insertIndex),
+      ],
     };
 
     const newMap = { ...localMap, [columnId]: updatedColumn };
@@ -403,7 +450,9 @@ export default function SlideCanvas({
     if (!column) return;
     let insertIndex = column.items.length;
     if (columnEl) {
-      const cards = Array.from(columnEl.querySelectorAll("[data-card-id]")) as HTMLElement[];
+      const cards = Array.from(
+        columnEl.querySelectorAll("[data-card-id]"),
+      ) as HTMLElement[];
       for (let i = 0; i < cards.length; i++) {
         const rect = cards[i].getBoundingClientRect();
         if (e.clientY < rect.top + rect.height / 2) {
@@ -427,8 +476,12 @@ export default function SlideCanvas({
     return null;
   })();
 
-  const selectedColumn = selectedColumnId ? localMap[selectedColumnId] || null : null;
-  const selectedBoard = selectedBoardId ? localBoards.find((b) => b.id === selectedBoardId) || null : null;
+  const selectedColumn = selectedColumnId
+    ? localMap[selectedColumnId] || null
+    : null;
+  const selectedBoard = selectedBoardId
+    ? localBoards.find((b) => b.id === selectedBoardId) || null
+    : null;
 
   return (
     <VStack
@@ -464,4 +517,3 @@ export default function SlideCanvas({
     </VStack>
   );
 }
-

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/StyledElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/StyledElementsPalette.tsx
@@ -24,7 +24,11 @@ export default function StyledElementsPalette({
   groupId,
 }: StyledElementsPaletteProps) {
   const [items, setItems] = useState<
-    (SlideElementDnDItemProps | ColumnType<SlideElementDnDItemProps> | BoardRow)[]
+    (
+      | SlideElementDnDItemProps
+      | ColumnType<SlideElementDnDItemProps>
+      | BoardRow
+    )[]
   >([]);
   const { data } = useQuery(GET_STYLES_WITH_CONFIG_BY_GROUP, {
     variables: {
@@ -52,7 +56,11 @@ export default function StyledElementsPalette({
         if (elementType === "row") {
           return { ...cfg, type: "row", id: crypto.randomUUID() };
         }
-        return { ...(cfg as SlideElementDnDItemProps), id: crypto.randomUUID() };
+        return {
+          ...(cfg as SlideElementDnDItemProps),
+          id: crypto.randomUUID(),
+          styleId: Number(s.id),
+        };
       });
       setItems(mapped);
     }
@@ -60,7 +68,9 @@ export default function StyledElementsPalette({
 
   return (
     <VStack align="start" w="100%">
-      <Text fontSize="sm" mb={2}>Styled Elements</Text>
+      <Text fontSize="sm" mb={2}>
+        Styled Elements
+      </Text>
       <DnDPalette
         testId="styled"
         items={items}

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/ThemeCanvas.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/ThemeCanvas.tsx
@@ -3,7 +3,9 @@
 import { Box, HStack, VStack } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useQuery } from "@apollo/client";
-import SlideElementsContainer, { BoardRow } from "@/components/lesson/slide/SlideElementsContainer";
+import SlideElementsContainer, {
+  BoardRow,
+} from "@/components/lesson/slide/SlideElementsContainer";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap, ColumnType } from "@/components/DnD/types";
 import { createInitialBoard } from "@/components/lesson/slide/SlideSequencer";
@@ -30,12 +32,22 @@ interface ThemeCanvasProps {
   paletteId: number | null;
 }
 
-export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProps) {
+export default function ThemeCanvas({
+  collectionId,
+  paletteId,
+}: ThemeCanvasProps) {
   const initial = createInitialBoard();
-  const [columnMap, setColumnMap] = useState<ColumnMap<SlideElementDnDItemProps>>(initial.columnMap);
+  const [columnMap, setColumnMap] = useState<
+    ColumnMap<SlideElementDnDItemProps>
+  >(initial.columnMap);
   const [boards, setBoards] = useState<BoardRow[]>(initial.boards);
-  const [dropIndicator, setDropIndicator] = useState<{ columnId: string; index: number } | null>(null);
-  const [selectedElementId, setSelectedElementId] = useState<string | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<{
+    columnId: string;
+    index: number;
+  } | null>(null);
+  const [selectedElementId, setSelectedElementId] = useState<string | null>(
+    null,
+  );
   const [selectedColumnId, setSelectedColumnId] = useState<string | null>(null);
   const [selectedBoardId, setSelectedBoardId] = useState<string | null>(null);
 
@@ -57,14 +69,13 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     setSelectedColumnId(null);
   };
 
-
   const { data: paletteData, refetch: refetchPalettes } = useQuery(
     GET_COLOR_PALETTES,
     {
       variables: { collectionId: String(collectionId) },
       skip: collectionId === null,
       fetchPolicy: "network-only",
-    }
+    },
   );
 
   useEffect(() => {
@@ -73,15 +84,17 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     }
   }, [collectionId, paletteId, refetchPalettes]);
 
-  const colorPalettes = (paletteData?.getAllColorPalette || []).map((p: any) => ({
-    id: Number(p.id),
-    name: p.name,
-    colors: p.colors,
-  }));
+  const colorPalettes = (paletteData?.getAllColorPalette || []).map(
+    (p: any) => ({
+      id: Number(p.id),
+      name: p.name,
+      colors: p.colors,
+    }),
+  );
 
   const handleChange = (
     map: ColumnMap<SlideElementDnDItemProps>,
-    b: BoardRow[]
+    b: BoardRow[],
   ) => {
     setColumnMap(map);
     setBoards(b);
@@ -97,7 +110,11 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           if (idx !== -1) {
             newMap[colId] = {
               ...col,
-              items: [...col.items.slice(0, idx), updated, ...col.items.slice(idx + 1)],
+              items: [
+                ...col.items.slice(0, idx),
+                updated,
+                ...col.items.slice(idx + 1),
+              ],
             };
             return newMap;
           }
@@ -152,10 +169,7 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           if (idx !== -1) {
             newMap[colId] = {
               ...col,
-              items: [
-                ...col.items.slice(0, idx),
-                ...col.items.slice(idx + 1),
-              ],
+              items: [...col.items.slice(0, idx), ...col.items.slice(idx + 1)],
             };
             return newMap;
           }
@@ -188,7 +202,7 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           ...b,
           orderedColumnIds: b.orderedColumnIds.filter((cid) => cid !== id),
         }))
-        .filter((b) => b.orderedColumnIds.length > 0)
+        .filter((b) => b.orderedColumnIds.length > 0),
     );
     if (selectedColumnId === id) {
       setSelectedColumnId(null);
@@ -262,8 +276,9 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
         {
           id: boardId,
           orderedColumnIds: [columnId],
-          wrapperStyles:
-            boardConfig?.wrapperStyles ?? { ...defaultBoardWrapperStyles },
+          wrapperStyles: boardConfig?.wrapperStyles ?? {
+            ...defaultBoardWrapperStyles,
+          },
           spacing: boardConfig?.spacing ?? 0,
         },
       ]);
@@ -298,8 +313,8 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
         prev.map((b) =>
           b.id === boardId
             ? { ...b, orderedColumnIds: [...b.orderedColumnIds, columnId] }
-            : b
-        )
+            : b,
+        ),
       );
       return;
     }
@@ -308,11 +323,14 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     const dropColumnId = columnEl?.dataset.columnId;
     setColumnMap((prev) => {
       const firstColumn = boards[0].orderedColumnIds[0];
-      const columnId = dropColumnId && prev[dropColumnId] ? dropColumnId : firstColumn;
+      const columnId =
+        dropColumnId && prev[dropColumnId] ? dropColumnId : firstColumn;
       const column = prev[columnId];
       let insertIndex = column.items.length;
       if (columnEl) {
-        const cards = Array.from(columnEl.querySelectorAll("[data-card-id]")) as HTMLElement[];
+        const cards = Array.from(
+          columnEl.querySelectorAll("[data-card-id]"),
+        ) as HTMLElement[];
         for (let i = 0; i < cards.length; i++) {
           const rect = cards[i].getBoundingClientRect();
           if (e.clientY < rect.top + rect.height / 2) {
@@ -322,7 +340,7 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
         }
       }
       const newEl: SlideElementDnDItemProps = config
-        ? { ...config, id: crypto.randomUUID() }
+        ? { ...config, id: crypto.randomUUID(), styleId: config.styleId }
         : {
             id: crypto.randomUUID(),
             type,
@@ -339,32 +357,32 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
                   },
                 }
               : type === "image"
-              ? { src: "https://via.placeholder.com/150" }
-              : type === "video"
-              ? { url: "" }
-              : type === "quiz"
-              ? { title: "Untitled Quiz", description: "", questions: [] }
-              : type === "table"
-              ? {
-                  table: {
-                    rows: 2,
-                    cols: 2,
-                    cells: Array.from({ length: 2 }, () =>
-                      Array.from({ length: 2 }, () => ({
-                        text: "Cell",
-                        styles: {
-                          color: "#000000",
-                          fontSize: "14px",
-                          fontFamily: availableFonts[0].fontFamily,
-                          fontWeight: "normal",
-                          lineHeight: "1.2",
-                          textAlign: "left",
-                        },
-                      }))
-                    ),
-                  },
-                }
-              : {}),
+                ? { src: "https://via.placeholder.com/150" }
+                : type === "video"
+                  ? { url: "" }
+                  : type === "quiz"
+                    ? { title: "Untitled Quiz", description: "", questions: [] }
+                    : type === "table"
+                      ? {
+                          table: {
+                            rows: 2,
+                            cols: 2,
+                            cells: Array.from({ length: 2 }, () =>
+                              Array.from({ length: 2 }, () => ({
+                                text: "Cell",
+                                styles: {
+                                  color: "#000000",
+                                  fontSize: "14px",
+                                  fontFamily: availableFonts[0].fontFamily,
+                                  fontWeight: "normal",
+                                  lineHeight: "1.2",
+                                  textAlign: "left",
+                                },
+                              })),
+                            ),
+                          },
+                        }
+                      : {}),
             wrapperStyles: { ...defaultColumnWrapperStyles },
             animation: undefined,
           };
@@ -396,7 +414,9 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     if (!column) return;
     let insertIndex = column.items.length;
     if (columnEl) {
-      const cards = Array.from(columnEl.querySelectorAll("[data-card-id]")) as HTMLElement[];
+      const cards = Array.from(
+        columnEl.querySelectorAll("[data-card-id]"),
+      ) as HTMLElement[];
       for (let i = 0; i < cards.length; i++) {
         const rect = cards[i].getBoundingClientRect();
         if (e.clientY < rect.top + rect.height / 2) {
@@ -420,8 +440,12 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     return null;
   })();
 
-  const selectedColumn = selectedColumnId ? columnMap[selectedColumnId] || null : null;
-  const selectedBoard = selectedBoardId ? boards.find((b) => b.id === selectedBoardId) || null : null;
+  const selectedColumn = selectedColumnId
+    ? columnMap[selectedColumnId] || null
+    : null;
+  const selectedBoard = selectedBoardId
+    ? boards.find((b) => b.id === selectedBoardId) || null
+    : null;
 
   return (
     <HStack

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
@@ -24,7 +24,11 @@ export default function StyledElementsPalette({
   groupId,
 }: StyledElementsPaletteProps) {
   const [items, setItems] = useState<
-    (SlideElementDnDItemProps | ColumnType<SlideElementDnDItemProps> | BoardRow)[]
+    (
+      | SlideElementDnDItemProps
+      | ColumnType<SlideElementDnDItemProps>
+      | BoardRow
+    )[]
   >([]);
   const { data } = useQuery(GET_STYLES_WITH_CONFIG_BY_GROUP, {
     variables: {
@@ -52,7 +56,11 @@ export default function StyledElementsPalette({
         if (elementType === "row") {
           return { ...cfg, type: "row", id: crypto.randomUUID() };
         }
-        return { ...(cfg as SlideElementDnDItemProps), id: crypto.randomUUID() };
+        return {
+          ...(cfg as SlideElementDnDItemProps),
+          id: crypto.randomUUID(),
+          styleId: Number(s.id),
+        };
       });
       setItems(mapped);
     }
@@ -60,7 +68,9 @@ export default function StyledElementsPalette({
 
   return (
     <VStack align="start" w="100%">
-      <Text fontSize="sm" mb={2}>Styled Elements</Text>
+      <Text fontSize="sm" mb={2}>
+        Styled Elements
+      </Text>
       <DnDPalette
         testId="styled"
         items={items}

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeCanvas.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeCanvas.tsx
@@ -3,7 +3,9 @@
 import { Box, HStack, VStack } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@apollo/client";
-import SlideElementsContainer, { BoardRow } from "@/components/lesson/slide/SlideElementsContainer";
+import SlideElementsContainer, {
+  BoardRow,
+} from "@/components/lesson/slide/SlideElementsContainer";
 import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnMap, ColumnType } from "@/components/DnD/types";
 import { createInitialBoard } from "@/components/lesson/slide/SlideSequencer";
@@ -31,12 +33,22 @@ interface ThemeCanvasProps {
   paletteId: number | null;
 }
 
-export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProps) {
+export default function ThemeCanvas({
+  collectionId,
+  paletteId,
+}: ThemeCanvasProps) {
   const initial = createInitialBoard();
-  const [columnMap, setColumnMap] = useState<ColumnMap<SlideElementDnDItemProps>>(initial.columnMap);
+  const [columnMap, setColumnMap] = useState<
+    ColumnMap<SlideElementDnDItemProps>
+  >(initial.columnMap);
   const [boards, setBoards] = useState<BoardRow[]>(initial.boards);
-  const [dropIndicator, setDropIndicator] = useState<{ columnId: string; index: number } | null>(null);
-  const [selectedElementId, setSelectedElementId] = useState<string | null>(null);
+  const [dropIndicator, setDropIndicator] = useState<{
+    columnId: string;
+    index: number;
+  } | null>(null);
+  const [selectedElementId, setSelectedElementId] = useState<string | null>(
+    null,
+  );
   const [selectedColumnId, setSelectedColumnId] = useState<string | null>(null);
   const [selectedBoardId, setSelectedBoardId] = useState<string | null>(null);
 
@@ -57,7 +69,9 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     setSelectedElementId(null);
     setSelectedColumnId(null);
   };
-  const [saveTarget, setSaveTarget] = useState<'element' | 'column' | 'row' | null>(null);
+  const [saveTarget, setSaveTarget] = useState<
+    "element" | "column" | "row" | null
+  >(null);
 
   const [createStyle] = useMutation(CREATE_STYLE);
 
@@ -67,7 +81,7 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
       variables: { collectionId: String(collectionId) },
       skip: collectionId === null,
       fetchPolicy: "network-only",
-    }
+    },
   );
 
   useEffect(() => {
@@ -76,15 +90,17 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     }
   }, [collectionId, paletteId, refetchPalettes]);
 
-  const colorPalettes = (paletteData?.getAllColorPalette || []).map((p: any) => ({
-    id: Number(p.id),
-    name: p.name,
-    colors: p.colors,
-  }));
+  const colorPalettes = (paletteData?.getAllColorPalette || []).map(
+    (p: any) => ({
+      id: Number(p.id),
+      name: p.name,
+      colors: p.colors,
+    }),
+  );
 
   const handleChange = (
     map: ColumnMap<SlideElementDnDItemProps>,
-    b: BoardRow[]
+    b: BoardRow[],
   ) => {
     setColumnMap(map);
     setBoards(b);
@@ -100,7 +116,11 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           if (idx !== -1) {
             newMap[colId] = {
               ...col,
-              items: [...col.items.slice(0, idx), updated, ...col.items.slice(idx + 1)],
+              items: [
+                ...col.items.slice(0, idx),
+                updated,
+                ...col.items.slice(idx + 1),
+              ],
             };
             return newMap;
           }
@@ -155,10 +175,7 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           if (idx !== -1) {
             newMap[colId] = {
               ...col,
-              items: [
-                ...col.items.slice(0, idx),
-                ...col.items.slice(idx + 1),
-              ],
+              items: [...col.items.slice(0, idx), ...col.items.slice(idx + 1)],
             };
             return newMap;
           }
@@ -191,7 +208,7 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           ...b,
           orderedColumnIds: b.orderedColumnIds.filter((cid) => cid !== id),
         }))
-        .filter((b) => b.orderedColumnIds.length > 0)
+        .filter((b) => b.orderedColumnIds.length > 0),
     );
     if (selectedColumnId === id) {
       setSelectedColumnId(null);
@@ -265,8 +282,9 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
         {
           id: boardId,
           orderedColumnIds: [columnId],
-          wrapperStyles:
-            boardConfig?.wrapperStyles ?? { ...defaultBoardWrapperStyles },
+          wrapperStyles: boardConfig?.wrapperStyles ?? {
+            ...defaultBoardWrapperStyles,
+          },
           spacing: boardConfig?.spacing ?? 0,
         },
       ]);
@@ -301,8 +319,8 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
         prev.map((b) =>
           b.id === boardId
             ? { ...b, orderedColumnIds: [...b.orderedColumnIds, columnId] }
-            : b
-        )
+            : b,
+        ),
       );
       return;
     }
@@ -311,11 +329,14 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     const dropColumnId = columnEl?.dataset.columnId;
     setColumnMap((prev) => {
       const firstColumn = boards[0].orderedColumnIds[0];
-      const columnId = dropColumnId && prev[dropColumnId] ? dropColumnId : firstColumn;
+      const columnId =
+        dropColumnId && prev[dropColumnId] ? dropColumnId : firstColumn;
       const column = prev[columnId];
       let insertIndex = column.items.length;
       if (columnEl) {
-        const cards = Array.from(columnEl.querySelectorAll("[data-card-id]")) as HTMLElement[];
+        const cards = Array.from(
+          columnEl.querySelectorAll("[data-card-id]"),
+        ) as HTMLElement[];
         for (let i = 0; i < cards.length; i++) {
           const rect = cards[i].getBoundingClientRect();
           if (e.clientY < rect.top + rect.height / 2) {
@@ -325,7 +346,7 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
         }
       }
       const newEl: SlideElementDnDItemProps = config
-        ? { ...config, id: crypto.randomUUID() }
+        ? { ...config, id: crypto.randomUUID(), styleId: config.styleId }
         : {
             id: crypto.randomUUID(),
             type,
@@ -342,32 +363,32 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
                   },
                 }
               : type === "image"
-              ? { src: "https://via.placeholder.com/150" }
-              : type === "video"
-              ? { url: "" }
-              : type === "quiz"
-              ? { title: "Untitled Quiz", description: "", questions: [] }
-              : type === "table"
-              ? {
-                  table: {
-                    rows: 2,
-                    cols: 2,
-                    cells: Array.from({ length: 2 }, () =>
-                      Array.from({ length: 2 }, () => ({
-                        text: "Cell",
-                        styles: {
-                          color: "#000000",
-                          fontSize: "14px",
-                          fontFamily: availableFonts[0].fontFamily,
-                          fontWeight: "normal",
-                          lineHeight: "1.2",
-                          textAlign: "left",
-                        },
-                      }))
-                    ),
-                  },
-                }
-              : {}),
+                ? { src: "https://via.placeholder.com/150" }
+                : type === "video"
+                  ? { url: "" }
+                  : type === "quiz"
+                    ? { title: "Untitled Quiz", description: "", questions: [] }
+                    : type === "table"
+                      ? {
+                          table: {
+                            rows: 2,
+                            cols: 2,
+                            cells: Array.from({ length: 2 }, () =>
+                              Array.from({ length: 2 }, () => ({
+                                text: "Cell",
+                                styles: {
+                                  color: "#000000",
+                                  fontSize: "14px",
+                                  fontFamily: availableFonts[0].fontFamily,
+                                  fontWeight: "normal",
+                                  lineHeight: "1.2",
+                                  textAlign: "left",
+                                },
+                              })),
+                            ),
+                          },
+                        }
+                      : {}),
             wrapperStyles: { ...defaultColumnWrapperStyles },
             animation: undefined,
           };
@@ -399,7 +420,9 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     if (!column) return;
     let insertIndex = column.items.length;
     if (columnEl) {
-      const cards = Array.from(columnEl.querySelectorAll("[data-card-id]")) as HTMLElement[];
+      const cards = Array.from(
+        columnEl.querySelectorAll("[data-card-id]"),
+      ) as HTMLElement[];
       for (let i = 0; i < cards.length; i++) {
         const rect = cards[i].getBoundingClientRect();
         if (e.clientY < rect.top + rect.height / 2) {
@@ -423,24 +446,34 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
     return null;
   })();
 
-  const selectedColumn = selectedColumnId ? columnMap[selectedColumnId] || null : null;
-  const selectedBoard = selectedBoardId ? boards.find((b) => b.id === selectedBoardId) || null : null;
+  const selectedColumn = selectedColumnId
+    ? columnMap[selectedColumnId] || null
+    : null;
+  const selectedBoard = selectedBoardId
+    ? boards.find((b) => b.id === selectedBoardId) || null
+    : null;
 
-  const handleSave = async ({ name, groupId }: { name: string; groupId: number | null }) => {
+  const handleSave = async ({
+    name,
+    groupId,
+  }: {
+    name: string;
+    groupId: number | null;
+  }) => {
     if (collectionId === null || !saveTarget) return;
     let elementType: string;
     let config: any;
-    if (saveTarget === 'element') {
+    if (saveTarget === "element") {
       if (!selectedElement) return;
       elementType = selectedElement.type;
       config = selectedElement;
-    } else if (saveTarget === 'column') {
+    } else if (saveTarget === "column") {
       if (!selectedColumn) return;
-      elementType = 'column';
+      elementType = "column";
       config = selectedColumn;
     } else {
       if (!selectedBoard) return;
-      elementType = 'row';
+      elementType = "row";
       config = selectedBoard;
     }
 
@@ -508,9 +541,7 @@ export default function ThemeCanvas({ collectionId, paletteId }: ThemeCanvasProp
           onClose={() => setSaveTarget(null)}
           collectionId={collectionId}
           elementType={
-            saveTarget === 'element'
-              ? selectedElement?.type || ''
-              : saveTarget
+            saveTarget === "element" ? selectedElement?.type || "" : saveTarget
           }
           onSave={handleSave}
         />

--- a/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
+++ b/insight-fe/src/components/DnD/cards/SlideElementDnDCard.tsx
@@ -26,6 +26,10 @@ export interface SlideElementDnDItemProps {
   id: string;
   type: string;
   /**
+   * ID of the style this element uses
+   */
+  styleId?: number;
+  /**
    * Text content for text elements
    */
   text?: string;
@@ -101,14 +105,14 @@ export const SlideElementDnDItem = ({
             item.animation.direction === "left"
               ? -50
               : item.animation.direction === "right"
-              ? 50
-              : 0,
+                ? 50
+                : 0,
           y:
             item.animation.direction === "top"
               ? -50
               : item.animation.direction === "bottom"
-              ? 50
-              : 0,
+                ? 50
+                : 0,
         },
         animate: { opacity: 1, x: 0, y: 0 },
         transition: { delay: item.animation.delay / 1000 },


### PR DESCRIPTION
## Summary
- allow `SlideElementDnDItemProps` to hold a `styleId`
- include `styleId` when providing styled elements
- keep `styleId` when dropping styled elements onto canvases
- enable saving lessons from the lesson builder page using `createLesson`
- strip style configs before saving lesson content

## Testing
- `npm test` *(fails: no output due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_684ea15781ec83268ab4800ec293aa0b