### PR TITLE
Replace theme dropdown with style collections

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -3,7 +3,7 @@ import { Flex, HStack, VStack, Button, Heading } from "@chakra-ui/react";
 import { useState } from "react";
 import { useMutation, useLazyQuery } from "@apollo/client";
 import { CREATE_LESSON, UPDATE_LESSON, GET_LESSON, GET_THEME } from "@/graphql/lesson";
-import ThemeDropdown from "@/components/dropdowns/ThemeDropdown";
+import StyleCollectionDropdown from "@/components/dropdowns/StyleCollectionDropdown";
 import { AvailableElements } from "./components/AvailableElements";
 import StyledElementsPalette from "./components/StyledElementsPalette";
 import SlideCanvas from "./components/SlideCanvas";
@@ -17,7 +17,6 @@ import {
 } from "@/components/lesson/slide/SlideSequencer";
 
 export const LessonBuilderPageClient = () => {
-  const [selectedThemeId, setSelectedThemeId] = useState<number | null>(null);
   const [selectedCollectionId, setSelectedCollectionId] = useState<
     number | null
   >(null);
@@ -76,7 +75,6 @@ export const LessonBuilderPageClient = () => {
   }) => {
     const base = {
       title: name,
-      themeId: selectedThemeId,
       content: prepareContent(),
     };
 
@@ -111,7 +109,6 @@ export const LessonBuilderPageClient = () => {
     setLessonId(Number(lesson.id));
     setLessonName(lesson.title);
     if (lesson.themeId) {
-      setSelectedThemeId(Number(lesson.themeId));
       const themeRes = await getTheme({ variables: { id: String(lesson.themeId) } });
       if (themeRes.data?.getTheme) {
         setSelectedCollectionId(Number(themeRes.data.getTheme.styleCollectionId));
@@ -132,17 +129,13 @@ export const LessonBuilderPageClient = () => {
     <VStack w="100%">
       {lessonName && <Heading size="md">{lessonName}</Heading>}
       <HStack flex={1} w="100%" align="start">
-        <ThemeDropdown
-          value={selectedThemeId ? String(selectedThemeId) : null}
-          onChange={(theme) => {
-            if (theme) {
-              setSelectedThemeId(theme.id);
-              setSelectedCollectionId(theme.styleCollectionId);
-              setSelectedPaletteId(theme.defaultPaletteId);
+        <StyleCollectionDropdown
+          value={selectedCollectionId ? String(selectedCollectionId) : null}
+          onChange={(collection) => {
+            if (collection) {
+              setSelectedCollectionId(collection.id);
             } else {
-              setSelectedThemeId(null);
               setSelectedCollectionId(null);
-              setSelectedPaletteId(null);
             }
           }}
         />

--- a/insight-fe/src/components/dropdowns/StyleCollectionDropdown.tsx
+++ b/insight-fe/src/components/dropdowns/StyleCollectionDropdown.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import { ChangeEvent, useMemo } from "react";
+import { useQuery } from "@apollo/client";
+import { GET_STYLE_COLLECTIONS } from "@/graphql/lesson";
+import SimpleDropdown from "./SimpleDropdown";
+
+export interface StyleCollectionOption {
+  id: number;
+  name: string;
+}
+
+interface StyleCollectionDropdownProps {
+  value: string | null;
+  onChange: (collection: StyleCollectionOption | null) => void;
+}
+
+export default function StyleCollectionDropdown({
+  value,
+  onChange,
+}: StyleCollectionDropdownProps) {
+  const { data, loading } = useQuery(GET_STYLE_COLLECTIONS);
+
+  const collections: StyleCollectionOption[] = useMemo(
+    () =>
+      (data?.getAllStyleCollection ?? []).map((c: any) => ({
+        id: Number(c.id),
+        name: c.name,
+      })),
+    [data],
+  );
+
+  const options = useMemo(
+    () => collections.map((c) => ({ label: c.name, value: String(c.id) })),
+    [collections],
+  );
+
+  return (
+    <SimpleDropdown
+      options={options}
+      value={value ?? ""}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+        const val = e.target.value;
+        const collection =
+          collections.find((c) => String(c.id) === val) || null;
+        onChange(collection);
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add new `StyleCollectionDropdown` component
- swap out the theme dropdown for the new style collection dropdown in the lesson builder

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526cd589d08326ba30b5d691440b7a