### PR TITLE
Implement loaded theme updates

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/SaveThemeModal.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/SaveThemeModal.tsx
@@ -7,20 +7,22 @@ interface SaveThemeModalProps {
   isOpen: boolean;
   onClose: () => void;
   onSave: (name: string) => void;
+  initialName?: string;
 }
 
 export default function SaveThemeModal({
   isOpen,
   onClose,
   onSave,
+  initialName = "",
 }: SaveThemeModalProps) {
-  const [name, setName] = useState("");
+  const [name, setName] = useState(initialName);
 
   useEffect(() => {
     if (isOpen) {
-      setName("");
+      setName(initialName);
     }
-  }, [isOpen]);
+  }, [isOpen, initialName]);
 
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} title="Save Theme">


### PR DESCRIPTION
## Summary
- show the loaded theme name in the theme editor
- allow editing an existing theme
- support editing theme names in SaveThemeModal

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in insight-be *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb128ec6c8326ac24660e9c1140a3