### PR TITLE
Add lesson viewer with slide navigation

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/students/lesson-viewer/LessonViewerPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/students/lesson-viewer/LessonViewerPageClient.tsx
@@ -1,12 +1,68 @@
-import { VStack } from "@chakra-ui/react";
-import { HStack } from "@chakra-ui/react";
-import { Text } from "@chakra-ui/react";
+"use client";
+
+import { VStack, HStack, Button, Text, Spinner } from "@chakra-ui/react";
+import { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
+import { useQuery } from "@apollo/client";
+import { GET_LESSON } from "@/graphql/lesson";
+import { Slide } from "@/components/lesson/slide/SlideSequencer";
+import { SlideRenderer } from "@/components/lesson/viewer";
 
 export const LessonViewerPageClient = () => {
+  const searchParams = useSearchParams();
+  const lessonId = searchParams.get("lessonId") || searchParams.get("id");
+
+  const { data, loading } = useQuery(GET_LESSON, {
+    skip: !lessonId,
+    variables: lessonId ? { data: { id: Number(lessonId) } } : undefined,
+  });
+
+  const slides: Slide[] = (data?.getLesson?.content?.slides ?? []) as Slide[];
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    if (slides.length) {
+      setIndex(0);
+    }
+  }, [slides]);
+
+  const prevSlide = () => setIndex((i) => Math.max(i - 1, 0));
+  const nextSlide = () => setIndex((i) => Math.min(i + 1, slides.length - 1));
+
+  if (!lessonId) {
+    return <Text>No lesson selected.</Text>;
+  }
+
+  if (loading) {
+    return (
+      <HStack w="100%" justify="center" mt={8}>
+        <Spinner />
+      </HStack>
+    );
+  }
+
+  const currentSlide = slides[index];
+
   return (
-    <VStack>
-      <HStack>
-        <Text>Lesson Viewer</Text>
+    <VStack w="100%" spacing={6} align="stretch">
+      <Text fontSize="xl" fontWeight="bold">
+        {data?.getLesson?.title || "Lesson"}
+      </Text>
+      {currentSlide ? (
+        <SlideRenderer slide={currentSlide} />
+      ) : (
+        <Text>No slides in this lesson.</Text>
+      )}
+      <HStack justify="space-between">
+        <Button onClick={prevSlide} isDisabled={index === 0}>
+          Previous
+        </Button>
+        <Text>
+          {slides.length > 0 ? index + 1 : 0} / {slides.length}
+        </Text>
+        <Button onClick={nextSlide} isDisabled={index + 1 >= slides.length}>
+          Next
+        </Button>
       </HStack>
     </VStack>
   );

--- a/insight-fe/src/components/lesson/viewer/SlideRenderer.tsx
+++ b/insight-fe/src/components/lesson/viewer/SlideRenderer.tsx
@@ -1,0 +1,34 @@
+import { VStack, HStack } from "@chakra-ui/react";
+import { Slide } from "@/components/lesson/slide/SlideSequencer";
+import { SlideElementDnDItem } from "@/components/DnD/cards/SlideElementDnDCard";
+
+interface SlideRendererProps {
+  slide: Slide;
+}
+
+export default function SlideRenderer({ slide }: SlideRendererProps) {
+  return (
+    <VStack spacing={4} w="100%" align="stretch">
+      {slide.boards.map((board) => (
+        <HStack key={board.id} spacing={board.spacing ?? 4} w="100%" align="start">
+          {board.orderedColumnIds.map((cid) => {
+            const column = slide.columnMap[cid];
+            if (!column) return null;
+            return (
+              <VStack
+                key={cid}
+                spacing={column.spacing ?? 2}
+                w="100%"
+                align="stretch"
+              >
+                {column.items.map((item) => (
+                  <SlideElementDnDItem key={item.id} item={item} />
+                ))}
+              </VStack>
+            );
+          })}
+        </HStack>
+      ))}
+    </VStack>
+  );
+}

--- a/insight-fe/src/components/lesson/viewer/index.ts
+++ b/insight-fe/src/components/lesson/viewer/index.ts
@@ -1,0 +1,1 @@
+export { default as SlideRenderer } from "./SlideRenderer";


### PR DESCRIPTION
## Summary
- implement `SlideRenderer` component to render slide boards and columns
- create lesson viewer page to load a lesson and navigate between slides

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa23d3334832695d49c6b3e3755cd