### PR TITLE
Add color palette selection to lesson builder

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/LessonBuilderPageClient.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useMutation, useLazyQuery } from "@apollo/client";
 import { CREATE_LESSON, UPDATE_LESSON, GET_LESSON, GET_THEME } from "@/graphql/lesson";
 import StyleCollectionDropdown from "@/components/dropdowns/StyleCollectionDropdown";
+import ColorPaletteDropdown from "@/components/dropdowns/ColorPaletteDropdown";
 import { AvailableElements } from "./components/AvailableElements";
 import StyledElementsPalette from "./components/StyledElementsPalette";
 import SlideCanvas from "./components/SlideCanvas";
@@ -128,7 +129,7 @@ export const LessonBuilderPageClient = () => {
   return (
     <VStack w="100%">
       {lessonName && <Heading size="md">{lessonName}</Heading>}
-      <HStack flex={1} w="100%" align="start">
+      <HStack flex={1} w="100%" align="start" spacing={4}>
         <StyleCollectionDropdown
           value={selectedCollectionId ? String(selectedCollectionId) : null}
           onChange={(collection) => {
@@ -137,7 +138,15 @@ export const LessonBuilderPageClient = () => {
             } else {
               setSelectedCollectionId(null);
             }
+            setSelectedPaletteId(null);
           }}
+        />
+        <ColorPaletteDropdown
+          collectionId={selectedCollectionId}
+          value={selectedPaletteId ? String(selectedPaletteId) : null}
+          onChange={(palette) =>
+            setSelectedPaletteId(palette ? palette.id : null)
+          }
         />
       </HStack>
       <HStack w="100%">
@@ -149,6 +158,7 @@ export const LessonBuilderPageClient = () => {
       <Flex w="100%" align="start" pt={4} bg="green.100" p={4}>
         <StyledElementsPalette
           collectionId={selectedCollectionId}
+          paletteId={selectedPaletteId}
           elementType={selectedElementType}
         />
       </Flex>

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/StyledElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/StyledElementsPalette.tsx
@@ -14,11 +14,13 @@ import type { BoardRow } from "@/components/lesson/slide/SlideElementsContainer"
 
 interface StyledElementsPaletteProps {
   collectionId: number | null;
+  paletteId: number | null;
   elementType: string | null;
 }
 
 export default function StyledElementsPalette({
   collectionId,
+  paletteId,
   elementType,
 }: StyledElementsPaletteProps) {
   const [items, setItems] = useState<
@@ -33,15 +35,15 @@ export default function StyledElementsPalette({
       collectionId: String(collectionId),
       element: elementType ?? "",
     },
-    skip: collectionId === null || !elementType,
+    skip: collectionId === null || paletteId === null || !elementType,
     fetchPolicy: "network-only",
   });
 
   useEffect(() => {
-    if (collectionId === null || !elementType) {
+    if (collectionId === null || paletteId === null || !elementType) {
       setItems([]);
     }
-  }, [collectionId, elementType]);
+  }, [collectionId, paletteId, elementType]);
 
   useEffect(() => {
     if (data?.getAllStyle) {

--- a/insight-fe/src/components/dropdowns/ColorPaletteDropdown.tsx
+++ b/insight-fe/src/components/dropdowns/ColorPaletteDropdown.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { ChangeEvent, useMemo, useEffect } from "react";
+import { useQuery } from "@apollo/client";
+import { GET_COLOR_PALETTES } from "@/graphql/lesson";
+import SimpleDropdown from "./SimpleDropdown";
+
+export interface ColorPaletteOption {
+  id: number;
+  name: string;
+}
+
+interface ColorPaletteDropdownProps {
+  collectionId: number | null;
+  value: string | null;
+  onChange: (palette: ColorPaletteOption | null) => void;
+}
+
+export default function ColorPaletteDropdown({
+  collectionId,
+  value,
+  onChange,
+}: ColorPaletteDropdownProps) {
+  const { data, loading } = useQuery(GET_COLOR_PALETTES, {
+    variables: { collectionId: String(collectionId) },
+    skip: collectionId === null,
+    fetchPolicy: "network-only",
+  });
+
+  const palettes: ColorPaletteOption[] = useMemo(
+    () =>
+      (data?.getAllColorPalette ?? []).map((p: any) => ({
+        id: Number(p.id),
+        name: p.name,
+      })),
+    [data]
+  );
+
+  const options = useMemo(
+    () => palettes.map((p) => ({ label: p.name, value: String(p.id) })),
+    [palettes]
+  );
+
+  // Reset selection when collection changes
+  useEffect(() => {
+    onChange(null);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [collectionId]);
+
+  return (
+    <SimpleDropdown
+      options={options}
+      value={value ?? ""}
+      isDisabled={collectionId === null}
+      isLoading={loading}
+      onChange={(e: ChangeEvent<HTMLSelectElement>) => {
+        const val = e.target.value;
+        const palette = palettes.find((p) => String(p.id) === val) || null;
+        onChange(palette);
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add `ColorPaletteDropdown` for selecting palettes by collection
- hook up palette dropdown in `LessonBuilderPageClient`
- require palette selection for styled elements

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852716795888326a3084df97b6b3ebb