### PR TITLE
Fix lesson load mutation var type

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -88,7 +88,7 @@ export const LessonBuilderPageClient = () => {
 
   const handleLoad = async (lessonId: string) => {
     const { data } = await loadLessonQuery({
-      variables: { data: { id: lessonId } },
+      variables: { data: { id: Number(lessonId) } },
     });
     if (!data?.getLesson) return;
     const lesson = data.getLesson as any;


### PR DESCRIPTION
## Summary
- fix integer type for lesson ID when loading a saved lesson

## Testing
- `npm test --prefix insight-fe` *(fails: jest not found)*
- `npm run lint --prefix insight-fe` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684eb57306e88326b711a6b9094f15e9