### PR TITLE
Implement Save Lesson modal

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -9,6 +9,7 @@ import { AvailableElements } from "./components/AvailableElements";
 import StyledElementsPalette from "./components/StyledElementsPalette";
 import SlideCanvas from "./components/SlideCanvas";
 import SlideManager from "./components/SlideManager";
+import SaveLessonModal from "./components/SaveLessonModal";
 import {
   Slide,
   createInitialBoard,
@@ -38,6 +39,7 @@ export const LessonBuilderPageClient = () => {
   const [selectedSlideId, setSelectedSlideId] = useState<string>(slides[0].id);
 
   const [createLesson] = useMutation(CREATE_LESSON);
+  const [isSaveOpen, setIsSaveOpen] = useState(false);
 
   const prepareContent = () => {
     return {
@@ -56,13 +58,25 @@ export const LessonBuilderPageClient = () => {
     };
   };
 
-  const handleSave = async () => {
+  const handleSave = async ({
+    name,
+    subjectId,
+    topicId,
+  }: {
+    name: string;
+    subjectId: string;
+    topicId: string;
+  }) => {
     await createLesson({
       variables: {
         data: {
-          title: "Untitled Lesson",
+          title: name,
           themeId: selectedThemeId,
           content: prepareContent(),
+          relationIds: [
+            { relation: "subject", ids: [Number(subjectId)] },
+            { relation: "topic", ids: [Number(topicId)] },
+          ],
         },
       },
     });
@@ -127,9 +141,17 @@ export const LessonBuilderPageClient = () => {
           }
         />
       )}
-      <Button onClick={handleSave} colorScheme="teal" alignSelf="flex-start">
+      <Button onClick={() => setIsSaveOpen(true)} colorScheme="teal" alignSelf="flex-start">
         Save Lesson
       </Button>
+      <SaveLessonModal
+        isOpen={isSaveOpen}
+        onClose={() => setIsSaveOpen(false)}
+        onSave={(data) => {
+          handleSave(data);
+          setIsSaveOpen(false);
+        }}
+      />
     </VStack>
   );
 };

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/SaveLessonModal.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/SaveLessonModal.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Button, Stack, FormControl, FormLabel, Input } from "@chakra-ui/react";
+import { BaseModal } from "@/components/modals/BaseModal";
+import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
+import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
+import TopicDropdown from "@/components/dropdowns/TopicDropdown";
+
+interface SaveLessonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (data: { name: string; yearGroupId: string; subjectId: string; topicId: string }) => void;
+}
+
+export default function SaveLessonModal({ isOpen, onClose, onSave }: SaveLessonModalProps) {
+  const [name, setName] = useState("");
+  const [yearGroupId, setYearGroupId] = useState<string | null>(null);
+  const [subjectId, setSubjectId] = useState<string | null>(null);
+  const [topicId, setTopicId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      setName("");
+      setYearGroupId(null);
+      setSubjectId(null);
+      setTopicId(null);
+    }
+  }, [isOpen]);
+
+  const isValid = !!name && !!yearGroupId && !!subjectId && !!topicId;
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} title="Save Lesson">
+      <Stack spacing={4}>
+        <FormControl>
+          <FormLabel>Lesson Name</FormLabel>
+          <Input value={name} onChange={(e) => setName(e.target.value)} />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Year Group</FormLabel>
+          <YearGroupDropdown
+            value={yearGroupId}
+            onChange={(id) => {
+              setYearGroupId(id);
+              setSubjectId(null);
+              setTopicId(null);
+            }}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Subject</FormLabel>
+          <SubjectDropdown
+            yearGroupId={yearGroupId}
+            value={subjectId}
+            onChange={(id) => {
+              setSubjectId(id);
+              setTopicId(null);
+            }}
+          />
+        </FormControl>
+        <FormControl>
+          <FormLabel>Topic</FormLabel>
+          <TopicDropdown
+            yearGroupId={yearGroupId}
+            subjectId={subjectId}
+            value={topicId}
+            onChange={setTopicId}
+          />
+        </FormControl>
+        <Button
+          colorScheme="blue"
+          isDisabled={!isValid}
+          onClick={() => {
+            if (yearGroupId && subjectId && topicId) {
+              onSave({ name, yearGroupId, subjectId, topicId });
+            }
+          }}
+        >
+          Save
+        </Button>
+      </Stack>
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- add SaveLessonModal component with year, subject, topic fields
- integrate modal into LessonBuilderPageClient and connect to the existing create lesson mutation

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ea67639d08326a1f4879aa1f226ea