### PR TITLE
Simplify lesson style group selection

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/__tests__/StyleGroupManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/__tests__/StyleGroupManagement.test.tsx
@@ -1,23 +1,20 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import StyleGroupManagement from '../components/StyleGroupManagement';
-import { useQuery, useMutation } from '@apollo/client';
+import { useQuery } from '@apollo/client';
 
 jest.mock('@apollo/client');
 
 let dropdownProps: any = null;
-jest.mock('@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown', () => (props: any) => {
+jest.mock('@/components/dropdowns/SimpleDropdown', () => (props: any) => {
   dropdownProps = props;
-  return <select data-testid="crud" value={props.value} onChange={e => props.onChange(e)}></select>;
+  return <select data-testid="simple" value={props.value} onChange={e => props.onChange(e)}></select>;
 });
 
-jest.mock('@/components/lesson/modals/AddStyleGroupModal', () => () => <div data-testid="group-modal" />);
-jest.mock('@/components/modals/ConfirmationModal', () => () => <div data-testid="confirm-modal" />);
 
 describe('StyleGroupManagement', () => {
   beforeEach(() => {
     (useQuery as jest.Mock).mockReturnValue({ data: { getAllStyleGroup: [ { id: '1', name: 'Group 1' } ] }, refetch: jest.fn() });
-    (useMutation as jest.Mock).mockReturnValue([jest.fn(), { loading: false }]);
     dropdownProps = null;
   });
 
@@ -35,7 +32,7 @@ describe('StyleGroupManagement', () => {
         onSelectGroup={onSelect}
       />
     );
-    await userEvent.selectOptions(screen.getByTestId('crud'), ['1']);
+    await userEvent.selectOptions(screen.getByTestId('simple'), ['1']);
     expect(onSelect).toHaveBeenCalledWith(1);
   });
 });

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/StyleGroupManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/StyleGroupManagement.tsx
@@ -1,18 +1,13 @@
 "use client";
 
 import { Flex, Text } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
-import { useMutation, useQuery } from "@apollo/client";
+import { useEffect, useMemo, useState } from "react";
+import { useQuery } from "@apollo/client";
 
 import {
   GET_STYLE_GROUPS,
-  CREATE_STYLE_GROUP,
-  UPDATE_STYLE_GROUP,
-  DELETE_STYLE_GROUP,
 } from "@/graphql/lesson";
-import CrudDropdown from "@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown";
-import AddStyleGroupModal from "@/components/lesson/modals/AddStyleGroupModal";
-import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
+import SimpleDropdown from "@/components/dropdowns/SimpleDropdown";
 
 interface StyleGroupManagementProps {
   collectionId: number | null;
@@ -20,22 +15,13 @@ interface StyleGroupManagementProps {
   onSelectGroup?: (id: number | null) => void;
 }
 
-const ELEMENT_TYPE_TO_ENUM: Record<string, string> = {
-  text: "Text",
-  row: "Row",
-  column: "Column",
-  table: "Table",
-  image: "Image",
-  video: "Video",
-  quiz: "Quiz",
-};
 
 export default function StyleGroupManagement({
   collectionId,
   elementType,
   onSelectGroup,
 }: StyleGroupManagementProps) {
-  const { data, refetch } = useQuery(GET_STYLE_GROUPS, {
+  const { data, loading } = useQuery(GET_STYLE_GROUPS, {
     variables: {
       collectionId: String(collectionId),
       element: elementType as string,
@@ -44,15 +30,8 @@ export default function StyleGroupManagement({
     fetchPolicy: "network-only",
   });
 
-  const [createGroup] = useMutation(CREATE_STYLE_GROUP);
-  const [updateGroup] = useMutation(UPDATE_STYLE_GROUP);
-  const [deleteGroup, { loading: deleting }] = useMutation(DELETE_STYLE_GROUP);
-
   const [groups, setGroups] = useState<{ id: number; name: string }[]>([]);
   const [selectedId, setSelectedId] = useState<number | "">("");
-  const [isAddOpen, setIsAddOpen] = useState(false);
-  const [isEditOpen, setIsEditOpen] = useState(false);
-  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
 
   useEffect(() => {
     onSelectGroup?.(selectedId === "" ? null : selectedId);
@@ -75,14 +54,16 @@ export default function StyleGroupManagement({
     setSelectedId("");
   }, [collectionId, elementType]);
 
-  const selected = groups.find((g) => g.id === selectedId);
-  const options = groups.map((g) => ({ label: g.name, value: String(g.id) }));
+  const options = useMemo(
+    () => groups.map((g) => ({ label: g.name, value: String(g.id) })),
+    [groups]
+  );
   const isDisabled = collectionId === null || !elementType;
 
   return (
     <Flex flex={1} p={4} w="100%" direction="column" align="start">
       <Text fontSize="sm" mb={2}>Style Groups</Text>
-      <CrudDropdown
+      <SimpleDropdown
         options={options}
         value={selectedId}
         onChange={(e) =>
@@ -90,81 +71,8 @@ export default function StyleGroupManagement({
             e.target.value === "" ? "" : parseInt(e.target.value, 10)
           )
         }
-        onCreate={() => setIsAddOpen(true)}
-        onUpdate={() => setIsEditOpen(true)}
-        onDelete={() => setIsDeleteOpen(true)}
-        isUpdateDisabled={selectedId === ""}
-        isDeleteDisabled={selectedId === ""}
-        isCreateDisabled={isDisabled}
         isDisabled={isDisabled}
-      />
-
-      <AddStyleGroupModal
-        isOpen={isAddOpen}
-        onClose={() => setIsAddOpen(false)}
-        onSave={async (name) => {
-          if (collectionId === null || !elementType) return;
-          const { data: res } = await createGroup({
-            variables: {
-              data: {
-                name,
-                collectionId,
-                element: ELEMENT_TYPE_TO_ENUM[elementType],
-              },
-            },
-          });
-          const created = res?.createStyleGroup;
-          if (created) {
-            const group = { id: Number(created.id), name: created.name };
-            setGroups((gs) => [...gs, group]);
-            setSelectedId(group.id);
-            refetch();
-          }
-        }}
-      />
-
-      <AddStyleGroupModal
-        isOpen={isEditOpen}
-        onClose={() => setIsEditOpen(false)}
-        title="Update Style Group"
-        confirmLabel="Update"
-        initialName={selected?.name ?? ""}
-        onSave={async (name) => {
-          if (selectedId === "" || collectionId === null || !elementType) return;
-          const { data: res } = await updateGroup({
-            variables: {
-              data: {
-                id: selectedId,
-                name,
-                collectionId,
-                element: ELEMENT_TYPE_TO_ENUM[elementType],
-              },
-            },
-          });
-          const updated = res?.updateStyleGroup;
-          if (updated) {
-            setGroups((gs) =>
-              gs.map((g) => (g.id === selectedId ? { id: g.id, name: updated.name } : g))
-            );
-            refetch();
-          }
-        }}
-      />
-
-      <ConfirmationModal
-        isOpen={isDeleteOpen}
-        onClose={() => setIsDeleteOpen(false)}
-        action="delete group"
-        bodyText="Are you sure you want to delete this group?"
-        onConfirm={async () => {
-          if (selectedId === "") return;
-          await deleteGroup({ variables: { data: { id: selectedId } } });
-          setGroups((gs) => gs.filter((g) => g.id !== selectedId));
-          setSelectedId("");
-          setIsDeleteOpen(false);
-          refetch();
-        }}
-        isLoading={deleting}
+        isLoading={loading}
       />
     </Flex>
   );


### PR DESCRIPTION
## Summary
- replace CRUD dropdown with simple dropdown when choosing style groups in lesson builder
- update tests for the lesson style group selector

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fb1ed6f3883268a1b529dd7dfbce1