### PR TITLE
Add theme builder start modal

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -8,6 +8,7 @@ import BaseElementsPalette from "./components/BaseElementsPalette";
 import ThemeCanvas from "./components/ThemeCanvas";
 import SaveThemeModal from "./components/SaveThemeModal";
 import LoadThemeModal, { ThemeInfo } from "./components/LoadThemeModal";
+import StartThemeModal from "./components/StartThemeModal";
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 import { useQuery, useMutation } from "@apollo/client";
 import { GET_ALL_THEMES, CREATE_THEME, UPDATE_THEME } from "@/graphql/lesson";
@@ -19,6 +20,8 @@ export const ThemeBuilderPageClient = () => {
   const [selectedPaletteId, setSelectedPaletteId] = useState<number | null>(
     null
   );
+  const [isStartOpen, setIsStartOpen] = useState(true);
+  const [showBuilder, setShowBuilder] = useState(false);
   const [isSaveThemeOpen, setIsSaveThemeOpen] = useState(false);
   const [isConfirmUpdateOpen, setIsConfirmUpdateOpen] = useState(false);
   const [isLoadThemeOpen, setIsLoadThemeOpen] = useState(false);
@@ -62,6 +65,7 @@ export const ThemeBuilderPageClient = () => {
         };
         setThemes((ts) => ts.map((t) => (t.id === theme.id ? theme : t)));
         setLoadedTheme(theme);
+        setShowBuilder(true);
       }
     } else {
       const { data } = await createTheme({
@@ -81,6 +85,7 @@ export const ThemeBuilderPageClient = () => {
         };
         setThemes((ts) => [...ts, theme]);
         setLoadedTheme(theme);
+        setShowBuilder(true);
       }
     }
   };
@@ -88,49 +93,57 @@ export const ThemeBuilderPageClient = () => {
   const handleLoadTheme = (theme: ThemeInfo) => {
     setSelectedPaletteId(theme.defaultPaletteId);
     setLoadedTheme(theme);
+    setShowBuilder(true);
   };
 
   return (
     <VStack w="100%">
-      <Heading size="md" data-testid="theme-name">
-        {loadedTheme ? loadedTheme.name : "New Theme"}
-      </Heading>
-      <HStack flex={1} w="100%" align="start">
-        <ColorPaletteManagement
-          collectionId={null}
-          onSelectPalette={setSelectedPaletteId}
-          selectedId={selectedPaletteId}
-        />
-      </HStack>
-      <HStack w="100%">
-        <AvailableElements
-          selectedType={selectedElementType}
-          onSelect={setSelectedElementType}
-        />
-      </HStack>
-      <HStack w="100%" align="start" pt={4} spacing={4}>
-        <Flex flex={1} width="50%" bg="blue.100" p={4}>
-          <BaseElementsPalette />
-        </Flex>
-        <Flex flex={1} width="50%" bg="green.100" p={4}>
-          <StyledElementsPalette
+      {showBuilder && (
+        <>
+          <Heading size="md" data-testid="theme-name">
+            {loadedTheme ? loadedTheme.name : "New Theme"}
+          </Heading>
+          <HStack flex={1} w="100%" align="start">
+            <ColorPaletteManagement
+              collectionId={null}
+              onSelectPalette={setSelectedPaletteId}
+              selectedId={selectedPaletteId}
+            />
+          </HStack>
+          <HStack w="100%">
+            <AvailableElements
+              selectedType={selectedElementType}
+              onSelect={setSelectedElementType}
+            />
+          </HStack>
+          <HStack w="100%" align="start" pt={4} spacing={4}>
+            <Flex flex={1} width="50%" bg="blue.100" p={4}>
+              <BaseElementsPalette />
+            </Flex>
+            <Flex flex={1} width="50%" bg="green.100" p={4}>
+              <StyledElementsPalette
+                themeId={loadedTheme ? loadedTheme.id : null}
+                elementType={selectedElementType}
+              />
+            </Flex>
+          </HStack>
+          <HStack w="100%" justify="flex-end" pt={2}>
+            <Button onClick={() => setIsLoadThemeOpen(true)}>Load Theme</Button>
+            <Button
+              colorScheme="blue"
+              onClick={() =>
+                loadedTheme ? setIsConfirmUpdateOpen(true) : setIsSaveThemeOpen(true)
+              }
+            >
+              Save Theme
+            </Button>
+          </HStack>
+          <ThemeCanvas
             themeId={loadedTheme ? loadedTheme.id : null}
-            elementType={selectedElementType}
+            paletteId={selectedPaletteId}
           />
-        </Flex>
-      </HStack>
-      <HStack w="100%" justify="flex-end" pt={2}>
-        <Button onClick={() => setIsLoadThemeOpen(true)}>Load Theme</Button>
-        <Button
-          colorScheme="blue"
-          onClick={() =>
-            loadedTheme ? setIsConfirmUpdateOpen(true) : setIsSaveThemeOpen(true)
-          }
-        >
-          Save Theme
-        </Button>
-      </HStack>
-      <ThemeCanvas themeId={loadedTheme ? loadedTheme.id : null} paletteId={selectedPaletteId} />
+        </>
+      )}
       <SaveThemeModal
         isOpen={isSaveThemeOpen}
         onClose={() => setIsSaveThemeOpen(false)}
@@ -158,6 +171,18 @@ export const ThemeBuilderPageClient = () => {
         onLoad={(theme) => {
           handleLoadTheme(theme);
           setIsLoadThemeOpen(false);
+        }}
+      />
+      <StartThemeModal
+        isOpen={isStartOpen}
+        onClose={() => setIsStartOpen(false)}
+        onCreate={() => {
+          setIsStartOpen(false);
+          setIsSaveThemeOpen(true);
+        }}
+        onLoad={() => {
+          setIsStartOpen(false);
+          setIsLoadThemeOpen(true);
         }}
       />
     </VStack>

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
@@ -65,6 +65,9 @@ describe('ThemeBuilderPageClient', () => {
 
   it('updates state based on child callbacks', async () => {
     render(<ThemeBuilderPageClient />);
+    await userEvent.click(screen.getByTestId('create-new'));
+    await userEvent.type(screen.getByRole('textbox'), 'Test');
+    await userEvent.click(screen.getByRole('button', { name: 'Save' }));
     expect(typeof paletteProps.onSelectPalette).toBe('function');
     await userEvent.click(screen.getByTestId('available'));
     expect(styledPaletteProps.items.length).toBeGreaterThan(0);
@@ -84,11 +87,8 @@ describe('ThemeBuilderPageClient', () => {
     });
 
     render(<ThemeBuilderPageClient />);
-    await userEvent.click(screen.getByText('Load Theme'));
-    await userEvent.selectOptions(
-      screen.getByLabelText('Select Theme'),
-      '1'
-    );
+    await userEvent.click(screen.getByTestId('modify-existing'));
+    await userEvent.selectOptions(screen.getByPlaceholderText('Select theme'), '1');
     await userEvent.click(screen.getByRole('button', { name: 'Load' }));
 
     expect(screen.getByTestId('theme-name')).toHaveTextContent('Loaded');
@@ -104,11 +104,8 @@ describe('ThemeBuilderPageClient', () => {
     });
 
     render(<ThemeBuilderPageClient />);
-    await userEvent.click(screen.getByText('Load Theme'));
-    await userEvent.selectOptions(
-      screen.getByLabelText('Select Theme'),
-      '1'
-    );
+    await userEvent.click(screen.getByTestId('modify-existing'));
+    await userEvent.selectOptions(screen.getByPlaceholderText('Select theme'), '1');
     await userEvent.click(screen.getByRole('button', { name: 'Load' }));
     await userEvent.click(screen.getByText('Save Theme'));
 

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StartThemeModal.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StartThemeModal.tsx
@@ -1,0 +1,30 @@
+"use client";
+import { Stack, Button } from "@chakra-ui/react";
+import { BaseModal } from "@/components/modals/BaseModal";
+
+interface StartThemeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onCreate: () => void;
+  onLoad: () => void;
+}
+
+export default function StartThemeModal({
+  isOpen,
+  onClose,
+  onCreate,
+  onLoad,
+}: StartThemeModalProps) {
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} title="Start Theme Builder">
+      <Stack spacing={4}>
+        <Button colorScheme="blue" onClick={onCreate} data-testid="create-new">
+          Create New Theme
+        </Button>
+        <Button onClick={onLoad} data-testid="modify-existing">
+          Modify Existing Theme
+        </Button>
+      </Stack>
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- add `StartThemeModal` component for choosing between a new or existing theme
- update `ThemeBuilderPageClient` to show new modal before the builder
- adjust tests for new workflow

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851230d12a08326b3f271e399304be5