### PR TITLE
Implement lesson style hydration

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.module.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.module.ts
@@ -3,9 +3,15 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { LessonService } from './lesson.service';
 import { LessonResolver } from './lesson.resolver';
 import { LessonEntity } from './lesson.entity';
+import { StyleModule } from '../style/style.module';
+import { ThemeModule } from '../theme/theme.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([LessonEntity])],
+  imports: [
+    TypeOrmModule.forFeature([LessonEntity]),
+    StyleModule,
+    ThemeModule,
+  ],
   providers: [LessonService, LessonResolver],
   exports: [LessonService],
 })

--- a/insight-be/src/modules/timbuktu/administrative/lesson/lesson.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/lesson/lesson.service.ts
@@ -4,6 +4,8 @@ import { DataSource, Repository } from 'typeorm';
 import { BaseService } from 'src/common/base.service';
 import { LessonEntity } from './lesson.entity';
 import { CreateLessonInput, UpdateLessonInput } from './lesson.inputs';
+import { StyleService } from '../style/style.service';
+import { ThemeService } from '../theme/theme.service';
 
 @Injectable()
 export class LessonService extends BaseService<
@@ -15,7 +17,54 @@ export class LessonService extends BaseService<
     @InjectRepository(LessonEntity)
     lessonRepository: Repository<LessonEntity>,
     @InjectDataSource() dataSource: DataSource,
+    private readonly styleService: StyleService,
+    private readonly themeService: ThemeService,
   ) {
     super(lessonRepository, dataSource);
+  }
+
+  async findOne(id: number, relations?: string[]): Promise<LessonEntity> {
+    const lesson = await super.findOne(id, relations);
+
+    if (lesson.themeId && lesson.content?.slides) {
+      const styleIds = new Set<number>();
+      for (const slide of lesson.content.slides as any[]) {
+        const columnMap = slide.columnMap ?? {};
+        for (const col of Object.values(columnMap) as any[]) {
+          if (Array.isArray(col.items)) {
+            for (const item of col.items) {
+              if (item.styleId) {
+                styleIds.add(Number(item.styleId));
+              }
+            }
+          }
+        }
+      }
+
+      if (styleIds.size) {
+        const styles = await this.styleService.findByIds(Array.from(styleIds));
+        for (const slide of lesson.content.slides as any[]) {
+          const columnMap = slide.columnMap ?? {};
+          for (const col of Object.values(columnMap) as any[]) {
+            if (Array.isArray(col.items)) {
+              col.items = col.items.map((item: any) => {
+                const style = styles.find((s) => s.id === item.styleId);
+                if (style) {
+                  const cfg = style.config as any;
+                  return {
+                    ...item,
+                    styles: cfg.styles,
+                    wrapperStyles: cfg.wrapperStyles,
+                  };
+                }
+                return item;
+              });
+            }
+          }
+        }
+      }
+    }
+
+    return lesson;
   }
 }

--- a/insight-be/src/modules/timbuktu/administrative/style/style.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style/style.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
-import { DataSource, Repository } from 'typeorm';
+import { DataSource, Repository, In } from 'typeorm';
 import { BaseService } from 'src/common/base.service';
 import { StyleEntity } from './style.entity';
 import { CreateStyleInput, UpdateStyleInput } from './style.inputs';
@@ -36,5 +36,10 @@ export class StyleService extends BaseService<
       ...(groupId ? [{ relation: 'group', ids: [groupId] }] : []),
     ];
     return super.update({ ...rest, relationIds: relations } as any);
+  }
+
+  async findByIds(ids: number[]): Promise<StyleEntity[]> {
+    if (!ids?.length) return [];
+    return this.repo.find({ where: { id: In(ids) } });
   }
 }


### PR DESCRIPTION
## Summary
- add `findByIds` method on `StyleService`
- allow `LessonModule` to inject `StyleService` and `ThemeService`
- hydrate lesson content with styles when fetching a lesson

## Testing
- `npm --prefix insight-be run lint` *(fails: Cannot find package '@eslint/js')*
- `npm --prefix insight-be test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebe50a9748326bfdc9d045c74f627