### PR TITLE
Sync styled element updates across theme builder

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -8,6 +8,7 @@ import { AvailableElements } from "./components/AvailableElements";
 import StyledElementsPalette from "./components/StyledElementsPalette";
 import BaseElementsPalette from "./components/BaseElementsPalette";
 import ThemeCanvas from "./components/ThemeCanvas";
+import { SlideElementDnDItemProps } from "@/components/DnD/cards/SlideElementDnDCard";
 import SaveThemeModal from "./components/SaveThemeModal";
 import LoadThemeModal, { ThemeInfo } from "./components/LoadThemeModal";
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
@@ -30,6 +31,12 @@ export const ThemeBuilderPageClient = () => {
   const [isLoadThemeOpen, setIsLoadThemeOpen] = useState(false);
   const [themes, setThemes] = useState<ThemeInfo[]>([]);
   const [loadedTheme, setLoadedTheme] = useState<ThemeInfo | null>(null);
+  // Keeps track of styled element updates so the palette can stay in sync
+  const [styleUpdates, setStyleUpdates] = useState<Record<number, SlideElementDnDItemProps>>({});
+
+  const handleStyleUpdate = (styleId: number, el: SlideElementDnDItemProps) => {
+    setStyleUpdates((prev) => ({ ...prev, [styleId]: el }));
+  };
 
   const { data: themesData } = useQuery(GET_ALL_THEMES);
   const [createTheme] = useMutation(CREATE_THEME);
@@ -138,6 +145,7 @@ export const ThemeBuilderPageClient = () => {
             collectionId={selectedCollectionId}
             elementType={selectedElementType}
             groupId={selectedGroupId}
+            styleUpdates={styleUpdates}
           />
         </Flex>
       </HStack>
@@ -155,6 +163,7 @@ export const ThemeBuilderPageClient = () => {
       <ThemeCanvas
         collectionId={selectedCollectionId}
         paletteId={selectedPaletteId}
+        onStyleUpdate={handleStyleUpdate}
       />
       <SaveThemeModal
         isOpen={isSaveThemeOpen}

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
@@ -16,12 +16,19 @@ interface StyledElementsPaletteProps {
   collectionId: number | null;
   elementType: string | null;
   groupId: number | null;
+  /**
+   * Map of style updates keyed by styleId. When provided, the palette will
+   * update the corresponding element configuration without refetching from
+   * the server.
+   */
+  styleUpdates?: Record<number, SlideElementDnDItemProps>;
 }
 
 export default function StyledElementsPalette({
   collectionId,
   elementType,
   groupId,
+  styleUpdates,
 }: StyledElementsPaletteProps) {
   const [items, setItems] = useState<
     (
@@ -65,6 +72,21 @@ export default function StyledElementsPalette({
       setItems(mapped);
     }
   }, [data, elementType]);
+
+  // Apply style updates coming from the canvas
+  useEffect(() => {
+    if (!styleUpdates) return;
+    setItems((prev) =>
+      prev.map((item) => {
+        const styleId = (item as any).styleId as number | undefined;
+        if (styleId && styleUpdates[styleId]) {
+          const { id: _ignore, ...rest } = styleUpdates[styleId];
+          return { ...item, ...rest, id: item.id } as typeof item;
+        }
+        return item;
+      }),
+    );
+  }, [styleUpdates]);
 
   return (
     <VStack align="start" w="100%">


### PR DESCRIPTION
## Summary
- update `ThemeCanvas` to sync updates for styled elements
- allow `ThemeBuilderPageClient` to track style updates and forward them
- update `StyledElementsPalette` when a styled element configuration changes

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854641303c083269429491926b1f18e