### PR TITLE
Add colorTokens to StyleCollection input

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
@@ -4,10 +4,15 @@ import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
 export class CreateStyleCollectionInput {
   @Field()
   name: string;
+
+  @Field(() => [String], { nullable: true })
+  colorTokens?: string[];
 }
 
 @InputType()
-export class UpdateStyleCollectionInput extends PartialType(CreateStyleCollectionInput) {
+export class UpdateStyleCollectionInput extends PartialType(
+  CreateStyleCollectionInput,
+) {
   @Field(() => ID)
   id: number;
 }


### PR DESCRIPTION
## Summary
- allow setting color tokens when creating or updating style collections

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfb057f8c832692e9b3a0c7dcd1bc