### PR TITLE
Add deletion drop zone for styled elements

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ThemeBuilderPageClient } from '../ThemeBuilderPageClient';
-import { useLazyQuery, useQuery } from '@apollo/client';
+import { useLazyQuery, useQuery, useMutation } from '@apollo/client';
 
 jest.mock('@apollo/client');
 
@@ -65,6 +65,7 @@ describe('ThemeBuilderPageClient', () => {
         getAllTheme: [],
       },
     });
+    (useMutation as jest.Mock).mockReturnValue([jest.fn()]);
     collectionProps = null;
     paletteProps = null;
     availableProps = null;

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
@@ -11,6 +11,7 @@ let availableProps: any = null;
 let styledPaletteProps: any = null;
 let basePaletteProps: any = null;
 let canvasProps: any = null;
+let deleteAreaProps: any = null;
 
 jest.mock('../components/ThemeCanvas', () => (props: any) => {
   canvasProps = props;
@@ -33,6 +34,11 @@ jest.mock('../components/ColorPaletteManagement', () => (props: any) => {
 
 jest.mock('@/components/modals/ConfirmationModal', () => (props: any) => {
   return <div data-testid="confirm" {...props} />;
+});
+
+jest.mock('../components/StyleDeleteDropArea', () => (props: any) => {
+  deleteAreaProps = props;
+  return <div data-testid="delete-area" />;
 });
 
 jest.mock('../components/AvailableElements', () => ({ onSelect, selectedType }: any) => {
@@ -72,6 +78,7 @@ describe('ThemeBuilderPageClient', () => {
     styledPaletteProps = null;
     basePaletteProps = null;
     canvasProps = null;
+    deleteAreaProps = null;
   });
 
   it('updates state based on child callbacks', async () => {
@@ -126,6 +133,12 @@ describe('ThemeBuilderPageClient', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Load' }));
     await userEvent.click(screen.getByText('Save Theme'));
 
+    expect(screen.getByTestId('confirm')).toBeInTheDocument();
+  });
+
+  it('shows confirm modal when dropping a style to delete', async () => {
+    render(<ThemeBuilderPageClient />);
+    deleteAreaProps.onDrop(5);
     expect(screen.getByTestId('confirm')).toBeInTheDocument();
   });
 });

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleDeleteDropArea.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleDeleteDropArea.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { Box, Icon } from "@chakra-ui/react";
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+
+interface StyleDeleteDropAreaProps {
+  onDrop?: (id: number) => void;
+}
+
+export default function StyleDeleteDropArea({ onDrop }: StyleDeleteDropAreaProps) {
+  const [isOver, setIsOver] = useState(false);
+
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    const raw = e.dataTransfer.getData("text/plain");
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed?.config?.styleId) {
+        setIsOver(true);
+      } else {
+        setIsOver(false);
+      }
+    } catch {
+      setIsOver(false);
+    }
+  };
+
+  const handleDragLeave = () => setIsOver(false);
+
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsOver(false);
+    const raw = e.dataTransfer.getData("text/plain");
+    try {
+      const parsed = JSON.parse(raw);
+      const styleId = parsed?.config?.styleId;
+      if (styleId) {
+        onDrop?.(styleId);
+      }
+    } catch {
+      /* ignore */
+    }
+  };
+
+  return (
+    <Box
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      data-testid="delete-style-area"
+      p={4}
+      minW="60px"
+      borderWidth="2px"
+      borderStyle="dashed"
+      borderColor={isOver ? "red.400" : "gray.300"}
+      borderRadius="md"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+      bg={isOver ? "red.50" : "transparent"}
+      color={isOver ? "red.500" : "gray.500"}
+      transition="background-color 0.2s ease, border-color 0.2s ease"
+    >
+      <Icon as={Trash2} boxSize={6} />
+    </Box>
+  );
+}

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
@@ -5,6 +5,7 @@ import { useQuery, useMutation } from "@apollo/client";
 import { GET_STYLES_WITH_CONFIG, DELETE_STYLE } from "@/graphql/lesson";
 import DnDPalette from "@/components/DnD/DnDPalette";
 import { VStack, Text, HStack } from "@chakra-ui/react";
+import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 import {
   SlideElementDnDItemProps,
   SlideElementDnDItem,
@@ -41,6 +42,8 @@ export default function StyledElementsPalette({
     fetchPolicy: "network-only",
   });
   const [deleteStyle] = useMutation(DELETE_STYLE);
+  const [styleIdToDelete, setStyleIdToDelete] = useState<number | null>(null);
+  const [deleting, setDeleting] = useState(false);
 
   useEffect(() => {
     if (collectionId === null || !elementType) {
@@ -76,9 +79,15 @@ export default function StyledElementsPalette({
     }
   }, [data, elementType]);
 
-  const handleDelete = async (id: number) => {
-    await deleteStyle({ variables: { data: { id } } });
-    setItems((prev) => prev.filter((it) => it.styleId !== id));
+  const handleRequestDelete = (id: number) => setStyleIdToDelete(id);
+
+  const confirmDelete = async () => {
+    if (styleIdToDelete === null) return;
+    setDeleting(true);
+    await deleteStyle({ variables: { data: { id: styleIdToDelete } } });
+    setItems((prev) => prev.filter((it) => it.styleId !== styleIdToDelete));
+    setDeleting(false);
+    setStyleIdToDelete(null);
   };
 
   return (
@@ -95,8 +104,16 @@ export default function StyledElementsPalette({
             JSON.stringify({ type: item.type, config: item })
           }
         />
-        <StyleDeleteDropArea onDrop={handleDelete} />
+        <StyleDeleteDropArea onDrop={handleRequestDelete} />
       </HStack>
+      <ConfirmationModal
+        isOpen={styleIdToDelete !== null}
+        onClose={() => setStyleIdToDelete(null)}
+        action="delete style"
+        bodyText="Are you sure you want to delete this styled element?"
+        onConfirm={confirmDelete}
+        isLoading={deleting}
+      />
     </VStack>
   );
 }

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyledElementsPalette.tsx
@@ -1,16 +1,17 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useQuery } from "@apollo/client";
-import { GET_STYLES_WITH_CONFIG } from "@/graphql/lesson";
+import { useQuery, useMutation } from "@apollo/client";
+import { GET_STYLES_WITH_CONFIG, DELETE_STYLE } from "@/graphql/lesson";
 import DnDPalette from "@/components/DnD/DnDPalette";
-import { VStack, Text } from "@chakra-ui/react";
+import { VStack, Text, HStack } from "@chakra-ui/react";
 import {
   SlideElementDnDItemProps,
   SlideElementDnDItem,
 } from "@/components/DnD/cards/SlideElementDnDCard";
 import { ColumnType } from "@/components/DnD/types";
 import type { BoardRow } from "@/components/lesson/slide/SlideElementsContainer";
+import StyleDeleteDropArea from "./StyleDeleteDropArea";
 
 interface StyledElementsPaletteProps {
   collectionId: number | null;
@@ -39,6 +40,7 @@ export default function StyledElementsPalette({
     skip: shouldSkip,
     fetchPolicy: "network-only",
   });
+  const [deleteStyle] = useMutation(DELETE_STYLE);
 
   useEffect(() => {
     if (collectionId === null || !elementType) {
@@ -74,19 +76,27 @@ export default function StyledElementsPalette({
     }
   }, [data, elementType]);
 
+  const handleDelete = async (id: number) => {
+    await deleteStyle({ variables: { data: { id } } });
+    setItems((prev) => prev.filter((it) => it.styleId !== id));
+  };
+
   return (
     <VStack align="start" w="100%">
       <Text fontSize="sm" mb={2}>
         Styled Elements
       </Text>
-      <DnDPalette
-        testId="styled"
-        items={items}
-        ItemComponent={SlideElementDnDItem}
-        getDragData={(item) =>
-          JSON.stringify({ type: item.type, config: item })
-        }
-      />
+      <HStack align="start" w="100%" spacing={4}>
+        <DnDPalette
+          testId="styled"
+          items={items}
+          ItemComponent={SlideElementDnDItem}
+          getDragData={(item) =>
+            JSON.stringify({ type: item.type, config: item })
+          }
+        />
+        <StyleDeleteDropArea onDrop={handleDelete} />
+      </HStack>
     </VStack>
   );
 }

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -28,6 +28,12 @@ export const UPDATE_STYLE = gql`
   }
 `;
 
+export const DELETE_STYLE = gql`
+  mutation DeleteStyle($data: IdInput!) {
+    deleteStyle(data: $data)
+  }
+`;
+
 
 export const CREATE_STYLE_COLLECTION = gql`
   mutation CreateStyleCollection($data: CreateStyleCollectionInput!) {


### PR DESCRIPTION
## Summary
- support deleting styles via new GraphQL `deleteStyle`
- add a `StyleDeleteDropArea` component to drag styles for deletion
- update `StyledElementsPalette` to show the delete area and call the delete mutation
- adjust tests to mock `useMutation`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a59433e588326832d79fb028ec2c4