### PR TITLE
Fix theme creation in builder

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.entity.ts
@@ -32,9 +32,9 @@ export class ThemeEntity extends AbstractBaseEntity {
   @JoinColumn({ name: 'default_palette_id' })
   defaultPalette?: ColorPaletteEntity;
 
-  @Field(() => ID)
-  @Column({ name: 'default_palette_id' })
+  @Field(() => ID, { nullable: true })
+  @Column({ name: 'default_palette_id', nullable: true })
   @RelationId((theme: ThemeEntity) => theme.defaultPalette)
-  defaultPaletteId!: number;
+  defaultPaletteId?: number;
 
 }

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.inputs.ts
@@ -6,8 +6,8 @@ export class CreateThemeInput extends HasRelationsInput {
   @Field()
   name: string;
 
-  @Field(() => ID)
-  defaultPaletteId: number;
+  @Field(() => ID, { nullable: true })
+  defaultPaletteId?: number;
 
 }
 

--- a/insight-be/src/modules/timbuktu/administrative/theme/theme.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/theme/theme.service.ts
@@ -22,7 +22,9 @@ export class ThemeService extends BaseService<
     const { defaultPaletteId, relationIds = [], ...rest } = data;
     const relations = [
       ...relationIds,
-      { relation: 'defaultPalette', ids: [defaultPaletteId] },
+      ...(defaultPaletteId
+        ? [{ relation: 'defaultPalette', ids: [defaultPaletteId] }]
+        : []),
     ];
     return super.create({ ...rest, relationIds: relations } as any);
   }


### PR DESCRIPTION
## Summary
- make `defaultPaletteId` optional for themes on the backend
- update ThemeService creation logic to only set relation if an ID is provided

## Testing
- `npm test --prefix insight-fe` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b4f772948326bb80e201cefc2ea9