### PR TITLE
Add colorTokens to style collections

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
@@ -11,6 +11,17 @@ export class StyleCollectionEntity extends AbstractBaseEntity {
   @Column()
   name: string;
 
+  /**
+   * List of color token names used for this style collection
+   */
+  @Field(() => [String])
+  @Column({
+    type: 'jsonb',
+    name: 'color_tokens',
+    default: () => '\'[]\'',
+  })
+  colorTokens!: string[];
+
   @Field(() => [StyleEntity], { nullable: true })
   @OneToMany(() => StyleEntity, (style) => style.collection)
   styles?: StyleEntity[];

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
@@ -4,6 +4,9 @@ import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
 export class CreateStyleCollectionInput {
   @Field()
   name: string;
+
+  @Field(() => [String], { defaultValue: [] })
+  colorTokens?: string[];
 }
 
 @InputType()

--- a/insight-fe/src/graphql/lesson.ts
+++ b/insight-fe/src/graphql/lesson.ts
@@ -5,6 +5,7 @@ export const GET_STYLE_COLLECTIONS = gql`
     getAllStyleCollection(data: { all: true }) {
       id
       name
+      colorTokens
     }
   }
 `;
@@ -40,6 +41,7 @@ export const CREATE_STYLE_COLLECTION = gql`
     createStyleCollection(data: $data) {
       id
       name
+      colorTokens
     }
   }
 `;
@@ -49,6 +51,7 @@ export const UPDATE_STYLE_COLLECTION = gql`
     updateStyleCollection(data: $data) {
       id
       name
+      colorTokens
     }
   }
 `;


### PR DESCRIPTION
## Summary
- add `colorTokens` jsonb column to style collections
- allow setting color tokens via `CreateStyleCollectionInput`
- request `colorTokens` in client GraphQL queries

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` in `insight-fe` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfacd8c2483268313e7570899d36b