### PR TITLE
Validate palette colors against tokens

### DIFF
--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.entity.ts
@@ -1,5 +1,6 @@
 import { Column, Entity, ManyToOne, JoinColumn, RelationId } from 'typeorm';
 import { Field, ObjectType, ID } from '@nestjs/graphql';
+import { GraphQLJSONObject } from 'graphql-type-json';
 import { AbstractBaseEntity } from 'src/common/base.entity';
 import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
 
@@ -10,9 +11,9 @@ export class ColorPaletteEntity extends AbstractBaseEntity {
   @Column()
   name: string;
 
-  @Field(() => [String])
+  @Field(() => GraphQLJSONObject)
   @Column({ type: 'jsonb' })
-  colors: string[];
+  colors: Record<string, string>;
 
   @Field(() => StyleCollectionEntity)
   @ManyToOne(() => StyleCollectionEntity, (collection) => collection.colorPalettes, { nullable: false })

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.inputs.ts
@@ -1,13 +1,14 @@
 import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
 import { HasRelationsInput, FindAllInput } from 'src/common/base.inputs';
+import { GraphQLJSONObject } from 'graphql-type-json';
 
 @InputType()
 export class CreateColorPaletteInput extends HasRelationsInput {
   @Field()
   name: string;
 
-  @Field(() => [String])
-  colors: string[];
+  @Field(() => GraphQLJSONObject)
+  colors: Record<string, string>;
 
   @Field(() => ID)
   collectionId: number;

--- a/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.service.ts
+++ b/insight-be/src/modules/timbuktu/administrative/color-palette/color-palette.service.ts
@@ -1,9 +1,10 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, BadRequestException } from '@nestjs/common';
 import { InjectDataSource, InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Repository } from 'typeorm';
 import { BaseService, FindAllOpts } from 'src/common/base.service';
 import { ColorPaletteEntity } from './color-palette.entity';
 import { CreateColorPaletteInput, UpdateColorPaletteInput } from './color-palette.inputs';
+import { StyleCollectionEntity } from '../style-collection/style-collection.entity';
 
 @Injectable()
 export class ColorPaletteService extends BaseService<
@@ -13,27 +14,57 @@ export class ColorPaletteService extends BaseService<
 > {
   constructor(
     @InjectRepository(ColorPaletteEntity) paletteRepository: Repository<ColorPaletteEntity>,
+    @InjectRepository(StyleCollectionEntity)
+    private readonly collectionRepository: Repository<StyleCollectionEntity>,
     @InjectDataSource() dataSource: DataSource,
   ) {
     super(paletteRepository, dataSource);
   }
 
   async create(data: CreateColorPaletteInput): Promise<ColorPaletteEntity> {
-    const { collectionId, relationIds = [], ...rest } = data;
+    const { collectionId, relationIds = [], colors, ...rest } = data;
+
+    const collection = await this.collectionRepository.findOneOrFail({
+      where: { id: collectionId },
+    });
+    const missing = (collection.colorTokens || []).filter(
+      (t) => !(t in (colors || {})),
+    );
+    if (missing.length) {
+      throw new BadRequestException(
+        `Missing color token${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}`,
+      );
+    }
+
     const relations = [
       ...relationIds,
       { relation: 'collection', ids: [collectionId] },
     ];
-    return super.create({ ...rest, relationIds: relations } as any);
+    return super.create({ ...rest, colors, relationIds: relations } as any);
   }
 
   async update(data: UpdateColorPaletteInput): Promise<ColorPaletteEntity> {
-    const { collectionId, relationIds = [], ...rest } = data;
+    const { collectionId, relationIds = [], colors, ...rest } = data;
+
+    if (collectionId) {
+      const collection = await this.collectionRepository.findOneOrFail({
+        where: { id: collectionId },
+      });
+      const missing = (collection.colorTokens || []).filter(
+        (t) => !(t in (colors || {})),
+      );
+      if (missing.length) {
+        throw new BadRequestException(
+          `Missing color token${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}`,
+        );
+      }
+    }
+
     const relations = [
       ...relationIds,
       ...(collectionId ? [{ relation: 'collection', ids: [collectionId] }] : []),
     ];
-    return super.update({ ...rest, relationIds: relations } as any);
+    return super.update({ ...rest, colors, relationIds: relations } as any);
   }
 
   async findAll(

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.entity.ts
@@ -14,7 +14,9 @@ export class StyleCollectionEntity extends AbstractBaseEntity {
   @Field(() => [StyleEntity], { nullable: true })
   @OneToMany(() => StyleEntity, (style) => style.collection)
   styles?: StyleEntity[];
-
+  @Field(() => [String])
+  @Column({ type: 'jsonb', name: 'color_tokens' })
+  colorTokens: string[];
 
   @Field(() => [ColorPaletteEntity], { nullable: true })
   @OneToMany(() => ColorPaletteEntity, (palette) => palette.collection)

--- a/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
+++ b/insight-be/src/modules/timbuktu/administrative/style-collection/style-collection.inputs.ts
@@ -4,6 +4,9 @@ import { Field, ID, InputType, PartialType } from '@nestjs/graphql';
 export class CreateStyleCollectionInput {
   @Field()
   name: string;
+
+  @Field(() => [String])
+  colorTokens: string[];
 }
 
 @InputType()


### PR DESCRIPTION
## Summary
- load the collection in the color palette service
- ensure palettes include colors for each token in the collection
- store palette colors as JSON objects keyed by token
- add color token list to style collections

## Testing
- `npm test` *(fails: jest not found)*
- `npm run build` *(fails: nest not found)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: cannot find module declarations)*


------
https://chatgpt.com/codex/tasks/task_e_685cfbc0c4908326aca7910fc069be8d