### PR TITLE
Fix lesson builder update handling

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -73,25 +73,29 @@ export const LessonBuilderPageClient = () => {
     topicId,
   }: {
     name: string;
-    subjectId: string;
-    topicId: string;
+    subjectId?: string;
+    topicId?: string;
   }) => {
-    const variables = {
+    const base = {
       title: name,
       themeId: selectedThemeId,
       content: prepareContent(),
-      relationIds: [
-        { relation: "subject", ids: [Number(subjectId)] },
-        { relation: "topic", ids: [Number(topicId)] },
-      ],
     };
+
     if (lessonId) {
-      await updateLesson({
-        variables: { data: { id: lessonId, ...variables } },
-      });
+      await updateLesson({ variables: { data: { id: lessonId, ...base } } });
     } else {
+      if (!subjectId || !topicId) return;
       const { data } = await createLesson({
-        variables: { data: variables },
+        variables: {
+          data: {
+            ...base,
+            relationIds: [
+              { relation: "subject", ids: [Number(subjectId)] },
+              { relation: "topic", ids: [Number(topicId)] },
+            ],
+          },
+        },
       });
       if (data?.createLesson?.id) {
         setLessonId(Number(data.createLesson.id));
@@ -203,6 +207,7 @@ export const LessonBuilderPageClient = () => {
           setIsSaveOpen(false);
         }}
         initialName={lessonName ?? undefined}
+        isExisting={lessonId !== null}
       />
       <LoadLessonModal
         isOpen={isLoadOpen}

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/SaveLessonModal.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/SaveLessonModal.tsx
@@ -9,10 +9,16 @@ import TopicDropdown from "@/components/dropdowns/TopicDropdown";
 interface SaveLessonModalProps {
   isOpen: boolean;
   onClose: () => void;
-  onSave: (data: { name: string; yearGroupId: string; subjectId: string; topicId: string }) => void;
+  onSave: (data: {
+    name: string;
+    yearGroupId: string;
+    subjectId: string;
+    topicId: string;
+  }) => void;
+  initialName?: string;
 }
 
-export default function SaveLessonModal({ isOpen, onClose, onSave }: SaveLessonModalProps) {
+export default function SaveLessonModal({ isOpen, onClose, onSave, initialName }: SaveLessonModalProps) {
   const [name, setName] = useState("");
   const [yearGroupId, setYearGroupId] = useState<string | null>(null);
   const [subjectId, setSubjectId] = useState<string | null>(null);
@@ -20,12 +26,12 @@ export default function SaveLessonModal({ isOpen, onClose, onSave }: SaveLessonM
 
   useEffect(() => {
     if (isOpen) {
-      setName("");
+      setName(initialName ?? "");
       setYearGroupId(null);
       setSubjectId(null);
       setTopicId(null);
     }
-  }, [isOpen]);
+  }, [isOpen, initialName]);
 
   const isValid = !!name && !!yearGroupId && !!subjectId && !!topicId;
 

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/SaveLessonModal.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/SaveLessonModal.tsx
@@ -2,6 +2,7 @@
 import { useState, useEffect } from "react";
 import { Button, Stack, FormControl, FormLabel, Input } from "@chakra-ui/react";
 import { BaseModal } from "@/components/modals/BaseModal";
+import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 import YearGroupDropdown from "@/components/dropdowns/YearGroupDropdown";
 import SubjectDropdown from "@/components/dropdowns/SubjectDropdown";
 import TopicDropdown from "@/components/dropdowns/TopicDropdown";
@@ -11,29 +12,52 @@ interface SaveLessonModalProps {
   onClose: () => void;
   onSave: (data: {
     name: string;
-    yearGroupId: string;
-    subjectId: string;
-    topicId: string;
+    yearGroupId?: string;
+    subjectId?: string;
+    topicId?: string;
   }) => void;
   initialName?: string;
+  /**
+   * When true, the modal acts as a simple confirmation dialog
+   * for updating an existing lesson instead of collecting
+   * creation details.
+   */
+  isExisting?: boolean;
 }
 
-export default function SaveLessonModal({ isOpen, onClose, onSave, initialName }: SaveLessonModalProps) {
+export default function SaveLessonModal({
+  isOpen,
+  onClose,
+  onSave,
+  initialName,
+  isExisting = false,
+}: SaveLessonModalProps) {
   const [name, setName] = useState("");
   const [yearGroupId, setYearGroupId] = useState<string | null>(null);
   const [subjectId, setSubjectId] = useState<string | null>(null);
   const [topicId, setTopicId] = useState<string | null>(null);
 
   useEffect(() => {
-    if (isOpen) {
-      setName(initialName ?? "");
-      setYearGroupId(null);
-      setSubjectId(null);
-      setTopicId(null);
-    }
+    if (!isOpen) return;
+    setName(initialName ?? "");
+    setYearGroupId(null);
+    setSubjectId(null);
+    setTopicId(null);
   }, [isOpen, initialName]);
 
   const isValid = !!name && !!yearGroupId && !!subjectId && !!topicId;
+
+  if (isExisting) {
+    return (
+      <ConfirmationModal
+        isOpen={isOpen}
+        onClose={onClose}
+        action="update lesson"
+        bodyText="Are you sure you want to update this lesson?"
+        onConfirm={() => onSave({ name })}
+      />
+    );
+  }
 
   return (
     <BaseModal isOpen={isOpen} onClose={onClose} title="Save Lesson">

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -132,6 +132,14 @@ export const CREATE_LESSON = gql`
   }
 `;
 
+export const UPDATE_LESSON = gql`
+  mutation UpdateLesson($data: UpdateLessonInput!) {
+    updateLesson(data: $data) {
+      id
+    }
+  }
+`;
+
 export const GET_LESSON = gql`
   query GetLesson($data: IdInput!) {
     getLesson(data: $data) {


### PR DESCRIPTION
## Summary
- show current lesson title when loaded
- allow editing of existing lessons
- pre-fill Save Lesson modal name

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb15605e08326974cd6b0ff86c063