### PR TITLE
Fix circular relation between Theme and ColorPalette

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
@@ -26,13 +26,13 @@ export class ThemeEntity extends AbstractBaseEntity {
   @OneToMany(() => ColorPaletteEntity, (palette) => palette.theme)
   colorPalettes?: ColorPaletteEntity[];
 
-  @Field(() => ColorPaletteEntity)
-  @ManyToOne(() => ColorPaletteEntity, { nullable: false })
+  @Field(() => ColorPaletteEntity, { nullable: true })
+  @ManyToOne(() => ColorPaletteEntity, { nullable: true })
   @JoinColumn({ name: 'default_palette_id' })
-  defaultPalette!: ColorPaletteEntity;
+  defaultPalette?: ColorPaletteEntity;
 
-  @Field(() => ID)
-  @Column({ name: 'default_palette_id' })
+  @Field(() => ID, { nullable: true })
+  @Column({ name: 'default_palette_id', nullable: true })
   @RelationId((theme: ThemeEntity) => theme.defaultPalette)
-  defaultPaletteId!: number;
+  defaultPaletteId?: number;
 }


### PR DESCRIPTION
## Summary
- make ThemeEntity.defaultPalette nullable

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68511d9f024c83268903ebd246ad3ef1