### PR TITLE
Fix theme builder numeric IDs

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -35,7 +35,7 @@ export const ThemeBuilderPageClient = () => {
         themesData.getAllTheme.map((t: any) => ({
           id: Number(t.id),
           name: t.name,
-          defaultPaletteId: t.defaultPaletteId,
+          defaultPaletteId: Number(t.defaultPaletteId),
         }))
       );
     }
@@ -58,7 +58,7 @@ export const ThemeBuilderPageClient = () => {
         const theme = {
           id: Number(updated.id),
           name: updated.name,
-          defaultPaletteId: updated.defaultPaletteId,
+          defaultPaletteId: Number(updated.defaultPaletteId),
         };
         setThemes((ts) => ts.map((t) => (t.id === theme.id ? theme : t)));
         setLoadedTheme(theme);
@@ -77,7 +77,7 @@ export const ThemeBuilderPageClient = () => {
         const theme = {
           id: Number(created.id),
           name: created.name,
-          defaultPaletteId: created.defaultPaletteId,
+          defaultPaletteId: Number(created.defaultPaletteId),
         };
         setThemes((ts) => [...ts, theme]);
         setLoadedTheme(theme);
@@ -86,8 +86,8 @@ export const ThemeBuilderPageClient = () => {
   };
 
   const handleLoadTheme = (theme: ThemeInfo) => {
-    setSelectedPaletteId(theme.defaultPaletteId);
-    setLoadedTheme(theme);
+    setSelectedPaletteId(Number(theme.defaultPaletteId));
+    setLoadedTheme({ ...theme, defaultPaletteId: Number(theme.defaultPaletteId) });
   };
 
   return (


### PR DESCRIPTION
## Summary
- fix mapping of theme data to convert palette IDs to numbers
- ensure created/updated themes cast palette IDs to numbers
- load themes with numeric palette IDs

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in insight-be *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518ea21384832687d4281328f245d9