### PR TITLE
Remove clone/delete buttons from theme builder

### DIFF
--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeAttributesPane.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeAttributesPane.tsx
@@ -17,8 +17,6 @@ interface ThemeAttributesPaneProps {
   onUpdateColumn: (col: ColumnType<SlideElementDnDItemProps>) => void;
   onUpdateBoard: (board: BoardRow) => void;
   onSave: (target: 'element' | 'column' | 'row') => void;
-  onClone?: () => void;
-  onDelete?: () => void;
 }
 
 export default function ThemeAttributesPane({
@@ -31,8 +29,6 @@ export default function ThemeAttributesPane({
   onUpdateColumn,
   onUpdateBoard,
   onSave,
-  onClone,
-  onDelete,
 }: ThemeAttributesPaneProps) {
   return (
     <Box p={4} borderWidth="1px" borderRadius="md" minW="250px">
@@ -58,8 +54,6 @@ export default function ThemeAttributesPane({
         <ElementAttributesPane
           element={element}
           onChange={onUpdateElement}
-          onClone={onClone}
-          onDelete={onDelete}
           colorPalettes={colorPalettes}
           selectedPaletteId={selectedPaletteId}
         />

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeCanvas.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ThemeCanvas.tsx
@@ -138,32 +138,6 @@ export default function ThemeCanvas({
     setBoards((bs) => bs.map((b) => (b.id === updated.id ? updated : b)));
   };
 
-  const cloneElement = () => {
-    if (!selectedElementId) return;
-    setColumnMap((prev) => {
-      const newMap = { ...prev };
-      for (const board of boards) {
-        for (const colId of board.orderedColumnIds) {
-          const col = newMap[colId];
-          const idx = col.items.findIndex((i) => i.id === selectedElementId);
-          if (idx !== -1) {
-            const orig = col.items[idx];
-            const copy = { ...orig, id: crypto.randomUUID() };
-            newMap[colId] = {
-              ...col,
-              items: [
-                ...col.items.slice(0, idx + 1),
-                copy,
-                ...col.items.slice(idx + 1),
-              ],
-            };
-            return newMap;
-          }
-        }
-      }
-      return newMap;
-    });
-  };
 
   const deleteElementById = (id: string) => {
     setColumnMap((prev) => {
@@ -244,10 +218,6 @@ export default function ThemeCanvas({
     });
   };
 
-  const deleteElement = () => {
-    if (!selectedElementId) return;
-    deleteElementById(selectedElementId);
-  };
 
   const handleDropElement = (e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -524,8 +494,6 @@ export default function ThemeCanvas({
           onUpdateColumn={updateColumn}
           onUpdateBoard={updateBoard}
           onSave={setSaveTarget}
-          onClone={cloneElement}
-          onDelete={deleteElement}
           colorPalettes={colorPalettes}
           selectedPaletteId={paletteId ?? ""}
         />


### PR DESCRIPTION
## Summary
- remove `onClone` and `onDelete` props from theme builder attribute pane
- stop passing clone/delete callbacks from theme canvas
- drop unused clone/delete functions

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*


------
https://chatgpt.com/codex/tasks/task_e_685ab13fe42083268d4b63bed4b15eed