### PR TITLE
Add lesson preview modal

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -11,6 +11,7 @@ import SlideCanvas from "./components/SlideCanvas";
 import SlideManager from "./components/SlideManager";
 import SaveLessonModal from "./components/SaveLessonModal";
 import LoadLessonModal from "./components/LoadLessonModal";
+import PreviewLessonModal from "./components/PreviewLessonModal";
 import {
   Slide,
   createInitialBoard,
@@ -42,6 +43,7 @@ export const LessonBuilderPageClient = () => {
   const [createLesson] = useMutation(CREATE_LESSON);
   const [isSaveOpen, setIsSaveOpen] = useState(false);
   const [isLoadOpen, setIsLoadOpen] = useState(false);
+  const [isPreviewOpen, setIsPreviewOpen] = useState(false);
   const [loadLessonQuery] = useLazyQuery(GET_LESSON);
   const [getTheme] = useLazyQuery(GET_THEME);
 
@@ -175,6 +177,9 @@ export const LessonBuilderPageClient = () => {
       <Button onClick={() => setIsSaveOpen(true)} colorScheme="teal" alignSelf="flex-start">
         Save Lesson
       </Button>
+      <Button onClick={() => setIsPreviewOpen(true)} colorScheme="teal" alignSelf="flex-start">
+        Preview Lesson
+      </Button>
       <SaveLessonModal
         isOpen={isSaveOpen}
         onClose={() => setIsSaveOpen(false)}
@@ -190,6 +195,11 @@ export const LessonBuilderPageClient = () => {
           handleLoad(id);
           setIsLoadOpen(false);
         }}
+      />
+      <PreviewLessonModal
+        isOpen={isPreviewOpen}
+        onClose={() => setIsPreviewOpen(false)}
+        slides={slides}
       />
     </VStack>
   );

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/PreviewLessonModal.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/PreviewLessonModal.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { BaseModal } from "@/components/modals/BaseModal";
+import { LessonViewer } from "@/components/lesson/viewer";
+import { Slide } from "@/components/lesson/slide/SlideSequencer";
+
+interface PreviewLessonModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  slides: Slide[];
+  title?: string;
+}
+
+export default function PreviewLessonModal({
+  isOpen,
+  onClose,
+  slides,
+  title,
+}: PreviewLessonModalProps) {
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} size="full" title="Lesson Preview">
+      <LessonViewer slides={slides} title={title} />
+    </BaseModal>
+  );
+}

--- a/insight-fe/src/app/(main)/(protected)/students/lesson-viewer/LessonViewerPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/students/lesson-viewer/LessonViewerPageClient.tsx
@@ -1,12 +1,11 @@
 "use client";
 
-import { VStack, HStack, Button, Text, Spinner } from "@chakra-ui/react";
-import { useState, useEffect } from "react";
+import { HStack, Text, Spinner } from "@chakra-ui/react";
 import { useSearchParams } from "next/navigation";
 import { useQuery } from "@apollo/client";
 import { GET_LESSON } from "@/graphql/lesson";
 import { Slide } from "@/components/lesson/slide/SlideSequencer";
-import { SlideRenderer } from "@/components/lesson/viewer";
+import { LessonViewer } from "@/components/lesson/viewer";
 
 export const LessonViewerPageClient = () => {
   const searchParams = useSearchParams();
@@ -18,16 +17,6 @@ export const LessonViewerPageClient = () => {
   });
 
   const slides: Slide[] = (data?.getLesson?.content?.slides ?? []) as Slide[];
-  const [index, setIndex] = useState(0);
-
-  useEffect(() => {
-    if (slides.length) {
-      setIndex(0);
-    }
-  }, [slides]);
-
-  const prevSlide = () => setIndex((i) => Math.max(i - 1, 0));
-  const nextSlide = () => setIndex((i) => Math.min(i + 1, slides.length - 1));
 
   if (!lessonId) {
     return <Text>No lesson selected.</Text>;
@@ -41,29 +30,7 @@ export const LessonViewerPageClient = () => {
     );
   }
 
-  const currentSlide = slides[index];
-
   return (
-    <VStack w="100%" spacing={6} align="stretch">
-      <Text fontSize="xl" fontWeight="bold">
-        {data?.getLesson?.title || "Lesson"}
-      </Text>
-      {currentSlide ? (
-        <SlideRenderer slide={currentSlide} />
-      ) : (
-        <Text>No slides in this lesson.</Text>
-      )}
-      <HStack justify="space-between">
-        <Button onClick={prevSlide} isDisabled={index === 0}>
-          Previous
-        </Button>
-        <Text>
-          {slides.length > 0 ? index + 1 : 0} / {slides.length}
-        </Text>
-        <Button onClick={nextSlide} isDisabled={index + 1 >= slides.length}>
-          Next
-        </Button>
-      </HStack>
-    </VStack>
+    <LessonViewer slides={slides} title={data?.getLesson?.title || "Lesson"} />
   );
 };

--- a/insight-fe/src/components/lesson/viewer/LessonViewer.tsx
+++ b/insight-fe/src/components/lesson/viewer/LessonViewer.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { VStack, HStack, Button, Text } from "@chakra-ui/react";
+import { useEffect, useState } from "react";
+import { Slide } from "@/components/lesson/slide/SlideSequencer";
+import SlideRenderer from "./SlideRenderer";
+
+export interface LessonViewerProps {
+  slides: Slide[];
+  title?: string;
+}
+
+export const LessonViewer = ({ slides, title }: LessonViewerProps) => {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    setIndex(0);
+  }, [slides]);
+
+  const prevSlide = () => setIndex((i) => Math.max(i - 1, 0));
+  const nextSlide = () => setIndex((i) => Math.min(i + 1, slides.length - 1));
+
+  const currentSlide = slides[index];
+
+  return (
+    <VStack w="100%" spacing={6} align="stretch">
+      {title && (
+        <Text fontSize="xl" fontWeight="bold">
+          {title}
+        </Text>
+      )}
+      {currentSlide ? (
+        <SlideRenderer slide={currentSlide} />
+      ) : (
+        <Text>No slides in this lesson.</Text>
+      )}
+      <HStack justify="space-between">
+        <Button onClick={prevSlide} isDisabled={index === 0}>
+          Previous
+        </Button>
+        <Text>
+          {slides.length > 0 ? index + 1 : 0} / {slides.length}
+        </Text>
+        <Button onClick={nextSlide} isDisabled={index + 1 >= slides.length}>
+          Next
+        </Button>
+      </HStack>
+    </VStack>
+  );
+};
+
+export default LessonViewer;

--- a/insight-fe/src/components/lesson/viewer/index.ts
+++ b/insight-fe/src/components/lesson/viewer/index.ts
@@ -1,1 +1,2 @@
 export { default as SlideRenderer } from "./SlideRenderer";
+export { default as LessonViewer } from "./LessonViewer";


### PR DESCRIPTION
## Summary
- abstract viewer logic into a reusable `LessonViewer` component
- use the new component in `LessonViewerPageClient`
- add a fullscreen preview modal to the lesson builder

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fa616ecb88326a87dba8ef98927f0