### PR TITLE
Add Theme Management CRUD dropdown

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -9,6 +9,7 @@ import BaseElementsPalette from "./components/BaseElementsPalette";
 import ThemeCanvas from "./components/ThemeCanvas";
 import SaveThemeModal from "./components/SaveThemeModal";
 import LoadThemeModal, { ThemeInfo } from "./components/LoadThemeModal";
+import ThemeManagement from "./components/ThemeManagement";
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 import { useQuery, useMutation } from "@apollo/client";
 import { GET_ALL_THEMES, CREATE_THEME, UPDATE_THEME } from "@/graphql/lesson";
@@ -114,6 +115,17 @@ export const ThemeBuilderPageClient = () => {
           collectionId={selectedCollectionId}
           onSelectPalette={setSelectedPaletteId}
           selectedId={selectedPaletteId}
+        />
+        <ThemeManagement
+          selectedId={loadedTheme?.id ?? null}
+          onSelectTheme={(id) => {
+            const theme = themes.find((t) => t.id === id);
+            if (theme) {
+              handleLoadTheme(theme);
+            } else {
+              setLoadedTheme(null);
+            }
+          }}
         />
       </HStack>
       <HStack w="100%">

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
@@ -11,6 +11,7 @@ let availableProps: any = null;
 let styledPaletteProps: any = null;
 let basePaletteProps: any = null;
 let canvasProps: any = null;
+let themeProps: any = null;
 
 jest.mock('../components/ThemeCanvas', () => (props: any) => {
   canvasProps = props;
@@ -29,6 +30,11 @@ jest.mock('../components/StyleCollectionManagement', () => (props: any) => {
 jest.mock('../components/ColorPaletteManagement', () => (props: any) => {
   paletteProps = props;
   return <div data-testid="palette" />;
+});
+
+jest.mock('../components/ThemeManagement', () => (props: any) => {
+  themeProps = props;
+  return <div data-testid="theme-mgmt" />;
 });
 
 jest.mock('@/components/modals/ConfirmationModal', () => (props: any) => {
@@ -67,6 +73,7 @@ describe('ThemeBuilderPageClient', () => {
     });
     collectionProps = null;
     paletteProps = null;
+    themeProps = null;
     availableProps = null;
     styledPaletteProps = null;
     basePaletteProps = null;

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeManagement.test.tsx
@@ -1,0 +1,27 @@
+import { render } from '@testing-library/react';
+import ThemeManagement from '../components/ThemeManagement';
+import { useQuery, useMutation } from '@apollo/client';
+
+jest.mock('@apollo/client');
+
+let dropdownProps: any = null;
+jest.mock('@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown', () => (props: any) => {
+  dropdownProps = props;
+  return <select data-testid="crud" value={props.value} onChange={e => props.onChange(e)}></select>;
+});
+
+jest.mock('@/components/lesson/modals/AddThemeModal', () => () => <div data-testid="theme-modal" />);
+jest.mock('@/components/modals/ConfirmationModal', () => () => <div data-testid="confirm-modal" />);
+
+describe('ThemeManagement', () => {
+  beforeEach(() => {
+    (useQuery as jest.Mock).mockReturnValue({ data: { getAllTheme: [ { id: '1', name: 'Theme 1' } ] }, refetch: jest.fn() });
+    (useMutation as jest.Mock).mockReturnValue([jest.fn(), { loading: false }]);
+    dropdownProps = null;
+  });
+
+  it('provides themes as options', () => {
+    render(<ThemeManagement />);
+    expect(dropdownProps.options).toEqual([{ label: 'Theme 1', value: '1' }]);
+  });
+});

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeManagement.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { Flex, Text } from "@chakra-ui/react";
+import { useState, useEffect } from "react";
+import { useQuery, useMutation } from "@apollo/client";
+
+import {
+  GET_ALL_THEMES,
+  CREATE_THEME,
+  UPDATE_THEME,
+  DELETE_THEME,
+} from "@/graphql/lesson";
+import CrudDropdown from "@/app/(main)/(protected)/administration/coordination-panel/_components/dropdowns/CrudDropdown";
+import AddThemeModal from "@/components/lesson/modals/AddThemeModal";
+import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
+
+interface ThemeManagementProps {
+  onSelectTheme?: (id: number | null) => void;
+  selectedId?: number | null;
+}
+
+export default function ThemeManagement({
+  onSelectTheme,
+  selectedId,
+}: ThemeManagementProps) {
+  const { data, refetch } = useQuery(GET_ALL_THEMES, {
+    fetchPolicy: "network-only",
+  });
+  const [createTheme] = useMutation(CREATE_THEME);
+  const [updateTheme] = useMutation(UPDATE_THEME);
+  const [deleteTheme, { loading: deleting }] = useMutation(DELETE_THEME);
+
+  const [themes, setThemes] = useState<{ id: number; name: string }[]>([]);
+  const [selectedState, setSelectedState] = useState<number | "">("");
+  const [isAddOpen, setIsAddOpen] = useState(false);
+  const [isEditOpen, setIsEditOpen] = useState(false);
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+
+  useEffect(() => {
+    if (selectedId !== undefined) {
+      setSelectedState(selectedId === null ? "" : selectedId);
+    }
+  }, [selectedId]);
+
+  useEffect(() => {
+    onSelectTheme?.(selectedState === "" ? null : selectedState);
+  }, [selectedState, onSelectTheme]);
+
+  useEffect(() => {
+    if (data?.getAllTheme) {
+      setThemes(
+        data.getAllTheme.map((t: any) => ({ id: Number(t.id), name: t.name }))
+      );
+    } else {
+      setThemes([]);
+    }
+  }, [data]);
+
+  const selected = themes.find((t) => t.id === selectedState);
+  const options = themes.map((t) => ({ label: t.name, value: String(t.id) }));
+
+  return (
+    <Flex flex={1} p={4} w="100%" direction="column" align="start">
+      <Text fontSize="sm" mb={2}>
+        Themes
+      </Text>
+      <CrudDropdown
+        options={options}
+        value={selectedState}
+        onChange={(e) =>
+          setSelectedState(
+            e.target.value === "" ? "" : parseInt(e.target.value, 10)
+          )
+        }
+        onCreate={() => setIsAddOpen(true)}
+        onUpdate={() => setIsEditOpen(true)}
+        onDelete={() => setIsDeleteOpen(true)}
+        isUpdateDisabled={selectedState === ""}
+        isDeleteDisabled={selectedState === ""}
+      />
+
+      <AddThemeModal
+        isOpen={isAddOpen}
+        onClose={() => setIsAddOpen(false)}
+        onSave={async (name) => {
+          const { data: res } = await createTheme({ variables: { data: { name } } });
+          const created = res?.createTheme;
+          if (created) {
+            const theme = { id: Number(created.id), name: created.name };
+            setThemes((ts) => [...ts, theme]);
+            setSelectedState(theme.id);
+            refetch();
+          }
+        }}
+      />
+
+      <AddThemeModal
+        isOpen={isEditOpen}
+        onClose={() => setIsEditOpen(false)}
+        title="Update Theme"
+        confirmLabel="Update"
+        initialName={selected?.name ?? ""}
+        onSave={async (name) => {
+          if (selectedState === "") return;
+          const { data: res } = await updateTheme({
+            variables: { data: { id: selectedState, name } },
+          });
+          const updated = res?.updateTheme;
+          if (updated) {
+            setThemes((ts) =>
+              ts.map((t) =>
+                t.id === selectedState ? { id: t.id, name: updated.name } : t
+              )
+            );
+            refetch();
+          }
+        }}
+      />
+
+      <ConfirmationModal
+        isOpen={isDeleteOpen}
+        onClose={() => setIsDeleteOpen(false)}
+        action="delete theme"
+        bodyText="Are you sure you want to delete this theme?"
+        onConfirm={async () => {
+          if (selectedState === "") return;
+          await deleteTheme({ variables: { data: { id: selectedState } } });
+          setThemes((ts) => ts.filter((t) => t.id !== selectedState));
+          setSelectedState("");
+          setIsDeleteOpen(false);
+          refetch();
+        }}
+        isLoading={deleting}
+      />
+    </Flex>
+  );
+}

--- a/insight-fe/src/components/lesson/modals/AddThemeModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddThemeModal.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from "react";
+import { Button, HStack, Input } from "@chakra-ui/react";
+import { BaseModal } from "@/components/modals/BaseModal";
+
+interface AddThemeModalProps {
+  isOpen: boolean;
+  onSave: (name: string) => void;
+  onClose: () => void;
+  /** Pre-populated theme name when editing */
+  initialName?: string;
+  /** Modal title */
+  title?: string;
+  /** Confirmation button label */
+  confirmLabel?: string;
+}
+
+export default function AddThemeModal({
+  isOpen,
+  onSave,
+  onClose,
+  initialName = "",
+  title = "Add Theme",
+  confirmLabel = "Save",
+}: AddThemeModalProps) {
+  const [name, setName] = useState(initialName);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setName(initialName);
+    }
+  }, [isOpen, initialName]);
+
+  return (
+    <BaseModal
+      isOpen={isOpen}
+      onClose={onClose}
+      title={title}
+      footer={
+        <HStack>
+          <Button
+            colorScheme="blue"
+            isLoading={loading}
+            onClick={async () => {
+              setLoading(true);
+              try {
+                await onSave(name);
+                if (initialName === "") {
+                  setName("");
+                }
+                onClose();
+              } finally {
+                setLoading(false);
+              }
+            }}
+          >
+            {confirmLabel}
+          </Button>
+          <Button onClick={onClose}>Cancel</Button>
+        </HStack>
+      }
+    >
+      <Input
+        placeholder="Theme name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+    </BaseModal>
+  );
+}


### PR DESCRIPTION
## Summary
- add `AddThemeModal` for theme name input
- add `ThemeManagement` component with CRUD dropdown
- include `ThemeManagement` in the theme builder client page
- test new management component

## Testing
- `npx jest` *(fails: 403 Forbidden to download jest)*

------
https://chatgpt.com/codex/tasks/task_e_6851ab616c9c832687ea6d0622c238d8