### PR TITLE
Implement token-based color palettes

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, ManyToOne, JoinColumn, RelationId } from 'typeorm';
 import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
 
@@ -10,9 +11,9 @@ export class ColorPaletteEntity extends AbstractBaseEntity {
   @Column()
   name: string;
 
-  @Field(() => [String])
+  @Field(() => GraphQLJSONObject)
   @Column({ type: 'jsonb' })
-  colors: string[];
+  colors: Record<string, string>;
 
   @Field(() => StyleCollectionEntity)
   @ManyToOne(() => StyleCollectionEntity, (collection) => collection.colorPalettes, { nullable: false })

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
@@ -1,13 +1,14 @@
 import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
 import { HasRelationsInput, FindAllInput } from 'src/common/base.inputs';
+import { GraphQLJSONObject } from 'graphql-type-json';
 
 @InputType()
 export class CreateColorPaletteInput extends HasRelationsInput {
   @Field()
   name: string;
 
-  @Field(() => [String])
-  colors: string[];
+  @Field(() => GraphQLJSONObject)
+  colors: Record<string, string>;
 
   @Field(() => ID)
   collectionId: number;

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
@@ -23,4 +23,8 @@ export class StyleCollectionEntity extends AbstractBaseEntity {
   @Field(() => [ColorPaletteEntity], { nullable: true })
   @OneToMany(() => ColorPaletteEntity, (palette) => palette.collection)
   colorPalettes?: ColorPaletteEntity[];
+
+  @Field(() => [String])
+  @Column({ type: 'jsonb', default: () => "'[]'" })
+  colorTokens!: string[];
 }

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
@@ -4,6 +4,9 @@ import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
 export class CreateStyleCollectionInput {
   @Field()
   name: string;
+
+  @Field(() => [String])
+  tokens: string[];
 }
 
 @InputType()

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/ColorPaletteManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/ColorPaletteManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 
@@ -11,11 +11,13 @@ import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 
 interface ColorPaletteManagementProps {
   collectionId: number | null;
+  tokens: string[];
   onSelectPalette?: (id: number | null) => void;
 }
 
 export default function ColorPaletteManagement({
   collectionId,
+  tokens,
   onSelectPalette,
 }: ColorPaletteManagementProps) {
   const { data, refetch } = useQuery(GET_COLOR_PALETTES, {
@@ -27,7 +29,7 @@ export default function ColorPaletteManagement({
     useMutation(DELETE_COLOR_PALETTE);
 
   const [palettes, setPalettes] = useState<
-    { id: number; name: string; colors: string[] }[]
+    { id: number; name: string; colors: Record<string, string> }[]
   >([]);
   const [selectedId, setSelectedId] = useState<number | "">("");
   const [isAddOpen, setIsAddOpen] = useState(false);
@@ -84,6 +86,7 @@ export default function ColorPaletteManagement({
         isOpen={isAddOpen}
         onClose={() => setIsAddOpen(false)}
         collectionId={collectionId === null ? 0 : (collectionId as number)}
+        tokens={tokens}
         onSave={async (palette) => {
           setPalettes((ps) => [...ps, palette]);
           refetch();
@@ -96,7 +99,8 @@ export default function ColorPaletteManagement({
         collectionId={collectionId === null ? 0 : (collectionId as number)}
         paletteId={selectedId === "" ? undefined : selectedId}
         initialName={selected?.name ?? ""}
-        initialColors={selected?.colors ?? []}
+        tokens={tokens}
+        initialColors={selected?.colors ?? {}}
         title="Update Color Palette"
         confirmLabel="Update"
         onSave={async (palette) => {

--- a/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/StyleCollectionManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/lesson-builder/components/StyleCollectionManagement.tsx
@@ -15,7 +15,7 @@ import AddStyleCollectionModal from "@/components/lesson/modals/AddStyleCollecti
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 
 interface StyleCollectionManagementProps {
-  onSelectCollection: (id: number | null) => void;
+  onSelectCollection: (id: number | null, tokens: string[]) => void;
 }
 
 export default function StyleCollectionManagement({
@@ -29,7 +29,7 @@ export default function StyleCollectionManagement({
   );
 
   const [collections, setCollections] = useState<
-    { id: number; name: string }[]
+    { id: number; name: string; tokens: string[] }[]
   >([]);
   const [selectedId, setSelectedId] = useState<number | "">("");
   const [isAddOpen, setIsAddOpen] = useState(false);
@@ -38,9 +38,10 @@ export default function StyleCollectionManagement({
 
   useEffect(() => {
     if (selectedId) {
-      onSelectCollection(selectedId);
+      const tokens = collections.find((c) => c.id === selectedId)?.tokens ?? [];
+      onSelectCollection(selectedId, tokens);
     }
-  }, [selectedId]);
+  }, [selectedId, collections]);
 
   useEffect(() => {
     if (data?.getAllStyleCollection) {
@@ -48,6 +49,7 @@ export default function StyleCollectionManagement({
         data.getAllStyleCollection.map((c: any) => ({
           id: Number(c.id),
           name: c.name,
+          tokens: c.colorTokens ?? [],
         }))
       );
     }
@@ -80,13 +82,17 @@ export default function StyleCollectionManagement({
       <AddStyleCollectionModal
         isOpen={isAddOpen}
         onClose={() => setIsAddOpen(false)}
-        onSave={async (name) => {
+        onSave={async (name, tokens) => {
           const { data: res } = await createCollection({
-            variables: { data: { name } },
+            variables: { data: { name, tokens } },
           });
           const created = res?.createStyleCollection;
           if (created) {
-            const coll = { id: Number(created.id), name: created.name };
+            const coll = {
+              id: Number(created.id),
+              name: created.name,
+              tokens: created.colorTokens,
+            };
             setCollections((c) => [...c, coll]);
             setSelectedId(coll.id);
             refetch();
@@ -100,16 +106,19 @@ export default function StyleCollectionManagement({
         title="Update Style Collection"
         confirmLabel="Update"
         initialName={selected?.name ?? ""}
-        onSave={async (name) => {
+        initialTokens={selected?.tokens ?? []}
+        onSave={async (name, tokens) => {
           if (selectedId === "") return;
           const { data: res } = await updateCollection({
-            variables: { data: { id: selectedId, name } },
+            variables: { data: { id: selectedId, name, tokens } },
           });
           const updated = res?.updateStyleCollection;
           if (updated) {
             setCollections((cs) =>
               cs.map((c) =>
-                c.id === selectedId ? { id: c.id, name: updated.name } : c
+                c.id === selectedId
+                  ? { id: c.id, name: updated.name, tokens: updated.colorTokens }
+                  : c
               )
             );
             refetch();

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/ThemeBuilderPageClient.tsx
@@ -18,6 +18,7 @@ export const ThemeBuilderPageClient = () => {
   const [selectedCollectionId, setSelectedCollectionId] = useState<
     number | null
   >(null);
+  const [collectionTokens, setCollectionTokens] = useState<string[]>([]);
   const [selectedElementType, setSelectedElementType] = useState<string | null>(
     null
   );
@@ -109,11 +110,15 @@ export const ThemeBuilderPageClient = () => {
       </Heading>
       <HStack flex={1} w="100%" align="start">
         <StyleCollectionManagement
-          onSelectCollection={setSelectedCollectionId}
+          onSelectCollection={(id, tokens) => {
+            setSelectedCollectionId(id);
+            setCollectionTokens(tokens);
+          }}
           selectedId={selectedCollectionId}
         />
         <ColorPaletteManagement
           collectionId={selectedCollectionId}
+          tokens={collectionTokens}
           onSelectPalette={setSelectedPaletteId}
           selectedId={selectedPaletteId}
         />

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ColorPaletteManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ColorPaletteManagement.test.tsx
@@ -22,22 +22,22 @@ describe('ColorPaletteManagement', () => {
   });
 
   it('provides palettes as options', () => {
-    render(<ColorPaletteManagement collectionId={1} />);
+    render(<ColorPaletteManagement collectionId={1} tokens={[]} />);
     expect(dropdownProps.options).toEqual([{ label: 'Palette 1', value: '1' }]);
   });
 
   it('clears selection when collection changes', async () => {
-    const { rerender } = render(<ColorPaletteManagement collectionId={1} />);
+    const { rerender } = render(<ColorPaletteManagement collectionId={1} tokens={[]} />);
     await userEvent.selectOptions(screen.getByTestId('crud'), ['1']);
     expect(dropdownProps.value).toBe(1);
-    rerender(<ColorPaletteManagement collectionId={2} />);
+    rerender(<ColorPaletteManagement collectionId={2} tokens={[]} />);
     expect(dropdownProps.value).toBe('');
   });
 
   it('calls onSelectPalette when a palette is selected', async () => {
     const onSelect = jest.fn();
     render(
-      <ColorPaletteManagement collectionId={1} onSelectPalette={onSelect} />,
+      <ColorPaletteManagement collectionId={1} tokens={[]} onSelectPalette={onSelect} />,
     );
     await userEvent.selectOptions(screen.getByTestId('crud'), ['1']);
     expect(onSelect).toHaveBeenCalledWith(1);

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleCollectionManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleCollectionManagement.test.tsx
@@ -22,7 +22,7 @@ describe('StyleCollectionManagement', () => {
 
   it('provides collections as options', () => {
     render(
-      <StyleCollectionManagement onSelectCollection={() => {}} />
+      <StyleCollectionManagement onSelectCollection={(id, tokens) => {}} />
     );
     expect(dropdownProps.options).toEqual([{ label: 'Collection 1', value: '1' }]);
   });

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleCollectionManagement.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/StyleCollectionManagement.test.tsx
@@ -15,13 +15,15 @@ jest.mock('@/components/modals/ConfirmationModal', () => () => <div data-testid=
 
 describe('StyleCollectionManagement', () => {
   beforeEach(() => {
-    (useQuery as jest.Mock).mockReturnValue({ data: { getAllStyleCollection: [ { id: '1', name: 'Collection 1' } ] }, refetch: jest.fn() });
+    (useQuery as jest.Mock).mockReturnValue({ data: { getAllStyleCollection: [ { id: '1', name: 'Collection 1', colorTokens: [] } ] }, refetch: jest.fn() });
     (useMutation as jest.Mock).mockReturnValue([jest.fn(), { loading: false }]);
     dropdownProps = null;
   });
 
   it('provides collections as options', () => {
-    render(<StyleCollectionManagement onSelectCollection={() => {}} />);
+    render(
+      <StyleCollectionManagement onSelectCollection={() => {}} />
+    );
     expect(dropdownProps.options).toEqual([{ label: 'Collection 1', value: '1' }]);
   });
 });

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/__tests__/ThemeBuilderPageClient.test.tsx
@@ -21,7 +21,10 @@ jest.mock('../components/ThemeCanvas', () => (props: any) => {
 jest.mock('../components/StyleCollectionManagement', () => (props: any) => {
   collectionProps = props;
   return (
-    <button data-testid="collection" onClick={() => props.onSelectCollection(1)}>
+    <button
+      data-testid="collection"
+      onClick={() => props.onSelectCollection(1, [])}
+    >
       collection
     </button>
   );

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ColorPaletteManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/ColorPaletteManagement.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import { useState, useEffect } from "react";
 import { useQuery, useMutation } from "@apollo/client";
 
@@ -11,12 +11,14 @@ import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 
 interface ColorPaletteManagementProps {
   collectionId: number | null;
+  tokens: string[];
   onSelectPalette?: (id: number | null) => void;
   selectedId?: number | null;
 }
 
 export default function ColorPaletteManagement({
   collectionId,
+  tokens,
   onSelectPalette,
   selectedId,
 }: ColorPaletteManagementProps) {
@@ -29,7 +31,7 @@ export default function ColorPaletteManagement({
     useMutation(DELETE_COLOR_PALETTE);
 
   const [palettes, setPalettes] = useState<
-    { id: number; name: string; colors: string[] }[]
+    { id: number; name: string; colors: Record<string, string> }[]
   >([]);
   const [selectedState, setSelectedState] = useState<number | "">("");
   const [isAddOpen, setIsAddOpen] = useState(false);
@@ -94,6 +96,7 @@ export default function ColorPaletteManagement({
         isOpen={isAddOpen}
         onClose={() => setIsAddOpen(false)}
         collectionId={collectionId === null ? 0 : (collectionId as number)}
+        tokens={tokens}
         onSave={async (palette) => {
           setPalettes((ps) => [...ps, palette]);
           refetch();
@@ -106,7 +109,8 @@ export default function ColorPaletteManagement({
         collectionId={collectionId === null ? 0 : (collectionId as number)}
         paletteId={selectedState === "" ? undefined : selectedState}
         initialName={selected?.name ?? ""}
-        initialColors={selected?.colors ?? []}
+        tokens={tokens}
+        initialColors={selected?.colors ?? {}}
         title="Update Color Palette"
         confirmLabel="Update"
         onSave={async (palette) => {

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleCollectionManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleCollectionManagement.tsx
@@ -31,7 +31,7 @@ export default function StyleCollectionManagement({
   );
 
   const [collections, setCollections] = useState<
-    { id: number; name: string }[]
+    { id: number; name: string; tokens: string[] }[]
   >([]);
   const [selectedState, setSelectedState] = useState<number | "">("");
   const [isAddOpen, setIsAddOpen] = useState(false);
@@ -50,6 +50,7 @@ export default function StyleCollectionManagement({
         data.getAllStyleCollection.map((c: any) => ({
           id: Number(c.id),
           name: c.name,
+          tokens: c.colorTokens ?? [],
         }))
       );
     }
@@ -88,13 +89,17 @@ export default function StyleCollectionManagement({
       <AddStyleCollectionModal
         isOpen={isAddOpen}
         onClose={() => setIsAddOpen(false)}
-        onSave={async (name) => {
+        onSave={async (name, tokens) => {
           const { data: res } = await createCollection({
-            variables: { data: { name } },
+            variables: { data: { name, tokens } },
           });
           const created = res?.createStyleCollection;
           if (created) {
-            const coll = { id: Number(created.id), name: created.name };
+            const coll = {
+              id: Number(created.id),
+              name: created.name,
+              tokens: created.colorTokens,
+            };
             setCollections((c) => [...c, coll]);
             setSelectedState(coll.id);
             refetch();
@@ -108,16 +113,19 @@ export default function StyleCollectionManagement({
         title="Update Style Collection"
         confirmLabel="Update"
         initialName={selected?.name ?? ""}
-        onSave={async (name) => {
+        initialTokens={selected?.tokens ?? []}
+        onSave={async (name, tokens) => {
           if (selectedState === "") return;
           const { data: res } = await updateCollection({
-            variables: { data: { id: selectedState, name } },
+            variables: { data: { id: selectedState, name, tokens } },
           });
           const updated = res?.updateStyleCollection;
           if (updated) {
             setCollections((cs) =>
               cs.map((c) =>
-                c.id === selectedState ? { id: c.id, name: updated.name } : c
+                c.id === selectedState
+                  ? { id: c.id, name: updated.name, tokens: updated.colorTokens }
+                  : c
               )
             );
             refetch();

--- a/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleCollectionManagement.tsx
+++ b/insight-fe/src/app/(main)/(protected)/educators/theme-builder/components/StyleCollectionManagement.tsx
@@ -15,7 +15,7 @@ import AddStyleCollectionModal from "@/components/lesson/modals/AddStyleCollecti
 import { ConfirmationModal } from "@/components/modals/ConfirmationModal";
 
 interface StyleCollectionManagementProps {
-  onSelectCollection: (id: number | null) => void;
+  onSelectCollection: (id: number | null, tokens: string[]) => void;
   selectedId?: number | null;
 }
 
@@ -40,9 +40,11 @@ export default function StyleCollectionManagement({
 
   useEffect(() => {
     if (selectedState) {
-      onSelectCollection(selectedState);
+      const tokens =
+        collections.find((c) => c.id === selectedState)?.tokens ?? [];
+      onSelectCollection(selectedState, tokens);
     }
-  }, [selectedState]);
+  }, [selectedState, collections]);
 
   useEffect(() => {
     if (data?.getAllStyleCollection) {

--- a/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddColorPaletteModal.tsx
@@ -2,15 +2,14 @@
 
 import { useState, useEffect } from "react";
 
-const DEFAULT_COLORS = ["#000000"];
+const DEFAULT_COLOR = "#000000";
 import {
   Button,
   HStack,
   Input,
   VStack,
-  IconButton,
+  Text,
 } from "@chakra-ui/react";
-import { Plus, Trash2 } from "lucide-react";
 import { BaseModal } from "@/components/modals/BaseModal";
 import { useMutation, useQuery } from "@apollo/client";
 import {
@@ -23,11 +22,12 @@ interface ColorPaletteModalProps {
   isOpen: boolean;
   onClose: () => void;
   collectionId: number;
-  onSave?: (palette: { id: number; name: string; colors: string[] }) => void;
+  tokens: string[];
+  onSave?: (palette: { id: number; name: string; colors: Record<string, string> }) => void;
   /** Pre-populated palette name */
   initialName?: string;
   /** Pre-populated list of colors */
-  initialColors?: string[];
+  initialColors?: Record<string, string>;
   /** Existing palette id for updates */
   paletteId?: number;
   /** Modal title */
@@ -40,17 +40,19 @@ export default function ColorPaletteModal({
   isOpen,
   onClose,
   collectionId,
+  tokens,
   onSave,
   initialName = "",
-  initialColors = DEFAULT_COLORS,
+  initialColors = {},
   paletteId,
   title = "Add Color Palette",
   confirmLabel = "Save",
 }: ColorPaletteModalProps) {
   const [name, setName] = useState(initialName);
-  const [colors, setColors] = useState<string[]>(
-    initialColors.length > 0 ? [...initialColors] : DEFAULT_COLORS
-  );
+  const [colors, setColors] = useState<Record<string, string>>(() => {
+    if (Object.keys(initialColors).length > 0) return { ...initialColors };
+    return Object.fromEntries(tokens.map((t) => [t, DEFAULT_COLOR]));
+  });
 
   const { data: paletteData } = useQuery(GET_COLOR_PALETTE, {
     variables: { id: String(paletteId) },
@@ -73,21 +75,20 @@ export default function ColorPaletteModal({
 
     if (paletteId && palette) {
       setName(palette.name);
-      setColors(palette.colors.length > 0 ? [...palette.colors] : DEFAULT_COLORS);
+      setColors({ ...palette.colors });
     } else {
       setName(initialName);
-      setColors(initialColors.length > 0 ? [...initialColors] : DEFAULT_COLORS);
+      setColors(
+        Object.keys(initialColors).length > 0
+          ? { ...initialColors }
+          : Object.fromEntries(tokens.map((t) => [t, DEFAULT_COLOR]))
+      );
     }
-  }, [isOpen, initialName, initialColors, paletteId, palette?.id]);
+  }, [isOpen, initialName, initialColors, paletteId, palette?.id, tokens]);
 
-  const handleColorChange = (idx: number, value: string) => {
-    setColors((cols) => cols.map((c, i) => (i === idx ? value : c)));
+  const handleColorChange = (token: string, value: string) => {
+    setColors((cols) => ({ ...cols, [token]: value }));
   };
-
-  const addColor = () => setColors((cols) => [...cols, "#000000"]);
-
-  const removeColor = (idx: number) =>
-    setColors((cols) => cols.filter((_, i) => i !== idx));
 
   return (
     <BaseModal
@@ -126,7 +127,7 @@ export default function ColorPaletteModal({
                     colors: data.createColorPalette.colors,
                   });
                   setName("");
-                  setColors(["#000000"]);
+                  setColors(Object.fromEntries(tokens.map((t) => [t, DEFAULT_COLOR])));
                 }
               }
               onClose();
@@ -144,27 +145,19 @@ export default function ColorPaletteModal({
           value={name}
           onChange={(e) => setName(e.target.value)}
         />
-        {colors.map((color, idx) => (
-          <HStack key={idx}>
+        {tokens.map((t) => (
+          <HStack key={t}>
             <Input
               type="color"
-              value={color}
-              onChange={(e) => handleColorChange(idx, e.target.value)}
+              value={colors[t] ?? DEFAULT_COLOR}
+              onChange={(e) => handleColorChange(t, e.target.value)}
               w="40px"
               h="40px"
               p={0}
             />
-            <IconButton
-              aria-label="Remove color"
-              size="sm"
-              icon={<Trash2 size={16} />}
-              onClick={() => removeColor(idx)}
-            />
+            <Text>{t}</Text>
           </HStack>
         ))}
-        <Button leftIcon={<Plus size={16} />} size="sm" onClick={addColor}>
-          Add Color
-        </Button>
       </VStack>
     </BaseModal>
   );

--- a/insight-fe/src/components/lesson/modals/AddStyleCollectionModal.tsx
+++ b/insight-fe/src/components/lesson/modals/AddStyleCollectionModal.tsx
@@ -4,10 +4,12 @@ import { BaseModal } from "@/components/modals/BaseModal";
 
 interface AddStyleCollectionModalProps {
   isOpen: boolean;
-  onSave: (name: string) => void;
+  onSave: (name: string, tokens: string[]) => void;
   onClose: () => void;
   /** Pre-populated name when editing an existing collection */
   initialName?: string;
+  /** Pre-populated tokens when editing */
+  initialTokens?: string[];
   /** Modal title, defaults to "Add Style Collection" */
   title?: string;
   /** Text displayed on the confirmation button */
@@ -19,18 +21,27 @@ export default function AddStyleCollectionModal({
   onSave,
   onClose,
   initialName = "",
+  initialTokens = [],
   title = "Add Style Collection",
   confirmLabel = "Save",
 }: AddStyleCollectionModalProps) {
   const [name, setName] = useState(initialName);
+  const [tokens, setTokens] = useState<string[]>(initialTokens);
   const [loading, setLoading] = useState(false);
+
+  const addToken = () => setTokens((ts) => [...ts, ""]);
+  const updateToken = (idx: number, value: string) =>
+    setTokens((ts) => ts.map((t, i) => (i === idx ? value : t)));
+  const removeToken = (idx: number) =>
+    setTokens((ts) => ts.filter((_, i) => i !== idx));
 
   // Reset name whenever the modal is opened or the initial value changes
   useEffect(() => {
     if (isOpen) {
       setName(initialName);
+      setTokens(initialTokens);
     }
-  }, [isOpen, initialName]);
+  }, [isOpen, initialName, initialTokens]);
 
   return (
     <BaseModal
@@ -45,9 +56,10 @@ export default function AddStyleCollectionModal({
             onClick={async () => {
               setLoading(true);
               try {
-                await onSave(name);
+                await onSave(name, tokens.filter((t) => t.trim() !== ""));
                 if (initialName === "") {
                   setName("");
+                  setTokens([]);
                 }
                 onClose();
               } finally {
@@ -66,6 +78,21 @@ export default function AddStyleCollectionModal({
         value={name}
         onChange={(e) => setName(e.target.value)}
       />
+      {tokens.map((t, idx) => (
+        <HStack key={idx} mt={2}>
+          <Input
+            placeholder="Token name"
+            value={t}
+            onChange={(e) => updateToken(idx, e.target.value)}
+          />
+          <Button size="sm" onClick={() => removeToken(idx)}>
+            Remove
+          </Button>
+        </HStack>
+      ))}
+      <Button size="sm" mt={2} onClick={addToken}>
+        Add Token
+      </Button>
     </BaseModal>
   );
 }

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -5,6 +5,7 @@ export const GET_STYLE_COLLECTIONS = gql`
     getAllStyleCollection(data: { all: true }) {
       id
       name
+      colorTokens
     }
   }
 `;
@@ -64,6 +65,7 @@ export const CREATE_STYLE_COLLECTION = gql`
     createStyleCollection(data: $data) {
       id
       name
+      colorTokens
     }
   }
 `;
@@ -73,6 +75,7 @@ export const UPDATE_STYLE_COLLECTION = gql`
     updateStyleCollection(data: $data) {
       id
       name
+      colorTokens
     }
   }
 `;


### PR DESCRIPTION
## Summary
- add `colorTokens` to style collections
- store palette colors by token name
- expose color token fields in GraphQL queries/mutations
- update modals and management components to edit tokens and assign colors
- adjust theme builder to pass token data
- update unit tests for new props

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ba6d452008326a5389ce2f1a18dfd