### PR TITLE
Use JSON object for color palette inputs

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
@@ -1,4 +1,5 @@
 import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
 import { HasRelationsInput, FindAllInput } from 'src/common/base.inputs';
 
 @InputType()
@@ -6,8 +7,8 @@ export class CreateColorPaletteInput extends HasRelationsInput {
   @Field()
   name: string;
 
-  @Field(() => [String])
-  colors: string[];
+  @Field(() => GraphQLJSONObject)
+  colors: Record<string, string>;
 
   @Field(() => ID)
   collectionId: number;


### PR DESCRIPTION
## Summary
- switch color palette input colours to use GraphQLJSONObject with Record type

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cfb247d3c8326b548b9a2cd31acf6